### PR TITLE
Fix activation logging server/client gaps for multi-sample inference (#3)

### DIFF
--- a/activation_logging/server.py
+++ b/activation_logging/server.py
@@ -1157,6 +1157,7 @@ class CompletionRequest(BaseModel):
     sample_group_id: Optional[str] = None  # Optional group ID to link samples
     sample_index: Optional[int] = None  # Optional index within the group
     request_id: Optional[str] = None  # Optional request ID for unique sample keys
+    skip_activation_logging: bool = False  # Per-request opt-out of activation logging
 
 
 class Choice(BaseModel):
@@ -1195,6 +1196,7 @@ class ChatCompletionRequest(BaseModel):
     sample_group_id: Optional[str] = None  # Optional group ID to link samples
     sample_index: Optional[int] = None  # Optional index within the group
     request_id: Optional[str] = None  # Optional request ID for unique sample keys
+    skip_activation_logging: bool = False  # Per-request opt-out of activation logging
 
 
 class ChatCompletionChoice(BaseModel):
@@ -1782,10 +1784,10 @@ def completions(request: CompletionRequest, http_request: Request):
     )
     sample_group_id = request.sample_group_id or prompt_key
     
-    if not model_name.endswith('.gguf') and model_outputs is not None:
+    if not model_name.endswith('.gguf') and model_outputs is not None and not request.skip_activation_logging:
         # Get appropriate logger based on parameters with overwrites
         logger_to_use, _, _ = get_logger_for_request(params)
-        
+
         try:
             # Pass the model outputs directly to the logger
             activation_start = time.time()
@@ -1927,7 +1929,7 @@ def chat_completions(request: ChatCompletionRequest, http_request: Request):
             response_text = shrunk
 
         # Log activation logging
-        if not model_name.endswith('.gguf') and model_outputs is not None:
+        if not model_name.endswith('.gguf') and model_outputs is not None and not request.skip_activation_logging:
             logger.info(f"[{request_id}] Starting activation logging")
             activation_start = time.time()
 

--- a/utils/exp.py
+++ b/utils/exp.py
@@ -62,6 +62,8 @@ def run_exp(
     inference_method="vllm",
     max_workers=64,
     max_tokens=512,
+    temperature=0.0,
+    top_p=1.0,
     return_gen = False,
     max_retries=3,
     base_delay=1.0,
@@ -85,6 +87,8 @@ def run_exp(
         inference_method: Inference method (vllm, openai, custom)
         max_workers: DEPRECATED - kept for backward compatibility, inference is now single-threaded
         max_tokens: Maximum tokens to generate
+        temperature: Sampling temperature (default: 0.0 for greedy). Set > 0 for stochastic sampling.
+        top_p: Top-p sampling parameter (default: 1.0)
         return_gen: Whether to return generations
         max_retries: Maximum retry attempts
         base_delay: Base delay for exponential backoff
@@ -197,12 +201,12 @@ def run_exp(
 
         # Define inference function based on method
         if inference_method == 'openai':
-            inference_fn = lambda p: lm.openai_generate(p, model=model_path, temperature=0.0, top_p=1.0, max_tokens=max_tokens)
+            inference_fn = lambda p: lm.openai_generate(p, model=model_path, temperature=temperature, top_p=top_p, max_tokens=max_tokens)
         elif inference_method == "vllm":
             port = None
-            inference_fn = lambda p: lm.call_vllm_api(p, model=model_path, temperature=0.0, top_p=1.0, max_tokens=max_tokens, port=port, max_retries=max_retries, base_delay=base_delay)
+            inference_fn = lambda p: lm.call_vllm_api(p, model=model_path, temperature=temperature, top_p=top_p, max_tokens=max_tokens, port=port, max_retries=max_retries, base_delay=base_delay)
         elif inference_method == "custom":
-            inference_fn = lambda p: lm.generate(p, model=model_path, temperature=0.0, top_p=1.0, max_tokens=max_tokens, max_retries=max_retries, base_delay=base_delay)
+            inference_fn = lambda p: lm.generate(p, model=model_path, temperature=temperature, top_p=top_p, max_tokens=max_tokens, max_retries=max_retries, base_delay=base_delay)
         else:
             raise NotImplementedError(f"No method {inference_method}")
 

--- a/utils/lm.py
+++ b/utils/lm.py
@@ -758,7 +758,7 @@ model_map = {   'meta-llama/Llama-3.1-405B-Instruct-FP8': {'name': 'llama3.1_405
             }
 ########################################################################################################
 
-def call_vllm_api(prompt, model, temperature=0.0, top_p=1.0, max_tokens=512, port=None, i=0, max_retries=3, base_delay=1.0):
+def call_vllm_api(prompt, model, temperature=0.0, top_p=1.0, max_tokens=512, port=None, i=0, max_retries=3, base_delay=1.0, extra_body: dict | None = None):
     """
     Call vLLM API with retry mechanism for timeout errors.
 
@@ -772,6 +772,9 @@ def call_vllm_api(prompt, model, temperature=0.0, top_p=1.0, max_tokens=512, por
         i: Server index for model_map
         max_retries: Maximum number of retry attempts (default: 3)
         base_delay: Base delay in seconds for exponential backoff (default: 1.0)
+        extra_body: Optional dict of extra fields to pass to the API (e.g. multi_sample,
+                    request_id, skip_activation_logging). The OpenAI SDK silently drops
+                    non-standard fields unless they are forwarded via extra_body.
 
     Returns:
         Generated text content
@@ -829,7 +832,8 @@ def call_vllm_api(prompt, model, temperature=0.0, top_p=1.0, max_tokens=512, por
                     {"role": "user","content": prompt}],
                 max_tokens=max_tokens,
                 temperature=temperature,
-                top_p=top_p
+                top_p=top_p,
+                **({"extra_body": extra_body} if extra_body else {})
             )
 
             request_time = time.time() - start_time


### PR DESCRIPTION
## Summary

Fixes all three gaps from issue #3, each blocking the `--step selfcheck` implementation in PR #2.

- **Gap 1** (`utils/lm.py`): Added `extra_body: dict | None = None` parameter to `call_vllm_api` and threads it through to the OpenAI SDK call. Without this, non-standard server fields (`multi_sample`, `request_id`, `sample_group_id`, `sample_index`, `skip_activation_logging`) are silently dropped by the SDK.

- **Gap 2** (`utils/exp.py`): Surfaced `temperature` and `top_p` as parameters on `run_exp` (defaults: `0.0` / `1.0` — no behaviour change for existing callers). All three inference lambdas (openai, vllm, custom) now use these values instead of hardcoded `0.0`/`1.0`. Selfcheck stochastic samples require `temperature > 0`.

- **Gap 3** (`activation_logging/server.py`): Added `skip_activation_logging: bool = False` to both `CompletionRequest` and `ChatCompletionRequest` Pydantic models. Both `log_entry` call sites are now guarded with `not request.skip_activation_logging`. Clients can opt out of Zarr writes per-request (via `extra_body` after Gap 1 is applied) without skipping text generation or logprob collection. The entry key is still built deterministically so the entry can be activation-logged in a future run without re-generating text.

## Test plan

- [ ] Existing single-pass inference: pass `temperature=0.0` (default) to `run_exp` — behaviour unchanged
- [ ] Stochastic sampling: pass `temperature=0.7` to `run_exp` — lambda forwards it correctly
- [ ] `extra_body` forwarding: call `call_vllm_api(..., extra_body={"multi_sample": True, "request_id": "sc_0"})` and verify fields arrive at the server
- [ ] `skip_activation_logging`: send a request with `extra_body={"skip_activation_logging": True}` and confirm no Zarr entry is written while the response text is returned normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)