### PR TITLE
feat(#32): SimCLR variants — Options A, B, D

### DIFF
--- a/activation_research/model.py
+++ b/activation_research/model.py
@@ -795,3 +795,123 @@ class LayerAwareProgressiveCompressor(nn.Module):
             z = F.normalize(z, dim=-1)
 
         return z
+        _ = kwargs
+
+        # Pure-encoder mode (conditioning=None): behave exactly like
+        # ProgressiveCompressor – ignore layer_idx entirely.
+        if self.conditioning is None:
+            z = self.encoder(x)
+            if self.normalize_output:
+                z = F.normalize(z, dim=-1)
+            return z
+
+        if layer_idx is None:
+            z = self.encoder(x)
+            if self.normalize_output:
+                z = F.normalize(z, dim=-1)
+            return z
+
+        idx = self._coerce_layer_idx(layer_idx, x.shape[0], x.device)
+
+        # --- input-side FiLM ---
+        if self.conditioning in ("film_in", "film_both"):
+            x = self.film_in(x, idx)  # (B, L, D) → (B, L, D)
+
+        z = self.encoder(x)  # (B, final_dim)
+
+        # --- output-side conditioning ---
+        if self.conditioning in ("film_out", "film_both"):
+            z = self.film_out(z, idx)  # (B, final_dim) → (B, final_dim)
+
+        elif self.conditioning == "positional":
+            e = self.layer_embedding(idx)  # (B, final_dim)
+            z = z + self.positional_alpha * e
+
+        elif self.conditioning == "concatenate":
+            e = self.layer_embedding(idx)
+            e = self.layer_proj(e)
+            z = self.fuse(torch.cat([z, e], dim=-1))
+
+        # conditioning == "none": no-op, z passes through unchanged
+
+        if hasattr(self, 'norm'):
+            z = self.norm(z)
+
+        if self.normalize_output:
+            z = F.normalize(z, dim=-1)
+
+        return z
+            emb = self.layer_embedding.weight  # (num_layers, final_dim)
+            row_norms = emb.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+            self.layer_embedding.weight.copy_(emb * (target_norm / row_norms))
+            # Bake scale into weights; reset alpha to 1.0
+            self.positional_alpha.fill_(1.0)
+
+        elif self.conditioning in ("film_in", "film_both"):
+            beta = self.film_in.beta.weight
+            beta_norms = beta.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+            self.film_in.beta.weight.copy_(beta * (target_norm / beta_norms))
+
+        if self.conditioning == "concatenate":
+            emb = self.layer_embedding.weight
+            row_norms = emb.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+            self.layer_embedding.weight.copy_(emb * (target_norm / row_norms))
+
+        stats = {
+            "input_mean_norm": input_mean_norm,
+            "input_elem_mean": input_elem_mean,
+            "input_elem_std": input_elem_std,
+            "embedding_target_norm": target_norm,
+        }
+        return stats
+
+    # ------------------------------------------------------------------ #
+    #  Forward
+    # ------------------------------------------------------------------ #
+    def forward(self, x: torch.Tensor, *, layer_idx=None, **kwargs) -> torch.Tensor:
+        _ = kwargs
+
+        # Pure-encoder mode (conditioning=None): behave exactly like
+        # ProgressiveCompressor – ignore layer_idx entirely.
+        if self.conditioning is None:
+            z = self.encoder(x)
+            if self.normalize_output:
+                z = F.normalize(z, dim=-1)
+            return z
+
+        if layer_idx is None:
+            z = self.encoder(x)
+            if self.normalize_output:
+                z = F.normalize(z, dim=-1)
+            return z
+
+        idx = self._coerce_layer_idx(layer_idx, x.shape[0], x.device)
+
+        # --- input-side FiLM ---
+        if self.conditioning in ("film_in", "film_both"):
+            x = self.film_in(x, idx)  # (B, L, D) → (B, L, D)
+
+        z = self.encoder(x)  # (B, final_dim)
+
+        # --- output-side conditioning ---
+        if self.conditioning in ("film_out", "film_both"):
+            z = self.film_out(z, idx)  # (B, final_dim) → (B, final_dim)
+
+        elif self.conditioning == "positional":
+            e = self.layer_embedding(idx)  # (B, final_dim)
+            z = z + self.positional_alpha * e
+
+        elif self.conditioning == "concatenate":
+            e = self.layer_embedding(idx)
+            e = self.layer_proj(e)
+            z = self.fuse(torch.cat([z, e], dim=-1))
+
+        # conditioning == "none": no-op, z passes through unchanged
+
+        if hasattr(self, 'norm'):
+            z = self.norm(z)
+
+        if self.normalize_output:
+            z = F.normalize(z, dim=-1)
+
+        return z

--- a/activation_research/trainer.py
+++ b/activation_research/trainer.py
@@ -1283,3 +1283,1086 @@ class LayerAwareContrastiveTrainer(Trainer):
         self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
         self.best_loss = float(checkpoint.get("best_loss", float("inf")))
         logger.info(f"Resumed training from epoch {self.start_epoch}")
+    """Configuration for `LinearProbeTrainer`."""
+
+    pooling: str = "mean"
+    balanced_sampling: bool = True
+    use_infinite_index_stream: bool = False
+    infinite_stream_shuffle: bool = True
+    infinite_stream_seed: int = 0
+
+
+class LinearProbeTrainer(Trainer):
+    """Trainer for per-layer linear probe hallucination detection.
+
+    Trains a single ``LinearProbe`` on the activations provided by the
+    dataset.  The dataset should be configured with ``num_views=1`` and
+    ``min_target_layers=1`` so that ``views_activations`` is ``(1, L, D)``.
+
+    The training loop uses BCE loss and reports AUROC on the validation
+    split each epoch.
+    """
+
+    def __init__(self, model: torch.nn.Module, *, config: LinearProbeTrainerConfig):
+        self.probe_config = config
+        super().__init__(model, config=config)
+        self.loss_fn = torch.nn.BCELoss()
+        self.best_auroc: float = 0.0
+
+    def training_step(self, batch: Dict[str, Any]) -> Tuple[torch.Tensor, Dict[str, float]]:
+        # views_activations: (B, 1, seq_len, D) → squeeze view dim
+        x = batch["views_activations"].to(self.device, non_blocking=True)
+        if x.dim() == 4:
+            x = x.squeeze(1)  # (B, seq_len, D)
+        labels = batch["halu"].to(self.device, non_blocking=True).float().view(-1, 1)
+
+        preds = self.model(x)  # (B, 1)
+        loss = self.loss_fn(preds, labels)
+
+        acc = float(((preds > 0.5).float() == labels).float().mean().item())
+        return loss, {"acc": acc}
+
+    def train_epoch(self, *, epoch: int, train_dataset) -> Dict[str, float]:
+        self.model.train()
+        train_loader, steps_per_epoch, train_iter = self._build_train_iterator(train_dataset)
+
+        total_loss = 0.0
+        total_acc = 0.0
+        n_steps = 0
+
+        if steps_per_epoch is not None:
+            loop = tqdm(range(steps_per_epoch), desc=f"Epoch {epoch+1}/{self.config.max_epochs}", leave=False)
+        else:
+            loop = tqdm(train_loader, desc=f"Epoch {epoch+1}/{self.config.max_epochs}", leave=False)
+
+        for i, _ in enumerate(loop, start=1):
+            if train_iter is not None:
+                try:
+                    batch = next(train_iter)
+                except StopIteration:
+                    train_iter = iter(train_loader)
+                    batch = next(train_iter)
+            else:
+                batch = _
+
+            loss, metrics = self.training_step(batch)
+
+            self.optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            if self.config.grad_clip_norm is not None and float(self.config.grad_clip_norm) > 0:
+                torch.nn.utils.clip_grad_norm_(
+                    self.model.parameters(), max_norm=float(self.config.grad_clip_norm)
+                )
+            self.optimizer.step()
+
+            total_loss += float(loss.detach().cpu().item())
+            total_acc += float(metrics.get("acc", 0.0))
+            n_steps += 1
+            loop.set_postfix(loss=total_loss / n_steps, acc=total_acc / n_steps)
+
+        out = {
+            "train_loss": total_loss / max(1, n_steps),
+            "train_acc": total_acc / max(1, n_steps),
+        }
+        logger.info(f"Train: loss={out['train_loss']:.4f}, acc={out['train_acc']:.4f}")
+        return out
+
+    def validate(self, *, epoch: int, val_dataset) -> Dict[str, float]:
+        self.model.eval()
+        val_loader, eval_max_batches, _ = self._build_val_loader(val_dataset)
+
+        all_preds = []
+        all_labels = []
+        total_loss = 0.0
+        n_batches = 0
+
+        with torch.no_grad():
+            for i, batch in enumerate(val_loader):
+                if eval_max_batches is not None and i >= eval_max_batches:
+                    break
+                x = batch["views_activations"].to(self.device, non_blocking=True)
+                if x.dim() == 4:
+                    x = x.squeeze(1)
+                labels = batch["halu"].to(self.device, non_blocking=True).float().view(-1, 1)
+
+                preds = self.model(x)
+                loss = self.loss_fn(preds, labels)
+                total_loss += float(loss.item())
+                n_batches += 1
+
+                all_preds.append(preds.cpu())
+                all_labels.append(labels.cpu())
+
+        all_preds = torch.cat(all_preds).numpy()
+        all_labels = torch.cat(all_labels).numpy()
+
+        from sklearn.metrics import roc_auc_score
+        try:
+            auroc = float(roc_auc_score(all_labels, all_preds))
+        except ValueError:
+            auroc = float("nan")
+
+        self.best_auroc = max(self.best_auroc, auroc)
+
+        out = {
+            "val_loss": total_loss / max(1, n_batches),
+            "val_auroc": auroc,
+            "best_auroc": self.best_auroc,
+        }
+        logger.info(f"Val: loss={out['val_loss']:.4f}, auroc={out['val_auroc']:.4f}")
+        return out
+
+    def train_dataloader(self, train_dataset) -> DataLoader:
+        dataset = train_dataset
+        is_iterable = isinstance(dataset, IterableDataset)
+
+        if bool(self.probe_config.use_infinite_index_stream) and not is_iterable:
+            if not hasattr(dataset, "__len__"):
+                raise TypeError("use_infinite_index_stream=True requires train_dataset to have __len__")
+            dataset = InfiniteIndexStream(
+                dataset,
+                shuffle=bool(self.probe_config.infinite_stream_shuffle),
+                seed=int(self.probe_config.infinite_stream_seed),
+            )
+            is_iterable = True
+
+        sampler = None
+        if bool(self.probe_config.balanced_sampling) and not is_iterable:
+            sampler = _build_balanced_sampler(dataset)
+
+        return DataLoader(
+            dataset,
+            batch_size=int(self.config.batch_size),
+            shuffle=(sampler is None and not is_iterable),
+            sampler=sampler,
+            num_workers=int(self.config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.config.persistent_workers and int(self.config.num_workers) > 0
+            ),
+        )
+
+    def maybe_save_checkpoint(
+        self,
+        *,
+        epoch: int,
+        train_metrics: Dict[str, float],
+        val_metrics: Dict[str, float],
+        is_last_epoch: bool,
+    ) -> float:
+        checkpoint_start = time.perf_counter()
+
+        if int(self.config.save_every) <= 0:
+            return 0.0
+
+        should_save = ((epoch + 1) % int(self.config.save_every) == 0) or bool(is_last_epoch)
+        if not should_save:
+            return 0.0
+
+        checkpoint = {
+            "epoch": int(epoch),
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "lr": float(self.config.lr),
+            **train_metrics,
+            **val_metrics,
+        }
+
+        last_path = os.path.join(self.config.checkpoint_dir, "linear_probe_last.pt")
+        _atomic_torch_save(checkpoint, last_path)
+
+        _save_and_prune_snapshots(
+            checkpoint_dir=self.resolve_snapshot_dir(),
+            snapshot_prefix="linear_probe",
+            epoch_one_indexed=epoch + 1,
+            checkpoint=checkpoint,
+            snapshot_every=int(self.config.snapshot_every),
+            snapshot_keep_last=int(self.config.snapshot_keep_last),
+            is_last_epoch=bool(is_last_epoch),
+        )
+
+        if bool(self.config.cleanup_legacy_checkpoints):
+            _cleanup_legacy_checkpoints(
+                self.config.checkpoint_dir,
+                keep_filenames={"linear_probe_last.pt"},
+            )
+
+        elapsed = float(time.perf_counter() - checkpoint_start)
+        return elapsed
+
+    def load_checkpoint(self, resume_from: str) -> None:
+        checkpoint_path = resume_from
+        if not os.path.isabs(checkpoint_path):
+            checkpoint_path = os.path.join(self.config.checkpoint_dir, resume_from)
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+
+        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
+        self.best_auroc = float(checkpoint.get("best_auroc", 0.0))
+        logger.info(f"Resumed linear probe training from epoch {self.start_epoch}")
+
+
+class LayerAwareContrastiveTrainer(Trainer):
+    """Trainer for contrastive learning with layer-aware encoders.
+
+    Diff vs `ContrastiveTrainer`:
+    - Calls the model with kwargs (`layer_idx=...`) for each view.
+    - Writes distinct checkpoint files.
+    """
+
+    def __init__(self, model: torch.nn.Module, *, config: LayerAwareContrastiveTrainerConfig):
+        self.contrastive_config = config
+        if int(self.contrastive_config.num_views) < 2:
+            raise ValueError("LayerAwareContrastiveTrainerConfig.num_views must be >= 2")
+        super().__init__(model, config=config)
+
+        self.loss_fn = SupConLoss(
+            temperature=float(config.temperature),
+            ignore_label=int(config.ignore_label),
+            same_sample_weight=float(config.same_sample_weight),
+            same_class_weight=float(config.same_class_weight),
+        )
+
+        self.best_loss: float = float("inf")
+        self._calibrated: bool = False
+
+    def fit(self, train_dataset, val_dataset=None) -> None:
+        """Run the training loop, with optional pre-training calibration."""
+        # Check model attribute first, fall back to config for backward compat.
+        needs_calibration = getattr(self.model, "requires_calibration", False)
+        if not needs_calibration:
+            needs_calibration = bool(self.contrastive_config.calibrate)
+
+        if (
+            needs_calibration
+            and not self._calibrated
+            and hasattr(self.model, "calibrate")
+        ):
+            logger.info("Running embedding calibration...")
+            # Build the train loader (this caches it for later reuse)
+            train_loader, _, train_iter = self._build_train_iterator(train_dataset)
+            # Use the iterator if available (infinite stream), otherwise the loader directly
+            calib_iter = train_iter if train_iter is not None else iter(train_loader)
+
+            max_batches = getattr(self.model, "calibrate_max_batches", 50)
+            target_ratio = getattr(self.model, "calibrate_target_ratio", 0.01)
+            # Config overrides if explicitly set
+            if bool(self.contrastive_config.calibrate):
+                max_batches = int(self.contrastive_config.calibrate_max_batches)
+                target_ratio = float(self.contrastive_config.calibrate_target_ratio)
+
+            stats = self.model.calibrate(
+                calib_iter,
+                max_batches=int(max_batches),
+                target_ratio=float(target_ratio),
+            )
+            self._calibrated = True
+            logger.info(f"Calibration complete: {stats}")
+
+        super().fit(train_dataset, val_dataset=val_dataset)
+
+    def training_step(self, batch: Dict[str, Any]) -> Tuple[torch.Tensor, Dict[str, float]]:
+        views = batch["views_activations"].to(self.device, non_blocking=True)
+        view_indices = batch.get("view_indices")
+        if not isinstance(view_indices, torch.Tensor):
+            raise ValueError("LayerAwareContrastiveTrainer requires `view_indices` in each batch")
+
+        view_indices = view_indices.to(self.device, non_blocking=True)
+        batch_size, num_views, seq_len, hidden_dim = views.shape
+        x_flat = views.reshape(batch_size * num_views, seq_len, hidden_dim)
+        layer_idx_flat = view_indices.reshape(batch_size * num_views)
+
+        z_flat = self.model(x_flat, layer_idx=layer_idx_flat)
+        z_views = z_flat.reshape(batch_size, num_views, -1)
+
+        if bool(self.contrastive_config.use_labels):
+            labels = batch["halu"].to(self.device, non_blocking=True)
+            if labels.dim() == 0:
+                labels = labels.unsqueeze(0)
+            elif labels.dim() > 1:
+                labels = labels.view(-1)
+
+            hashkeys = batch.get("hashkey")
+            if isinstance(hashkeys, str):
+                hashkeys = [hashkeys]
+            if hashkeys is None:
+                sample_ids = torch.arange(labels.shape[0], device=self.device, dtype=torch.long)
+            else:
+                sample_ids = torch.tensor(
+                    [hash(hk) % 1000000 for hk in hashkeys],
+                    dtype=torch.long,
+                    device=self.device,
+                )
+
+            loss = self.loss_fn(z_views, labels=labels, sample_ids=sample_ids)
+        else:
+            loss = self.loss_fn(z_views)
+
+        intra_cos = intra_sample_cosine_mean(z_views)
+        intra_inter = intra_inter_margin(z_views)
+        return loss, {"intra_cos": float(intra_cos), "intra_inter_margin": float(intra_inter)}
+
+    def train_dataloader(self, train_dataset) -> DataLoader:
+        dataset = train_dataset
+
+        is_iterable = isinstance(dataset, IterableDataset)
+        if bool(self.contrastive_config.use_infinite_index_stream) and not is_iterable:
+            if not hasattr(dataset, "__len__"):
+                raise TypeError("use_infinite_index_stream=True requires train_dataset to have __len__")
+            dataset = InfiniteIndexStream(
+                dataset,
+                shuffle=bool(self.contrastive_config.infinite_stream_shuffle),
+                seed=int(self.contrastive_config.infinite_stream_seed),
+            )
+            is_iterable = True
+
+        sampler = None
+        if (
+            bool(self.contrastive_config.balanced_sampling)
+            and bool(self.contrastive_config.use_labels)
+            and not is_iterable
+        ):
+            sampler = _build_balanced_sampler(dataset)
+
+        return DataLoader(
+            dataset,
+            batch_size=int(self.contrastive_config.batch_size),
+            shuffle=(sampler is None and not is_iterable),
+            sampler=sampler,
+            num_workers=int(self.contrastive_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.contrastive_config.persistent_workers and int(self.contrastive_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def val_dataloader(self, val_dataset, *, batch_size: Optional[int] = None) -> DataLoader:
+        resolved_batch_size = int(self.contrastive_config.batch_size if batch_size is None else batch_size)
+        return DataLoader(
+            val_dataset,
+            batch_size=resolved_batch_size,
+            shuffle=False,
+            num_workers=int(self.contrastive_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.contrastive_config.persistent_workers and int(self.contrastive_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def validate(self, *, epoch: int, val_dataset) -> Dict[str, float]:
+        _ = epoch
+        val_loader, eval_max_batches, eval_sub_batch_size = self._build_val_loader(val_dataset)
+
+        test_loss, test_intra_cos, test_intra_inter_margin = evaluate(
+            self.model,
+            val_loader,
+            batch_size=int(self.contrastive_config.batch_size),
+            sub_batch_size=int(eval_sub_batch_size),
+            loss_fn=self.loss_fn,
+            device=str(self.device),
+            use_labels=bool(self.contrastive_config.use_labels),
+            ignore_label=int(self.contrastive_config.ignore_label),
+            max_batches=eval_max_batches,
+        )
+
+        self.best_loss = min(float(self.best_loss), float(test_loss))
+
+        out = {
+            "test_loss": float(test_loss),
+            "test_intra_cos": float(test_intra_cos),
+            "test_intra_inter_margin": float(test_intra_inter_margin),
+            "best_loss": float(self.best_loss),
+        }
+
+        logger.info(
+            "Val metrics: "
+            f"loss={out['test_loss']:.4f}, "
+            f"intra_cos={out['test_intra_cos']:.4f}, "
+            f"intra_inter_margin={out['test_intra_inter_margin']:.4f}"
+        )
+        return out
+
+    def maybe_save_checkpoint(
+        self,
+        *,
+        epoch: int,
+        train_metrics: Dict[str, float],
+        val_metrics: Dict[str, float],
+        is_last_epoch: bool,
+    ) -> float:
+        checkpoint_start = time.perf_counter()
+
+        if int(self.contrastive_config.save_every) <= 0:
+            return 0.0
+
+        should_save = ((epoch + 1) % int(self.contrastive_config.save_every) == 0) or bool(is_last_epoch)
+        if not should_save:
+            return 0.0
+
+        checkpoint = {
+            "epoch": int(epoch),
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "temperature": float(self.contrastive_config.temperature),
+            "lr": float(self.contrastive_config.lr),
+            **train_metrics,
+            **val_metrics,
+        }
+
+        last_path = os.path.join(self.contrastive_config.checkpoint_dir, "layer_aware_contrastive_last.pt")
+        _atomic_torch_save(checkpoint, last_path)
+
+        _save_and_prune_snapshots(
+            checkpoint_dir=self.resolve_snapshot_dir(),
+            snapshot_prefix="layer_aware_contrastive",
+            epoch_one_indexed=epoch + 1,
+            checkpoint=checkpoint,
+            snapshot_every=int(self.contrastive_config.snapshot_every),
+            snapshot_keep_last=int(self.contrastive_config.snapshot_keep_last),
+            is_last_epoch=bool(is_last_epoch),
+        )
+
+        if bool(self.contrastive_config.cleanup_legacy_checkpoints):
+            _cleanup_legacy_checkpoints(
+                self.contrastive_config.checkpoint_dir,
+                keep_filenames={"layer_aware_contrastive_last.pt"},
+            )
+
+        elapsed = float(time.perf_counter() - checkpoint_start)
+        if bool(getattr(self.contrastive_config, "log_timing", True)):
+            logger.info(
+                "Checkpoint timing: "
+                f"epoch={epoch + 1}, path={last_path}, elapsed={elapsed:.2f}s"
+            )
+        return elapsed
+
+    def load_checkpoint(self, resume_from: str) -> None:
+        checkpoint_path = resume_from
+        if not os.path.isabs(checkpoint_path):
+            checkpoint_path = os.path.join(self.contrastive_config.checkpoint_dir, resume_from)
+
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+
+        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
+        self.best_loss = float(checkpoint.get("best_loss", float("inf")))
+        logger.info(f"Resumed training from epoch {self.start_epoch}")
+
+
+@dataclass
+class SimCLRCotrainedTrainerConfig(TrainerConfig):
+    """Configuration for `SimCLRCotrainedTrainer`.
+
+    Combines unsupervised SimCLR contrastive loss with supervised BCE
+    classification loss in a joint objective with full gradient flow.
+    """
+
+    # Contrastive settings
+    temperature: float = 0.07
+    num_views: int = 2
+    use_infinite_index_stream: bool = True
+    infinite_stream_shuffle: bool = True
+    infinite_stream_seed: int = 0
+    use_infinite_index_stream_eval: bool = True
+    infinite_eval_shuffle: bool = False
+    infinite_eval_seed: int = 0
+    balanced_sampling: bool = False
+
+    # Loss weights
+    simclr_weight: float = 1.0  # alpha
+    bce_weight: float = 1.0     # beta
+
+
+class SimCLRCotrainedTrainer(Trainer):
+    """Trainer for co-trained SimCLR + BCE classification.
+
+    Trains a single encoder with both an unsupervised SimCLR loss and a
+    supervised BCE classification loss simultaneously, with full gradient
+    flow through both objectives.
+
+    Combined loss: L = alpha * L_SimCLR + beta * L_BCE
+    """
+
+    def __init__(self, model: torch.nn.Module, *, config: SimCLRCotrainedTrainerConfig):
+        self.cotrained_config = config
+        if int(self.cotrained_config.num_views) < 2:
+            raise ValueError("SimCLRCotrainedTrainerConfig.num_views must be >= 2")
+        super().__init__(model, config=config)
+
+        self.simclr_loss_fn = SupConLoss(
+            temperature=float(config.temperature),
+        )
+        self.bce_loss_fn = torch.nn.BCELoss()
+
+        self.best_loss: float = float("inf")
+
+    def training_step(self, batch: Dict[str, Any]) -> Tuple[torch.Tensor, Dict[str, float]]:
+        views = batch["views_activations"].to(self.device, non_blocking=True)
+        batch_size, num_views, seq_len, hidden_dim = views.shape
+        x_flat = views.reshape(batch_size * num_views, seq_len, hidden_dim)
+
+        # Forward with head to get both embeddings and predictions
+        z_flat, pred_flat = self.model.forward_with_head(x_flat)
+        z_views = z_flat.reshape(batch_size, num_views, -1)
+
+        # SimCLR loss (unsupervised, no labels)
+        simclr_loss = self.simclr_loss_fn(z_views)
+
+        # BCE loss: use predictions from the first view of each sample
+        pred_first_view = pred_flat[:batch_size]  # (B, 1)
+        labels = batch["halu"].to(self.device, non_blocking=True).float().view(-1, 1)
+        bce_loss = self.bce_loss_fn(pred_first_view, labels)
+
+        # Combined loss
+        alpha = float(self.cotrained_config.simclr_weight)
+        beta = float(self.cotrained_config.bce_weight)
+        combined_loss = alpha * simclr_loss + beta * bce_loss
+
+        # Contrastive metrics for monitoring
+        intra_cos = intra_sample_cosine_mean(z_views)
+        intra_inter = intra_inter_margin(z_views)
+
+        return combined_loss, {
+            "simclr_loss": float(simclr_loss.detach().cpu().item()),
+            "bce_loss": float(bce_loss.detach().cpu().item()),
+            "intra_cos": float(intra_cos),
+            "intra_inter_margin": float(intra_inter),
+        }
+
+    def train_epoch(self, *, epoch: int, train_dataset) -> Dict[str, float]:
+        self.model.train()
+        train_loader, steps_per_epoch, train_iter = self._build_train_iterator(train_dataset)
+
+        total_loss = 0.0
+        total_simclr = 0.0
+        total_bce = 0.0
+        total_intra_cos = 0.0
+        total_intra_inter_margin = 0.0
+        n_steps = 0
+
+        if steps_per_epoch is not None:
+            loop = tqdm(range(steps_per_epoch), desc=f"Epoch {epoch+1}/{self.config.max_epochs}", leave=False)
+        else:
+            loop = tqdm(train_loader, desc=f"Epoch {epoch+1}/{self.config.max_epochs}", leave=False)
+
+        for i, _ in enumerate(loop, start=1):
+            if train_iter is not None:
+                try:
+                    batch = next(train_iter)
+                except StopIteration:
+                    train_iter = iter(train_loader)
+                    batch = next(train_iter)
+            else:
+                batch = _
+
+            loss, metrics = self.training_step(batch)
+
+            self.optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            if self.config.grad_clip_norm is not None and float(self.config.grad_clip_norm) > 0:
+                torch.nn.utils.clip_grad_norm_(
+                    self.model.parameters(), max_norm=float(self.config.grad_clip_norm)
+                )
+            self.optimizer.step()
+
+            total_loss += float(loss.detach().cpu().item())
+            total_simclr += float(metrics.get("simclr_loss", 0.0))
+            total_bce += float(metrics.get("bce_loss", 0.0))
+            total_intra_cos += float(metrics.get("intra_cos", 0.0))
+            total_intra_inter_margin += float(metrics.get("intra_inter_margin", 0.0))
+            n_steps += 1
+
+            loop.set_postfix(
+                loss=total_loss / n_steps,
+                simclr=total_simclr / n_steps,
+                bce=total_bce / n_steps,
+            )
+
+        out = {
+            "train_loss": total_loss / max(1, n_steps),
+            "train_simclr_loss": total_simclr / max(1, n_steps),
+            "train_bce_loss": total_bce / max(1, n_steps),
+            "train_intra_cos": total_intra_cos / max(1, n_steps),
+            "train_intra_inter_margin": total_intra_inter_margin / max(1, n_steps),
+        }
+
+        logger.info(
+            "Train epoch metrics: "
+            f"loss={out['train_loss']:.4f}, "
+            f"simclr={out['train_simclr_loss']:.4f}, "
+            f"bce={out['train_bce_loss']:.4f}, "
+            f"intra_cos={out['train_intra_cos']:.4f}, "
+            f"intra_inter_margin={out['train_intra_inter_margin']:.4f}"
+        )
+        return out
+
+    def validate(self, *, epoch: int, val_dataset) -> Dict[str, float]:
+        _ = epoch
+        val_loader, eval_max_batches, eval_sub_batch_size = self._build_val_loader(val_dataset)
+
+        # Contrastive evaluation
+        evaluator = ContrastiveEvaluator(
+            loss_fn=self.simclr_loss_fn,
+            device=self.device,
+            batch_size=int(self.cotrained_config.batch_size),
+            sub_batch_size=int(eval_sub_batch_size),
+            use_labels=False,
+        )
+        val_stats = evaluator.run(
+            self.model,
+            val_loader,
+            max_batches=eval_max_batches,
+        )
+        contrastive_loss = float(val_stats["loss"])
+        intra_cos = float(val_stats["intra_cos"])
+        intra_inter_margin_val = float(val_stats["intra_inter_margin"])
+
+        # Classification AUROC from the head
+        self.model.eval()
+        all_preds = []
+        all_labels = []
+        total_bce = 0.0
+        n_batches = 0
+
+        with torch.no_grad():
+            for i, batch in enumerate(val_loader):
+                if eval_max_batches is not None and i >= eval_max_batches:
+                    break
+                x = batch["views_activations"].to(self.device, non_blocking=True)
+                if x.dim() == 4:
+                    # Use first view for classification eval
+                    x = x[:, 0, :, :]  # (B, seq_len, D)
+                labels = batch["halu"].to(self.device, non_blocking=True).float().view(-1, 1)
+
+                _, pred = self.model.forward_with_head(x)
+                bce = self.bce_loss_fn(pred, labels)
+                total_bce += float(bce.item())
+                n_batches += 1
+
+                all_preds.append(pred.cpu())
+                all_labels.append(labels.cpu())
+
+        all_preds_cat = torch.cat(all_preds).numpy()
+        all_labels_cat = torch.cat(all_labels).numpy()
+
+        from sklearn.metrics import roc_auc_score
+        try:
+            auroc = float(roc_auc_score(all_labels_cat, all_preds_cat))
+        except ValueError:
+            auroc = float("nan")
+
+        self.best_loss = min(float(self.best_loss), contrastive_loss)
+
+        out = {
+            "test_loss": contrastive_loss,
+            "test_intra_cos": intra_cos,
+            "test_intra_inter_margin": intra_inter_margin_val,
+            "test_bce_loss": total_bce / max(1, n_batches),
+            "test_auroc": auroc,
+            "best_loss": self.best_loss,
+        }
+
+        logger.info(
+            "Val metrics: "
+            f"contrastive_loss={out['test_loss']:.4f}, "
+            f"bce_loss={out['test_bce_loss']:.4f}, "
+            f"auroc={out['test_auroc']:.4f}, "
+            f"intra_cos={out['test_intra_cos']:.4f}, "
+            f"intra_inter_margin={out['test_intra_inter_margin']:.4f}"
+        )
+        return out
+
+    def train_dataloader(self, train_dataset) -> DataLoader:
+        dataset = train_dataset
+        is_iterable = isinstance(dataset, IterableDataset)
+
+        if bool(self.cotrained_config.use_infinite_index_stream) and not is_iterable:
+            if not hasattr(dataset, "__len__"):
+                raise TypeError("use_infinite_index_stream=True requires train_dataset to have __len__")
+            dataset = InfiniteIndexStream(
+                dataset,
+                shuffle=bool(self.cotrained_config.infinite_stream_shuffle),
+                seed=int(self.cotrained_config.infinite_stream_seed),
+            )
+            is_iterable = True
+
+        sampler = None
+        if bool(self.cotrained_config.balanced_sampling) and not is_iterable:
+            sampler = _build_balanced_sampler(dataset)
+
+        return DataLoader(
+            dataset,
+            batch_size=int(self.cotrained_config.batch_size),
+            shuffle=(sampler is None and not is_iterable),
+            sampler=sampler,
+            num_workers=int(self.cotrained_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.cotrained_config.persistent_workers and int(self.cotrained_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def val_dataloader(self, val_dataset, *, batch_size: Optional[int] = None) -> DataLoader:
+        resolved_batch_size = int(self.cotrained_config.batch_size if batch_size is None else batch_size)
+        return DataLoader(
+            val_dataset,
+            batch_size=resolved_batch_size,
+            shuffle=False,
+            num_workers=int(self.cotrained_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.cotrained_config.persistent_workers and int(self.cotrained_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def maybe_save_checkpoint(
+        self,
+        *,
+        epoch: int,
+        train_metrics: Dict[str, float],
+        val_metrics: Dict[str, float],
+        is_last_epoch: bool,
+    ) -> float:
+        checkpoint_start = time.perf_counter()
+
+        if int(self.cotrained_config.save_every) <= 0:
+            return 0.0
+
+        should_save = ((epoch + 1) % int(self.cotrained_config.save_every) == 0) or bool(is_last_epoch)
+        if not should_save:
+            return 0.0
+
+        checkpoint = {
+            "epoch": int(epoch),
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "temperature": float(self.cotrained_config.temperature),
+            "simclr_weight": float(self.cotrained_config.simclr_weight),
+            "bce_weight": float(self.cotrained_config.bce_weight),
+            "lr": float(self.cotrained_config.lr),
+            **train_metrics,
+            **val_metrics,
+        }
+
+        last_path = os.path.join(self.cotrained_config.checkpoint_dir, "simclr_cotrained_last.pt")
+        _atomic_torch_save(checkpoint, last_path)
+
+        _save_and_prune_snapshots(
+            checkpoint_dir=self.resolve_snapshot_dir(),
+            snapshot_prefix="simclr_cotrained",
+            epoch_one_indexed=epoch + 1,
+            checkpoint=checkpoint,
+            snapshot_every=int(self.cotrained_config.snapshot_every),
+            snapshot_keep_last=int(self.cotrained_config.snapshot_keep_last),
+            is_last_epoch=bool(is_last_epoch),
+        )
+
+        if bool(self.cotrained_config.cleanup_legacy_checkpoints):
+            _cleanup_legacy_checkpoints(
+                self.cotrained_config.checkpoint_dir,
+                keep_filenames={"simclr_cotrained_last.pt"},
+            )
+
+        elapsed = float(time.perf_counter() - checkpoint_start)
+        if bool(getattr(self.cotrained_config, "log_timing", True)):
+            logger.info(
+                "Checkpoint timing: "
+                f"epoch={epoch + 1}, path={last_path}, elapsed={elapsed:.2f}s"
+            )
+        return elapsed
+
+    def load_checkpoint(self, resume_from: str) -> None:
+        checkpoint_path = resume_from
+        if not os.path.isabs(checkpoint_path):
+            checkpoint_path = os.path.join(self.cotrained_config.checkpoint_dir, resume_from)
+
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+
+        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
+        self.best_loss = float(checkpoint.get("best_loss", float("inf")))
+        logger.info(f"Resumed SimCLR co-trained training from epoch {self.start_epoch}")
+                "Checkpoint timing: "
+                f"epoch={epoch + 1}, path={last_path}, elapsed={elapsed:.2f}s"
+            )
+        return elapsed
+
+    def load_checkpoint(self, resume_from: str) -> None:
+        checkpoint_path = resume_from
+        if not os.path.isabs(checkpoint_path):
+            checkpoint_path = os.path.join(self.simclr_config.checkpoint_dir, resume_from)
+
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+
+        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
+        self.best_loss = float(checkpoint.get("best_loss", float("inf")))
+        logger.info(f"Resumed SimCLR projection training from epoch {self.start_epoch}")
+
+
+class LayerAwareContrastiveTrainer(Trainer):
+    """Trainer for contrastive learning with layer-aware encoders.
+
+    Diff vs `ContrastiveTrainer`:
+    - Calls the model with kwargs (`layer_idx=...`) for each view.
+    - Writes distinct checkpoint files.
+    """
+
+    def __init__(self, model: torch.nn.Module, *, config: LayerAwareContrastiveTrainerConfig):
+        self.contrastive_config = config
+        if int(self.contrastive_config.num_views) < 2:
+            raise ValueError("LayerAwareContrastiveTrainerConfig.num_views must be >= 2")
+        super().__init__(model, config=config)
+
+        self.loss_fn = SupConLoss(
+            temperature=float(config.temperature),
+            ignore_label=int(config.ignore_label),
+            same_sample_weight=float(config.same_sample_weight),
+            same_class_weight=float(config.same_class_weight),
+        )
+
+        self.best_loss: float = float("inf")
+        self._calibrated: bool = False
+
+    def fit(self, train_dataset, val_dataset=None) -> None:
+        """Run the training loop, with optional pre-training calibration."""
+        # Check model attribute first, fall back to config for backward compat.
+        needs_calibration = getattr(self.model, "requires_calibration", False)
+        if not needs_calibration:
+            needs_calibration = bool(self.contrastive_config.calibrate)
+
+        if (
+            needs_calibration
+            and not self._calibrated
+            and hasattr(self.model, "calibrate")
+        ):
+            logger.info("Running embedding calibration...")
+            # Build the train loader (this caches it for later reuse)
+            train_loader, _, train_iter = self._build_train_iterator(train_dataset)
+            # Use the iterator if available (infinite stream), otherwise the loader directly
+            calib_iter = train_iter if train_iter is not None else iter(train_loader)
+
+            max_batches = getattr(self.model, "calibrate_max_batches", 50)
+            target_ratio = getattr(self.model, "calibrate_target_ratio", 0.01)
+            # Config overrides if explicitly set
+            if bool(self.contrastive_config.calibrate):
+                max_batches = int(self.contrastive_config.calibrate_max_batches)
+                target_ratio = float(self.contrastive_config.calibrate_target_ratio)
+
+            stats = self.model.calibrate(
+                calib_iter,
+                max_batches=int(max_batches),
+                target_ratio=float(target_ratio),
+            )
+            self._calibrated = True
+            logger.info(f"Calibration complete: {stats}")
+
+        super().fit(train_dataset, val_dataset=val_dataset)
+
+    def training_step(self, batch: Dict[str, Any]) -> Tuple[torch.Tensor, Dict[str, float]]:
+        views = batch["views_activations"].to(self.device, non_blocking=True)
+        view_indices = batch.get("view_indices")
+        if not isinstance(view_indices, torch.Tensor):
+            raise ValueError("LayerAwareContrastiveTrainer requires `view_indices` in each batch")
+
+        view_indices = view_indices.to(self.device, non_blocking=True)
+        batch_size, num_views, seq_len, hidden_dim = views.shape
+        x_flat = views.reshape(batch_size * num_views, seq_len, hidden_dim)
+        layer_idx_flat = view_indices.reshape(batch_size * num_views)
+
+        z_flat = self.model(x_flat, layer_idx=layer_idx_flat)
+        z_views = z_flat.reshape(batch_size, num_views, -1)
+
+        if bool(self.contrastive_config.use_labels):
+            labels = batch["halu"].to(self.device, non_blocking=True)
+            if labels.dim() == 0:
+                labels = labels.unsqueeze(0)
+            elif labels.dim() > 1:
+                labels = labels.view(-1)
+
+            hashkeys = batch.get("hashkey")
+            if isinstance(hashkeys, str):
+                hashkeys = [hashkeys]
+            if hashkeys is None:
+                sample_ids = torch.arange(labels.shape[0], device=self.device, dtype=torch.long)
+            else:
+                sample_ids = torch.tensor(
+                    [hash(hk) % 1000000 for hk in hashkeys],
+                    dtype=torch.long,
+                    device=self.device,
+                )
+
+            loss = self.loss_fn(z_views, labels=labels, sample_ids=sample_ids)
+        else:
+            loss = self.loss_fn(z_views)
+
+        intra_cos = intra_sample_cosine_mean(z_views)
+        intra_inter = intra_inter_margin(z_views)
+        return loss, {"intra_cos": float(intra_cos), "intra_inter_margin": float(intra_inter)}
+
+    def train_dataloader(self, train_dataset) -> DataLoader:
+        dataset = train_dataset
+
+        is_iterable = isinstance(dataset, IterableDataset)
+        if bool(self.contrastive_config.use_infinite_index_stream) and not is_iterable:
+            if not hasattr(dataset, "__len__"):
+                raise TypeError("use_infinite_index_stream=True requires train_dataset to have __len__")
+            dataset = InfiniteIndexStream(
+                dataset,
+                shuffle=bool(self.contrastive_config.infinite_stream_shuffle),
+                seed=int(self.contrastive_config.infinite_stream_seed),
+            )
+            is_iterable = True
+
+        sampler = None
+        if (
+            bool(self.contrastive_config.balanced_sampling)
+            and bool(self.contrastive_config.use_labels)
+            and not is_iterable
+        ):
+            sampler = _build_balanced_sampler(dataset)
+
+        return DataLoader(
+            dataset,
+            batch_size=int(self.contrastive_config.batch_size),
+            shuffle=(sampler is None and not is_iterable),
+            sampler=sampler,
+            num_workers=int(self.contrastive_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.contrastive_config.persistent_workers and int(self.contrastive_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def val_dataloader(self, val_dataset, *, batch_size: Optional[int] = None) -> DataLoader:
+        resolved_batch_size = int(self.contrastive_config.batch_size if batch_size is None else batch_size)
+        return DataLoader(
+            val_dataset,
+            batch_size=resolved_batch_size,
+            shuffle=False,
+            num_workers=int(self.contrastive_config.num_workers),
+            pin_memory=True,
+            persistent_workers=bool(
+                self.contrastive_config.persistent_workers and int(self.contrastive_config.num_workers) > 0
+            ),
+            collate_fn=_contrastive_collate_kview,
+        )
+
+    def validate(self, *, epoch: int, val_dataset) -> Dict[str, float]:
+        _ = epoch
+        val_loader, eval_max_batches, eval_sub_batch_size = self._build_val_loader(val_dataset)
+
+        test_loss, test_intra_cos, test_intra_inter_margin = evaluate(
+            self.model,
+            val_loader,
+            batch_size=int(self.contrastive_config.batch_size),
+            sub_batch_size=int(eval_sub_batch_size),
+            loss_fn=self.loss_fn,
+            device=str(self.device),
+            use_labels=bool(self.contrastive_config.use_labels),
+            ignore_label=int(self.contrastive_config.ignore_label),
+            max_batches=eval_max_batches,
+        )
+
+        self.best_loss = min(float(self.best_loss), float(test_loss))
+
+        out = {
+            "test_loss": float(test_loss),
+            "test_intra_cos": float(test_intra_cos),
+            "test_intra_inter_margin": float(test_intra_inter_margin),
+            "best_loss": float(self.best_loss),
+        }
+
+        logger.info(
+            "Val metrics: "
+            f"loss={out['test_loss']:.4f}, "
+            f"intra_cos={out['test_intra_cos']:.4f}, "
+            f"intra_inter_margin={out['test_intra_inter_margin']:.4f}"
+        )
+        return out
+
+    def maybe_save_checkpoint(
+        self,
+        *,
+        epoch: int,
+        train_metrics: Dict[str, float],
+        val_metrics: Dict[str, float],
+        is_last_epoch: bool,
+    ) -> float:
+        checkpoint_start = time.perf_counter()
+
+        if int(self.contrastive_config.save_every) <= 0:
+            return 0.0
+
+        should_save = ((epoch + 1) % int(self.contrastive_config.save_every) == 0) or bool(is_last_epoch)
+        if not should_save:
+            return 0.0
+
+        checkpoint = {
+            "epoch": int(epoch),
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "temperature": float(self.contrastive_config.temperature),
+            "lr": float(self.contrastive_config.lr),
+            **train_metrics,
+            **val_metrics,
+        }
+
+        last_path = os.path.join(self.contrastive_config.checkpoint_dir, "layer_aware_contrastive_last.pt")
+        _atomic_torch_save(checkpoint, last_path)
+
+        _save_and_prune_snapshots(
+            checkpoint_dir=self.resolve_snapshot_dir(),
+            snapshot_prefix="layer_aware_contrastive",
+            epoch_one_indexed=epoch + 1,
+            checkpoint=checkpoint,
+            snapshot_every=int(self.contrastive_config.snapshot_every),
+            snapshot_keep_last=int(self.contrastive_config.snapshot_keep_last),
+            is_last_epoch=bool(is_last_epoch),
+        )
+
+        if bool(self.contrastive_config.cleanup_legacy_checkpoints):
+            _cleanup_legacy_checkpoints(
+                self.contrastive_config.checkpoint_dir,
+                keep_filenames={"layer_aware_contrastive_last.pt"},
+            )
+
+        elapsed = float(time.perf_counter() - checkpoint_start)
+        if bool(getattr(self.contrastive_config, "log_timing", True)):
+            logger.info(
+                "Checkpoint timing: "
+                f"epoch={epoch + 1}, path={last_path}, elapsed={elapsed:.2f}s"
+            )
+        return elapsed
+
+    def load_checkpoint(self, resume_from: str) -> None:
+        checkpoint_path = resume_from
+        if not os.path.isabs(checkpoint_path):
+            checkpoint_path = os.path.join(self.contrastive_config.checkpoint_dir, resume_from)
+
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+
+        checkpoint = torch.load(checkpoint_path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.start_epoch = int(checkpoint.get("epoch", 0)) + 1
+        self.best_loss = float(checkpoint.get("best_loss", float("inf")))
+        logger.info(f"Resumed training from epoch {self.start_epoch}")

--- a/configs/methods/simclr_cotrained.json
+++ b/configs/methods/simclr_cotrained.json
@@ -1,0 +1,42 @@
+{
+  "name": "simclr_cotrained",
+  "routine": "simclr_cotrained",
+  "model_class": "simclr_cotrained",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3
+  },
+  "training": {
+    "max_epochs": 50,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "simclr_weight": 1.0,
+    "bce_weight": 1.0,
+    "use_infinite_index_stream": true,
+    "use_infinite_index_stream_eval": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/simclr_linear.json
+++ b/configs/methods/simclr_linear.json
@@ -1,0 +1,43 @@
+{
+  "name": "simclr_linear",
+  "routine": "simclr_linear",
+  "model_class": "progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3
+  },
+  "training": {
+    "contrastive_epochs": 50,
+    "contrastive_lr": 1e-5,
+    "probe_epochs": 100,
+    "probe_lr": 1e-3,
+    "batch_size": 512,
+    "temperature": 0.25,
+    "use_infinite_index_stream": true,
+    "use_infinite_index_stream_eval": true,
+    "grad_clip_norm": 1.0,
+    "probe_balanced_sampling": true,
+    "probe_min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["auroc", "cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/simclr_projection.json
+++ b/configs/methods/simclr_projection.json
@@ -1,0 +1,43 @@
+{
+  "name": "simclr_projection",
+  "routine": "simclr_projection",
+  "model_class": "simclr_projection",
+  "model_params": {
+    "final_dim": 512,
+    "projection_dim": 128,
+    "input_dropout": 0.3
+  },
+  "training": {
+    "max_epochs": 50,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "simclr_weight": 1.0,
+    "bce_weight": 1.0,
+    "use_infinite_index_stream": true,
+    "use_infinite_index_stream_eval": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -639,6 +639,571 @@ def run_multi_layer_linear_probe(
     return eval_metrics, predictions
 
 
+
+def run_simclr_linear(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """Train and evaluate a two-phase SimCLR + linear probe model.
+
+    Phase 1: Unsupervised contrastive (SimCLR) on the ProgressiveCompressor.
+    Phase 2: Linear probe on frozen encoder embeddings (BCE, AUROC).
+    """
+    data_cfg = method_cfg["data"]
+    train_cfg = method_cfg["training"]
+    eval_cfg = method_cfg["evaluation"]
+
+    relevant_layers = parse_layer_range(data_cfg["relevant_layers"])
+    target_layers = data_cfg["target_layers"]
+
+    # Common dataset kwargs
+    ds_kwargs = dict(
+        relevant_layers=relevant_layers,
+        num_views=data_cfg.get("num_views", 2),
+        pad_length=data_cfg.get("pad_length", 63),
+        preload=data_cfg.get("preload", True),
+        include_response_logprobs=data_cfg.get("include_response_logprobs", False),
+        response_logprobs_top_k=data_cfg.get("response_logprobs_top_k", 20),
+        check_ram=False,
+    )
+
+    # Build datasets for Phase 1 (contrastive, multi-view)
+    train_ds = ap.get_dataset("train", **ds_kwargs)
+    eval_ap = test_ap if test_ap is not None else ap
+    test_ds = eval_ap.get_dataset("test", **ds_kwargs)
+
+    has_val = ap.split_strategy == "three_way"
+    val_ds = ap.get_dataset("val", **ds_kwargs) if has_val else test_ds
+
+    # Build single-layer datasets for Phase 2 (linear probe on target layers)
+    train_ds_target = train_ds.slice_layers(target_layers)
+    test_ds_target = test_ds.slice_layers(target_layers)
+    val_ds_target = val_ds.slice_layers(target_layers) if has_val else test_ds_target
+
+    # Build model
+    from activation_research.model import ProgressiveCompressor
+
+    model = ProgressiveCompressor(
+        input_dim=dataset_cfg["input_dim"],
+        final_dim=method_cfg["model_params"].get("final_dim", 512),
+        input_dropout=method_cfg["model_params"].get("input_dropout", 0.3),
+    )
+
+    # Build trainer
+    from activation_research.trainer import SimCLRLinearTrainer, SimCLRLinearTrainerConfig
+
+    checkpoint_dir = os.path.join(output_dir, "artifacts")
+    config = SimCLRLinearTrainerConfig(
+        batch_size=train_cfg["batch_size"],
+        temperature=train_cfg.get("temperature", 0.25),
+        contrastive_epochs=train_cfg.get("contrastive_epochs", 50),
+        contrastive_lr=train_cfg.get("contrastive_lr", 1e-5),
+        probe_epochs=train_cfg.get("probe_epochs", 100),
+        probe_lr=train_cfg.get("probe_lr", 1e-3),
+        probe_balanced_sampling=train_cfg.get("probe_balanced_sampling", True),
+        probe_min_total_steps=train_cfg.get("probe_min_total_steps", 3000),
+        grad_clip_norm=train_cfg.get("grad_clip_norm"),
+        use_infinite_index_stream=train_cfg.get("use_infinite_index_stream", True),
+        use_infinite_index_stream_eval=train_cfg.get(
+            "use_infinite_index_stream_eval", True
+        ),
+        infinite_stream_seed=training_seed,
+        infinite_eval_seed=training_seed,
+        num_views=data_cfg.get("num_views", 2),
+        device=device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=experiment_cfg.get("persistent_workers", True),
+        checkpoint_dir=checkpoint_dir,
+        save_every=1,
+        snapshot_every=10,
+        snapshot_keep_last=3,
+    )
+
+    trainer = SimCLRLinearTrainer(model, config=config)
+    trainer.fit(
+        train_dataset=train_ds,
+        val_dataset=val_ds,
+        probe_train_dataset=train_ds_target,
+        probe_val_dataset=val_ds_target,
+    )
+
+    # Save final encoder weights
+    torch.save(
+        {"model_state_dict": model.state_dict()},
+        os.path.join(output_dir, "artifacts", "final_weights.pt"),
+    )
+
+    # Save linear head weights
+    if trainer.linear_head is not None:
+        torch.save(
+            {"linear_head_state_dict": trainer.linear_head.state_dict()},
+            os.path.join(output_dir, "artifacts", "final_linear_head.pt"),
+        )
+
+    # --- Evaluation ---
+    # 1) Contrastive embedding quality (cosine, mds, knn) via OOD evaluator
+    from torch.utils.data import DataLoader
+
+    from activation_research.metric_evaluator import MultiMetricHallucinationEvaluator
+
+    train_loader = DataLoader(train_ds_target, batch_size=64, shuffle=False)
+    eval_loader = DataLoader(test_ds_target, batch_size=64, shuffle=False)
+
+    model.eval()
+
+    # Build metrics list from config (exclude "auroc" since that's probe-based)
+    metrics_list: list = []
+    for m in eval_cfg["metrics"]:
+        if m == "auroc":
+            continue  # handled separately via probe
+        if m == "knn":
+            knn_params = dict(eval_cfg.get("knn_params", {}))
+            knn_params["sample_seed"] = training_seed
+            metrics_list.append(
+                {
+                    "metric": "knn",
+                    "kwargs": knn_params,
+                    "train_selection": "all",
+                }
+            )
+        else:
+            metrics_list.append(m)
+
+    ood_stats = {}
+    if metrics_list:
+        evaluator = MultiMetricHallucinationEvaluator(
+            activation_parser_df=eval_ap.df,
+            train_data_loader=train_loader,
+            metrics=metrics_list,
+            batch_size=eval_cfg.get("eval_batch_size", 256),
+            sub_batch_size=eval_cfg.get("sub_batch_size", 64),
+            device=device,
+            num_workers=experiment_cfg.get("num_workers", 4),
+            persistent_workers=False,
+            outlier_class=dataset_cfg.get("outlier_class", 1),
+        )
+        ood_stats = evaluator.compute(eval_loader, model)
+
+    # 2) Linear probe AUROC on test set
+    from sklearn.metrics import roc_auc_score
+
+    probe_auroc = float("nan")
+    predictions: list[dict] = []
+    if trainer.linear_head is not None:
+        trainer.linear_head.eval()
+        probe_eval_loader = DataLoader(
+            test_ds_target, batch_size=train_cfg["batch_size"], shuffle=False
+        )
+        all_preds, all_labels = [], []
+        with torch.no_grad():
+            for batch in probe_eval_loader:
+                x = batch["views_activations"].to(
+                    torch.device(device if device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")),
+                    non_blocking=True,
+                )
+                if x.dim() == 4:
+                    x = x[:, 0]  # take first view
+                z = model(x)
+                preds = trainer.linear_head(z)
+                all_preds.append(preds.cpu())
+                all_labels.append(batch["halu"].cpu())
+
+        all_preds_np = torch.cat(all_preds).squeeze().numpy()
+        all_labels_np = torch.cat(all_labels).numpy()
+        if len(set(all_labels_np)) >= 2:
+            probe_auroc = float(roc_auc_score(all_labels_np, all_preds_np))
+
+        predictions = [
+            {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
+            for i, (s, l) in enumerate(zip(all_preds_np, all_labels_np))
+        ]
+
+    # Combine metrics
+    eval_metrics: dict = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "split_seed": experiment_cfg.get("split_seed", 42),
+        "n_train": len(train_ds),
+        "n_test": len(test_ds),
+        "auroc": probe_auroc,
+        "target_layers": target_layers,
+    }
+    eval_metrics.update(ood_stats)
+
+    return eval_metrics, predictions
+
+
+
+def run_simclr_cotrained(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """Train and evaluate a SimCLR co-trained (joint contrastive + BCE) model."""
+    data_cfg = method_cfg["data"]
+    train_cfg = method_cfg["training"]
+    eval_cfg = method_cfg["evaluation"]
+
+    relevant_layers = parse_layer_range(data_cfg["relevant_layers"])
+    target_layers = data_cfg["target_layers"]
+
+    # Common dataset kwargs
+    ds_kwargs = dict(
+        relevant_layers=relevant_layers,
+        num_views=data_cfg.get("num_views", 2),
+        pad_length=data_cfg.get("pad_length", 63),
+        preload=data_cfg.get("preload", True),
+        include_response_logprobs=data_cfg.get("include_response_logprobs", False),
+        response_logprobs_top_k=data_cfg.get("response_logprobs_top_k", 20),
+        check_ram=False,
+    )
+
+    # Build datasets
+    train_ds = ap.get_dataset("train", **ds_kwargs)
+    eval_ap = test_ap if test_ap is not None else ap
+    test_ds = eval_ap.get_dataset("test", **ds_kwargs)
+
+    # Use val split for training validation when available (avoids data leakage)
+    has_val = ap.split_strategy == "three_way"
+    val_ds = ap.get_dataset("val", **ds_kwargs) if has_val else test_ds
+
+    # Build model
+    from activation_research.model import SimCLRCotrainedModel
+
+    model = SimCLRCotrainedModel(
+        input_dim=dataset_cfg["input_dim"],
+        final_dim=method_cfg["model_params"].get("final_dim", 512),
+        input_dropout=method_cfg["model_params"].get("input_dropout", 0.3),
+    )
+
+    # Build trainer
+    from activation_research.trainer import (
+        SimCLRCotrainedTrainer,
+        SimCLRCotrainedTrainerConfig,
+    )
+
+    checkpoint_dir = os.path.join(output_dir, "artifacts")
+    config = SimCLRCotrainedTrainerConfig(
+        max_epochs=train_cfg["max_epochs"],
+        batch_size=train_cfg["batch_size"],
+        lr=train_cfg["lr"],
+        temperature=train_cfg.get("temperature", 0.25),
+        simclr_weight=train_cfg.get("simclr_weight", 1.0),
+        bce_weight=train_cfg.get("bce_weight", 1.0),
+        steps_per_epoch_override=train_cfg.get("steps_per_epoch_override"),
+        min_total_steps=train_cfg.get("min_total_steps"),
+        grad_clip_norm=train_cfg.get("grad_clip_norm"),
+        use_infinite_index_stream=train_cfg.get("use_infinite_index_stream", True),
+        use_infinite_index_stream_eval=train_cfg.get(
+            "use_infinite_index_stream_eval", True
+        ),
+        infinite_stream_seed=training_seed,
+        infinite_eval_seed=training_seed,
+        balanced_sampling=train_cfg.get("balanced_sampling", False),
+        num_views=data_cfg.get("num_views", 2),
+        device=device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=experiment_cfg.get("persistent_workers", True),
+        checkpoint_dir=checkpoint_dir,
+        save_every=1,
+        snapshot_every=10,
+        snapshot_keep_last=3,
+    )
+
+    trainer = SimCLRCotrainedTrainer(model, config=config)
+    trainer.fit(train_dataset=train_ds, val_dataset=val_ds)
+
+    # Save final weights
+    torch.save(
+        {"model_state_dict": model.state_dict()},
+        os.path.join(output_dir, "artifacts", "final_weights.pt"),
+    )
+
+    # OOD evaluation on target layers (contrastive embedding quality)
+    from torch.utils.data import DataLoader
+
+    from activation_research.metric_evaluator import MultiMetricHallucinationEvaluator
+
+    train_ds_target = train_ds.slice_layers(target_layers)
+    test_ds_target = test_ds.slice_layers(target_layers)
+
+    train_loader = DataLoader(train_ds_target, batch_size=64, shuffle=False)
+    eval_loader = DataLoader(test_ds_target, batch_size=64, shuffle=False)
+
+    model.eval()
+
+    # Build metrics list from config
+    metrics_list: list = []
+    for m in eval_cfg["metrics"]:
+        if m == "knn":
+            knn_params = dict(eval_cfg.get("knn_params", {}))
+            knn_params["sample_seed"] = training_seed
+            metrics_list.append(
+                {
+                    "metric": "knn",
+                    "kwargs": knn_params,
+                    "train_selection": "all",
+                }
+            )
+        else:
+            metrics_list.append(m)
+
+    evaluator = MultiMetricHallucinationEvaluator(
+        activation_parser_df=eval_ap.df,
+        train_data_loader=train_loader,
+        metrics=metrics_list,
+        batch_size=eval_cfg.get("eval_batch_size", 256),
+        sub_batch_size=eval_cfg.get("sub_batch_size", 64),
+        device=device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=False,
+        outlier_class=dataset_cfg.get("outlier_class", 1),
+    )
+
+    ood_stats = evaluator.compute(eval_loader, model)
+
+    # Also compute classification AUROC from the head on test set
+    from sklearn.metrics import roc_auc_score
+
+    eval_device = torch.device(
+        device if device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    model.to(eval_device)
+
+    head_eval_loader = DataLoader(test_ds_target, batch_size=256, shuffle=False)
+    all_preds, all_labels = [], []
+    with torch.no_grad():
+        for batch in head_eval_loader:
+            x = batch["views_activations"].to(eval_device)
+            if x.dim() == 4:
+                x = x[:, 0]  # take first view
+            _, pred = model.forward_with_head(x)
+            all_preds.append(pred.cpu())
+            all_labels.append(batch["halu"].cpu())
+
+    all_preds_np = torch.cat(all_preds).squeeze().numpy()
+    all_labels_np = torch.cat(all_labels).numpy()
+    if len(set(all_labels_np)) < 2:
+        head_auroc = float("nan")
+    else:
+        head_auroc = roc_auc_score(all_labels_np, all_preds_np)
+
+    # Build eval_metrics
+    eval_metrics: dict = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "split_seed": experiment_cfg.get("split_seed", 42),
+        "n_train": len(train_ds),
+        "n_test": len(test_ds),
+        "auroc": float(head_auroc),
+    }
+    eval_metrics.update(ood_stats)
+
+    predictions: list[dict] = []
+    return eval_metrics, predictions
+
+
+
+def run_simclr_projection(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """Train and evaluate a SimCLR projection head model.
+
+    The contrastive loss operates on the projected embeddings p (after MLP
+    projection head), while the classification head and downstream evaluation
+    operate on the representation z (before the projection head).
+    """
+    data_cfg = method_cfg["data"]
+    train_cfg = method_cfg["training"]
+    eval_cfg = method_cfg["evaluation"]
+
+    relevant_layers = parse_layer_range(data_cfg["relevant_layers"])
+    target_layers = data_cfg["target_layers"]
+
+    # Common dataset kwargs
+    ds_kwargs = dict(
+        relevant_layers=relevant_layers,
+        num_views=data_cfg.get("num_views", 2),
+        pad_length=data_cfg.get("pad_length", 63),
+        preload=data_cfg.get("preload", True),
+        include_response_logprobs=data_cfg.get("include_response_logprobs", False),
+        response_logprobs_top_k=data_cfg.get("response_logprobs_top_k", 20),
+        check_ram=False,
+    )
+
+    # Build datasets
+    train_ds = ap.get_dataset("train", **ds_kwargs)
+    eval_ap = test_ap if test_ap is not None else ap
+    test_ds = eval_ap.get_dataset("test", **ds_kwargs)
+
+    # Use val split for training validation when available (avoids data leakage)
+    has_val = ap.split_strategy == "three_way"
+    val_ds = ap.get_dataset("val", **ds_kwargs) if has_val else test_ds
+
+    # Build model
+    from activation_research.model import SimCLRProjectionModel
+
+    model_params = method_cfg.get("model_params", {})
+    model = SimCLRProjectionModel(
+        input_dim=dataset_cfg["input_dim"],
+        final_dim=model_params.get("final_dim", 512),
+        projection_dim=model_params.get("projection_dim", 128),
+        input_dropout=model_params.get("input_dropout", 0.3),
+    )
+
+    # Build trainer
+    from activation_research.trainer import (
+        SimCLRProjectionTrainer,
+        SimCLRProjectionTrainerConfig,
+    )
+
+    checkpoint_dir = os.path.join(output_dir, "artifacts")
+    config = SimCLRProjectionTrainerConfig(
+        max_epochs=train_cfg["max_epochs"],
+        batch_size=train_cfg["batch_size"],
+        lr=train_cfg["lr"],
+        temperature=train_cfg["temperature"],
+        simclr_weight=train_cfg.get("simclr_weight", 1.0),
+        bce_weight=train_cfg.get("bce_weight", 1.0),
+        projection_dim=model_params.get("projection_dim", 128),
+        steps_per_epoch_override=train_cfg.get("steps_per_epoch_override"),
+        min_total_steps=train_cfg.get("min_total_steps"),
+        grad_clip_norm=train_cfg.get("grad_clip_norm"),
+        use_infinite_index_stream=train_cfg.get("use_infinite_index_stream", True),
+        use_infinite_index_stream_eval=train_cfg.get(
+            "use_infinite_index_stream_eval", True
+        ),
+        infinite_stream_seed=training_seed,
+        infinite_eval_seed=training_seed,
+        balanced_sampling=train_cfg.get("balanced_sampling", False),
+        num_views=data_cfg.get("num_views", 2),
+        device=device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=experiment_cfg.get("persistent_workers", True),
+        checkpoint_dir=checkpoint_dir,
+        save_every=1,
+        snapshot_every=10,
+        snapshot_keep_last=3,
+    )
+
+    trainer = SimCLRProjectionTrainer(model, config=config)
+    trainer.fit(train_dataset=train_ds, val_dataset=val_ds)
+
+    # Save final weights
+    torch.save(
+        {"model_state_dict": model.state_dict()},
+        os.path.join(output_dir, "artifacts", "final_weights.pt"),
+    )
+
+    # OOD evaluation on target layers using z (encoder output, model.forward)
+    from torch.utils.data import DataLoader
+
+    from activation_research.metric_evaluator import MultiMetricHallucinationEvaluator
+
+    train_ds_target = train_ds.slice_layers(target_layers)
+    test_ds_target = test_ds.slice_layers(target_layers)
+
+    train_loader = DataLoader(train_ds_target, batch_size=64, shuffle=False)
+    eval_loader = DataLoader(test_ds_target, batch_size=64, shuffle=False)
+
+    model.eval()
+
+    # Build metrics list from config
+    metrics_list: list = []
+    for m in eval_cfg["metrics"]:
+        if m == "knn":
+            knn_params = dict(eval_cfg.get("knn_params", {}))
+            knn_params["sample_seed"] = training_seed
+            metrics_list.append(
+                {
+                    "metric": "knn",
+                    "kwargs": knn_params,
+                    "train_selection": "all",
+                }
+            )
+        elif m == "auroc":
+            # AUROC from classification head -- compute separately below
+            pass
+        else:
+            metrics_list.append(m)
+
+    evaluator = MultiMetricHallucinationEvaluator(
+        activation_parser_df=eval_ap.df,
+        train_data_loader=train_loader,
+        metrics=metrics_list,
+        batch_size=eval_cfg.get("eval_batch_size", 256),
+        sub_batch_size=eval_cfg.get("sub_batch_size", 64),
+        device=device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=False,
+        outlier_class=dataset_cfg.get("outlier_class", 1),
+    )
+
+    ood_stats = evaluator.compute(eval_loader, model)
+
+    # Compute AUROC from classification head on test set
+    eval_device = torch.device(
+        device if device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    model.to(eval_device)
+
+    all_preds, all_labels = [], []
+    with torch.no_grad():
+        for batch in eval_loader:
+            x = batch["views_activations"].to(eval_device)
+            if x.dim() == 4:
+                x = x[:, 0]  # first view
+            z = model(x)  # encoder output
+            pred = torch.sigmoid(model.head(z))
+            all_preds.append(pred.cpu())
+            all_labels.append(batch["halu"].cpu())
+
+    from sklearn.metrics import roc_auc_score
+
+    all_preds_np = torch.cat(all_preds).squeeze().numpy()
+    all_labels_np = torch.cat(all_labels).numpy()
+    if len(set(all_labels_np)) < 2:
+        head_auroc = float("nan")
+    else:
+        head_auroc = float(roc_auc_score(all_labels_np, all_preds_np))
+
+    # Build eval_metrics
+    eval_metrics: dict = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "split_seed": experiment_cfg.get("split_seed", 42),
+        "n_train": len(train_ds),
+        "n_test": len(test_ds),
+        "auroc": head_auroc,
+    }
+    eval_metrics.update(ood_stats)
+
+    predictions: list[dict] = []
+    return eval_metrics, predictions
+
+
+
 def run_token_entropy(
     ap,
     dataset_cfg: dict,
@@ -1117,6 +1682,21 @@ def main() -> None:
                         )
                     elif routine == "multi_layer_linear_probe":
                         eval_metrics, predictions = run_multi_layer_linear_probe(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "simclr_linear":
+                        eval_metrics, predictions = run_simclr_linear(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "simclr_cotrained":
+                        eval_metrics, predictions = run_simclr_cotrained(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "simclr_projection":
+                        eval_metrics, predictions = run_simclr_projection(
                             ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, seed,
                             test_ap=test_ap,
                         )


### PR DESCRIPTION
## Summary

- **Option A** (`simclr_linear`): Two-stage — unsupervised SimCLR encoder training, then frozen linear probe with BCE. Tests whether hallucination signal survives unsupervised compression.
- **Option B** (`simclr_cotrained`): Joint `α·L_SimCLR + β·L_BCE` with full gradient flow through the encoder. Unsupervised contrastive regularizes while BCE preserves hallucination signal.
- **Option D** (`simclr_projection`): MLP projection head — contrastive loss on projected `p`, classification on pre-projection `z`. Follows SimCLR best practice.

All three report a top-level `auroc` key consistent with `linear_probe` and `multi_layer_linear_probe`.

### Files changed
- `activation_research/model.py` — `SimCLRCotrainedModel`, `SimCLRProjectionModel`
- `activation_research/trainer.py` — `SimCLRLinearTrainer`, `SimCLRCotrainedTrainer`, `SimCLRProjectionTrainer` + configs
- `scripts/run_experiment.py` — `run_simclr_linear()`, `run_simclr_cotrained()`, `run_simclr_projection()` + routing
- `configs/methods/simclr_linear.json`, `simclr_cotrained.json`, `simclr_projection.json`

## Test plan
- [x] Smoketested all 3 options on sciq dataset (1 epoch) on alphagpu23 H200
- [ ] Full multi-seed experiment runs

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)