### PR TITLE
fix: randomize train/val split per training seed

### DIFF
--- a/activation_logging/activation_parser.py
+++ b/activation_logging/activation_parser.py
@@ -981,7 +981,46 @@ class ActivationParser:
 
         return gendf
 
-            
+    def resplit(self, random_seed: int) -> None:
+        """Re-apply the train/val split with a new random seed.
+
+        This allows different training seeds to operate on different
+        train/val partitions, producing meaningful variance across runs.
+
+        Args:
+            random_seed: New seed for the train/val split.
+        """
+        if self.split_strategy == "none":
+            return
+
+        logger.info(f"Resplitting train/val with random_seed={random_seed}")
+        self.random_seed = random_seed
+
+        # Reset split column
+        self.gendf['split'] = 'unassigned'
+
+        train_df, test_df = train_test_split(
+            self.gendf, test_size=0.2,
+            stratify=self.gendf['halu'], random_state=self.random_seed,
+        )
+        self.gendf.loc[train_df.index, 'split'] = 'train'
+        self.gendf.loc[test_df.index, 'split'] = 'test'
+
+        if self.split_strategy == "three_way":
+            train_only_df, val_df = train_test_split(
+                train_df, test_size=0.125,
+                stratify=train_df['halu'], random_state=self.random_seed + 1,
+            )
+            self.gendf.loc[val_df.index, 'split'] = 'val'
+            if self.verbose:
+                logger.info(f"Val set size: {len(val_df)}")
+
+        if self.verbose:
+            logger.info(
+                f"Resplit complete: train={len(self.gendf[self.gendf['split'] == 'train'])}, "
+                f"test={len(test_df)}"
+            )
+
     def _hash_prompt(self, prompt: str) -> str:
         """
         Hash a prompt string to match the format used in ActivationsLogger.

--- a/activation_logging/activation_parser.py
+++ b/activation_logging/activation_parser.py
@@ -997,27 +997,27 @@ class ActivationParser:
         self.random_seed = random_seed
 
         # Reset split column
-        self.gendf['split'] = 'unassigned'
+        self.df['split'] = 'unassigned'
 
         train_df, test_df = train_test_split(
-            self.gendf, test_size=0.2,
-            stratify=self.gendf['halu'], random_state=self.random_seed,
+            self.df, test_size=0.2,
+            stratify=self.df['halu'], random_state=self.random_seed,
         )
-        self.gendf.loc[train_df.index, 'split'] = 'train'
-        self.gendf.loc[test_df.index, 'split'] = 'test'
+        self.df.loc[train_df.index, 'split'] = 'train'
+        self.df.loc[test_df.index, 'split'] = 'test'
 
         if self.split_strategy == "three_way":
             train_only_df, val_df = train_test_split(
                 train_df, test_size=0.125,
                 stratify=train_df['halu'], random_state=self.random_seed + 1,
             )
-            self.gendf.loc[val_df.index, 'split'] = 'val'
+            self.df.loc[val_df.index, 'split'] = 'val'
             if self.verbose:
                 logger.info(f"Val set size: {len(val_df)}")
 
         if self.verbose:
             logger.info(
-                f"Resplit complete: train={len(self.gendf[self.gendf['split'] == 'train'])}, "
+                f"Resplit complete: train={len(self.df[self.df['split'] == 'train'])}, "
                 f"test={len(test_df)}"
             )
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1648,6 +1648,7 @@ def main() -> None:
                         from utils.seeding import seed_everything
 
                         seed_everything(seed)
+                        ap.resplit(seed)
 
                     # Write merged config
                     merged_config = {
@@ -1655,7 +1656,7 @@ def main() -> None:
                         "method": method_cfg,
                         "experiment": {k: v for k, v in experiment_cfg.items()},
                         "training_seed": seed,
-                        "split_seed": experiment_cfg.get("split_seed", 42),
+                        "split_seed": seed if seed is not None else experiment_cfg.get("split_seed", 42),
                     }
                     with open(os.path.join(run_dir, "config.json"), "w") as f:
                         json.dump(merged_config, f, indent=2)


### PR DESCRIPTION
Closes #34

## Summary
- Add `ActivationParser.resplit(random_seed)` method that re-applies train/val split with a new seed
- Call `ap.resplit(seed)` in the training seed loop in `run_experiment.py` so each seed gets a different data partition
- Record actual split seed used in merged config

Previously, `split_seed=42` was hardcoded, meaning all training seeds operated on identical train/val splits. AUROC std across seeds (~0.0008) reflected only weight initialization noise, not true variance.

## Test plan
- [ ] Run a multi-seed experiment and verify AUROC std is higher than before
- [ ] Verify that `config.json` in each run dir shows the training seed as `split_seed`
- [ ] Verify non-learned methods (token_entropy, logprob) still work (resplit is a no-op when seed is None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)