### PR TITLE
feat(#52): LLMsKnow probe baseline with adaptive (layer, token) sweep

### DIFF
--- a/PAPER_ROADMAP.md
+++ b/PAPER_ROADMAP.md
@@ -1,6 +1,6 @@
 # Paper Roadmap — EMNLP Submission
 
-**Last updated:** 2026-05-12 (SAPLMA baseline added to grid)
+**Last updated:** 2026-05-12 (SAPLMA baseline added to grid; semantic-entropy item rescoped to a sampling-based baselines bundle — SE + SelfCheckGPT + SEP-SE + SEP-binary across 5–6 datasets, see #49)
 **Target venue:** EMNLP 2026 (Main / Findings)
 **Submission window:** ~4 weeks from today
 **Status:** seed-0 sweep complete; multi-seed expansion + second-model + missing baselines in flight
@@ -38,7 +38,7 @@ If any of those clauses fails to hold up empirically, the framing changes — th
 | Qwen3-8B seed sweep, seeds {1, 2, 3, 4} × 6 datasets | 🟡 in flight | Runner shells: `scripts/run_baseline_qwen3_seed{1..4}.sh` |
 | SAPLMA baseline (`SimpleHaluClassifier`) on full grid | ❌ not started | Code already in `activation_research/model.py:276` as `SimpleHaluClassifier` (~11M-param MLP on last-token activations) — wired into trainer but **absent from `configs/experiments/baseline_comparison_*.json`**. Forecloses the "linear probe is a strawman" reviewer concern. Activation-space; reuses cached zarr stores. Tracked in [#51](https://github.com/hyang0129/HalluLens/issues/51). |
 | P(true) baseline | ❌ not started | Cheap; one extra prompt per example. Tracked in [#50](https://github.com/hyang0129/HalluLens/issues/50). Output-space only — does not need activation logging; can run concurrently with the seed sweeps. |
-| Semantic-entropy baseline (Farquhar et al. 2024) on 3-dataset subset | ❌ not started | 10× inference cost; cap at HotpotQA, NQ, PopQA. Tracked in [#49](https://github.com/hyang0129/HalluLens/issues/49). Output-space only — does not need activation logging; can run concurrently with the seed sweeps on a separate GPU. |
+| Sampling-based baselines bundle (SE + SelfCheckGPT + SEP-SE + SEP-binary) | ❌ not started | One K=10 sampling pass produces 4 baselines. 5 free-form datasets {HotpotQA, NQ, PopQA, SciQ, SearchQA} for SE/SelfCheckGPT/SEP-SE; 6 datasets for SEP-binary (MMLU added — SEP-binary is activation-space and survives the NLI-clustering degeneracy on letter tokens that excludes MMLU from SE/SelfCheckGPT). SearchQA capped 10k test / 5k train. SEP-SE trained on 5k stratified train subset (Kossen-faithful regression on SE labels); SEP-binary trained on full train split with binary hallu labels — free byproduct, apples-to-apples with linear probe. Tracked in [#49](https://github.com/hyang0129/HalluLens/issues/49). Sampling pass is output-space only — can run concurrently with the seed sweeps on a separate GPU. |
 | Cross-dataset transfer table | ❌ not started | Train→test pairs across datasets, no new training |
 | AUPRC, ECE, bootstrap 95% CIs | ❌ not started | Pure analysis; zero compute |
 | Ablation: SimCLR-only vs +logprob-recon | ✅ tried | Unsupervised SimCLR features + linear probe on top → ~random guessing. Logprob-recon aux loss is load-bearing. Need to log the run + write it up; no further compute. |
@@ -65,7 +65,13 @@ Each item names the reviewer concern it forecloses. Don't reorder without a reas
 1. **Second model: Qwen2.5-7B-Instruct.** Forecloses "results may be Llama-specific." This is the single highest-leverage missing piece. The Qwen 72B qgen plumbing is partially built (legacy §8.6); the 7B inference path needs `model_map` + `--quantization` wiring or the equivalent for non-quantized 7B. Prefer non-quantized 7B unless VRAM forces otherwise. *(Status note: substituted with Qwen3-8B-Instruct — see §2 status table.)*
 2. **SAPLMA baseline** (Azaria & Mitchell 2023, "The Internal State of an LLM Knows When It's Lying"). Forecloses "linear probe is a strawman; you didn't compare to the established activation-based hallucination detector." The model is already implemented as `SimpleHaluClassifier` in [`activation_research/model.py:276`](activation_research/model.py#L276) — a 3-hidden-layer MLP (4096 → 2048 → 1024 → 512 → 1) on the last-token activations of a single layer, with ReLU + Dropout. It's wired into the trainer at [`scripts/train_activation_model.py:235`](scripts/train_activation_model.py#L235) as `simple_halu_classifier`, but **not in any `configs/experiments/baseline_comparison_*.json`** — so it's never been run in the baseline grid. The discriminating question this addresses: does our contrastive method beat (a) a 4K-param single linear hyperplane and (b) an 11M-param nonlinear MLP on the same activations, or only (a)? Without this, the paper's headline could collapse to "more parameters helps" rather than "contrastive structure helps." Activation-space; reuses cached activations; no new inference. Run on the full grid: 5 seeds × 6 datasets × {Llama-3.1-8B, Qwen3-8B} = 60 training runs. Probe layer should match `linear_probe` (layer 22) for an apples-to-apples comparison. Tracked in [#51](https://github.com/hyang0129/HalluLens/issues/51).
 3. **P(true) baseline** (Kadavath et al. 2022). Forecloses "didn't compare to prompt-based self-evaluation." Implementation cost: one templated follow-up prompt per generated answer. Run on all 6 datasets, both models. **Output-space only — does not need activation logging**, so this can be dispatched independently of the seed sweeps. Tracked in [#50](https://github.com/hyang0129/HalluLens/issues/50).
-4. **Semantic entropy** (Farquhar et al. *Nature* 2024) on 3-dataset subset. Forecloses "didn't compare to the strongest sampling-based method." Cap at HotpotQA, NQ, PopQA to keep GPU bounded; frame as **compute-matched comparison** (1 forward pass vs. 10 samples + entailment clustering). Both models if budget allows; Llama-only is acceptable as long as the framing is honest. **Output-space only — does not need activation logging**, so this can be dispatched independently of the seed sweeps and won't compete for zarr stores. Tracked in [#49](https://github.com/hyang0129/HalluLens/issues/49).
+4. **Sampling-based baselines bundle** — one K=10 sampling pass produces 4 baselines, each foreclosing a distinct reviewer concern:
+   - **Semantic entropy** (Farquhar et al. *Nature* 2024) — forecloses "didn't compare to the strongest sampling-based method."
+   - **SelfCheckGPT** (Manakul et al. EMNLP 2023; variants NLI / BERTScore / n-gram) — forecloses "didn't compare to the canonical black-box consistency baseline."
+   - **SEP-SE** (Kossen et al. 2024) — linear probe on activations trained to predict length-normalized SE; forecloses "didn't compare to the natural probe-based descendant of SE."
+   - **SEP-binary** — free byproduct of SEP infrastructure: linear probe on the same activations but trained on the binary hallucination label over the full train split. Forecloses "you undertrained SEP relative to your linear probe" and gives a genuine compute-matched probe baseline.
+
+   **Scope:** 5 free-form datasets (HotpotQA, NQ, PopQA, SciQ, SearchQA) for SE / SelfCheckGPT / SEP-SE; 6 datasets for SEP-binary (MMLU added — SEP-binary is activation-space and survives the NLI-clustering degeneracy on letter tokens that forces MMLU out of SE/SelfCheckGPT). SearchQA capped at 10k test / 5k train items to keep GPU bounded. SEP-SE trained on 5k stratified train subset per (dataset, model). Frame as **compute-matched comparison** (1 forward pass + linear probe vs. 10 samples + entailment clustering). Both models if budget allows; Llama-only is the firm fallback. **Sampling pass is output-space only — does not need activation logging**, so it can be dispatched independently of the seed sweeps and won't compete for zarr stores; SEP variants then read existing cached activations. Tracked in [#49](https://github.com/hyang0129/HalluLens/issues/49).
 5. **Cross-dataset transfer table.** Forecloses "trained classifier may overfit per-dataset." For each (source, target) dataset pair, evaluate the source-trained checkpoint on the target test split. No new training. One supplementary table, one summary number in the body.
 6. **AUPRC + ECE + bootstrap 95% CIs across seeds.** Forecloses "AUROC alone hides class imbalance / calibration issues / seed noise." Pure analysis; merge into the main table where space allows, push extras to appendix.
 7. **Ablation: contrastive loss decomposition — writeup only.** Already tried: unsupervised SimCLR contrastive pretraining followed by a linear probe on the learned features → ~random (AUROC ≈ 0.5). Interpretation: the logprob-recon auxiliary loss carries the hallucination signal; SimCLR alone learns representations that are invariant to the right things for self-supervision but orthogonal to the hallucination axis. The logprob-recon-only variant is still worth running (1 retrain × seeds × 2 datasets, cached activations) to complete the decomposition. Either way, this ablation closes the "which part of the loss matters" question, and the negative SimCLR-only result is itself a useful contribution.
@@ -95,7 +101,12 @@ Per (model, dataset, method) cell: 5 training seeds {0, 5, 26, 42, 63}, split se
 **Trained methods (per cell × 5 seeds):** {Linear probe, SAPLMA (`SimpleHaluClassifier`), Contrastive+Logprob-recon}
 **Ablation-only (seed-0, not in main grid):** Multi-layer probe (layers 14–29 concatenated) — reported once for motivation; see §4 item 9.
 **Non-trained methods (per cell × 1):** {Logprob, Token entropy, P(true)}
-**Sampling baselines:** Semantic entropy on {HotpotQA, NQ, PopQA} only.
+**Sampling baselines** (5 free-form datasets only — MMLU excluded due to NLI-clustering degeneracy on letter tokens; SearchQA test capped at 10k items, seed=42):
+- Semantic entropy — length-normalized (headline) + discrete (supplementary).
+- SelfCheckGPT — NLI (headline) + BERTScore + n-gram (supplementary).
+**Probe-style baselines from the same sampling pass (SEP, Kossen et al. 2024):**
+- SEP-SE: `sklearn.linear_model.Ridge` on last-token activations at the linear-probe layer, target = length-normalized SE. Trained on 5k stratified train subset per (dataset, model). 5 datasets.
+- SEP-binary: `sklearn.linear_model.LogisticRegression` on the same features, target = binary hallucination label, trained on full train split (free — no new sampling). 6 datasets (MMLU included). Apples-to-apples with the linear probe baseline.
 
 **Reported scorers for the contrastive method:** Cosine, Mahalanobis, KNN — KNN as the headline number based on seed-0 evidence; the other two as ablation rows.
 
@@ -118,12 +129,12 @@ GPU time is the binding constraint, not student time. Order matters.
 | 2 | Llama remaining seeds (×4) × 7 datasets × 3 trained methods | Cheap once activations are cached; CPU-feasible-ish but GPU faster | ~1–2 days |
 | 3 | Qwen seeds × 7 × 3 methods | Starts as soon as job 1 produces each dataset's activations | ~2–3 days |
 | 4 | P(true) inference on both models × 6 datasets — see [#50](https://github.com/hyang0129/HalluLens/issues/50) | Independent of training jobs; can interleave. Output-space only, so it can run on any free GPU regardless of activation-cache state. | ~1 day |
-| 5 | Semantic entropy on {HotpotQA, NQ, PopQA} × both models (or Llama-only if budget tight) — see [#49](https://github.com/hyang0129/HalluLens/issues/49) | 10× inference cost; deliberately the last expensive thing. Output-space only, so it can run on any free GPU regardless of activation-cache state. | ~2–3 days |
+| 5 | Sampling-based baselines bundle (SE + SelfCheckGPT + SEP-SE) on 5 free-form datasets × both models — see [#49](https://github.com/hyang0129/HalluLens/issues/49). SEP-binary then trained for free on 6 datasets from cached activations. | One K=10 sampling pass yields inputs for 4 baselines (SearchQA capped 5k train / 10k test). Output-space only, so it can run on any free GPU regardless of activation-cache state. | ~25–30 GPU-hr full / ~12–15 GPU-hr Llama-only |
 | 6 | Ablations (loss decomposition, layer-pair) | All on cached activations | <1 day |
 
 Use `scripts/gpu_dispatch.py` for batch dispatch, `resume=True` everywhere. **Never submit or kill SLURM jobs without explicit approval** (per CLAUDE.md).
 
-If GPU access slips by >3 days at any stage: cut semantic entropy first, then Qwen ablations, then drop semantic-entropy to Llama-only. Do not cut the Qwen full sweep — losing the second-model story is worse than losing semantic entropy.
+If GPU access slips by >3 days at any stage, cut #49's sampling-pass scope in this order: (1) drop SearchQA from #49 entirely (largest single dataset), (2) drop Qwen3-8B for SE + SelfCheckGPT + SEP-SE (Llama-only), (3) drop SciQ from the sampling-based methods, (4) drop SelfCheckGPT-BERTScore + n-gram (keep SelfCheckGPT-NLI). Then cut Qwen ablations. **Never cut SEP-binary** — it has no sampling cost and runs from cached activations. **Never cut the Qwen full seed sweep** — losing the second-model story is worse than losing sampling-based baselines.
 
 ---
 
@@ -144,7 +155,7 @@ Tables/figures owners (each is a single deliverable):
 - **Transfer matrix:** Heatmap of off-diagonal AUROC.
 - **Ablation table:** Loss decomposition + layer-pair sweep.
 - **Calibration figure:** Reliability diagrams for one dataset per model.
-- **Compute-matched comparison:** Bar of AUROC per forward-pass count (ours @ 1, semantic entropy @ 10) on the 3 covered datasets.
+- **Compute-matched comparison:** AUROC per forward-pass count across covered datasets. K=1 cluster: ours, linear probe, SAPLMA, SEP-binary, SEP-SE, P(true). K=10 cluster: semantic entropy (length-normalized), SelfCheckGPT-NLI. One panel per dataset (5 free-form datasets; MMLU gets the K=1 cluster only).
 
 ---
 
@@ -153,7 +164,8 @@ Tables/figures owners (each is a single deliverable):
 | Risk | Likelihood | Mitigation |
 |---|---|---|
 | Qwen results materially weaker than Llama | medium | Reframe as "model-family-dependent" honestly; Movies-style root-cause; this is a finding, not a failure — but it changes the abstract |
-| Semantic entropy beats us on its 3 datasets at 10× compute | medium | Pivot framing to compute-matched: ours wins per-FLOP. Theory still holds. |
+| SE or SelfCheckGPT-NLI beats us at 10× compute on its 5 datasets | medium | Pivot framing to compute-matched: ours wins per-FLOP. Theory still holds. |
+| **SEP-binary** (genuinely compute-matched linear probe) beats us on some datasets | medium | This would be a real threat, not a per-FLOP escape hatch — SEP-binary uses the same forward-pass count and the same training data as our linear probe baseline. Mitigation depends on outcome: if SEP-binary < contrastive across the board, this is a strong positive. If SEP-binary ≈ contrastive, the contribution must rest on transfer (§4 item 5) + ablations + the SAPLMA gap. Decide on data, not in advance. |
 | GPU node reclamation interrupts long Qwen inference | medium | `resume=True` everywhere; Zarr checkpointing; dispatch with `gpu_dispatch.py` not raw SSH |
 | Movies anomaly is genuine ("contrastive prior hurts on small entity-domain datasets") | medium | Own it in §6 limitations + a one-paragraph diagnosis. This actually strengthens the paper if framed as bounded scope. |
 | Multi-seed CIs reveal that contrastive vs. multi-layer probe gap is not significant on some datasets | medium-high | Headline becomes "consistent improvement at matched parameter count + transfer + Movies-style insight," not "always wins." Pre-commit to AUROC + AUPRC + win-rate-across-seeds reporting. |

--- a/activation_research/llmsknow_probe.py
+++ b/activation_research/llmsknow_probe.py
@@ -1,0 +1,217 @@
+"""LLMsKnow Probe Baseline.
+
+Implements a location-sweep sklearn logistic regression probe that:
+1. Finds the best (layer, token_position) pair on a dev subset.
+2. Trains a final classifier on the full training set at that location.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from loguru import logger
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import StratifiedShuffleSplit
+
+
+def _get_split_cache(
+    ds,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Extract (cache, labels) from a PreloadedActivationDataset.
+
+    Handles both the direct-indexing case (cache is already split-sized) and
+    the memmap-indirection case (cache is full-sized, _row_indices addresses
+    the split rows).
+
+    Returns:
+        cache: float16 numpy array of shape (N_split, L, T, H)
+        labels: int numpy array of shape (N_split,)
+    """
+    full_cache: np.ndarray = ds.cache  # may be (N_total, L, T, H) or (N_split, L, T, H)
+    labels: np.ndarray = np.asarray(ds.labels, dtype=np.int32)
+
+    row_indices = getattr(ds, "_row_indices", None)
+    if row_indices is not None:
+        # Memmap path: cache is full; index down to split rows
+        cache = full_cache[row_indices]  # (N_split, L, T, H)
+    else:
+        cache = full_cache  # already split-sized
+
+    return cache, labels
+
+
+def sweep_locations(
+    train_cache: np.ndarray,
+    train_labels: np.ndarray,
+    relevant_layers: list[int],
+    dev_size: int = 1000,
+    seed: int = 42,
+    C: float = 1.0,
+    max_iter: int = 1000,
+) -> tuple[np.ndarray, int, int]:
+    """Sweep all (layer_idx, token_pos) pairs on a dev subset.
+
+    Args:
+        train_cache: Float16 array of shape (N, L, T, H).
+        train_labels: Int/bool array of shape (N,).
+        relevant_layers: List of model layer indices (length L), e.g. [14, ..., 29].
+        dev_size: Number of samples to use in the dev subset.
+        seed: Random seed for stratified sampling and LogisticRegression.
+        C: Regularisation strength for LogisticRegression.
+        max_iter: Max iterations for LogisticRegression solver.
+
+    Returns:
+        sweep_auroc_matrix: Float array of shape (L, T), AUROC per pair (NaN for
+            skipped/padded positions).
+        best_layer_idx: Index into the L dimension (positional, not model layer id).
+        best_token_pos: Index into the T dimension.
+    """
+    N, L, T, H = train_cache.shape
+    labels = np.asarray(train_labels, dtype=np.int32)
+
+    # Stratified dev subset
+    actual_dev = min(dev_size, N)
+    if actual_dev < N:
+        splitter = StratifiedShuffleSplit(n_splits=1, test_size=actual_dev, random_state=seed)
+        _, dev_idx = next(splitter.split(np.zeros(N), labels))
+    else:
+        dev_idx = np.arange(N)
+
+    dev_cache = train_cache[dev_idx].astype(np.float32)  # (D, L, T, H)
+    dev_labels = labels[dev_idx]
+
+    unique_classes = np.unique(dev_labels)
+    if len(unique_classes) < 2:
+        logger.warning(
+            "sweep_locations: dev subset has only one class — "
+            "AUROC is undefined. Falling back to (0, 0)."
+        )
+        return np.full((L, T), np.nan, dtype=np.float32), 0, 0
+
+    logger.info(
+        f"sweep_locations: sweeping {L} layers × {T} token positions "
+        f"= {L * T} pairs on {len(dev_idx)}-sample dev subset ..."
+    )
+
+    sweep_auroc = np.full((L, T), np.nan, dtype=np.float32)
+
+    for li in range(L):
+        for ti in range(T):
+            # Skip padded noise positions (activations are constant across samples)
+            col = dev_cache[:, li, ti, :]  # (D, H)
+            if np.std(col) < 1e-6:
+                continue  # leave as NaN
+
+            clf = LogisticRegression(C=C, max_iter=max_iter, random_state=seed)
+            clf.fit(col, dev_labels)
+            scores = clf.predict_proba(col)[:, 1]
+
+            if len(np.unique(dev_labels)) < 2:
+                auroc = float("nan")
+            else:
+                auroc = roc_auc_score(dev_labels, scores)
+
+            sweep_auroc[li, ti] = float(auroc)
+
+    # Select best pair
+    if np.all(np.isnan(sweep_auroc)):
+        logger.warning(
+            "sweep_locations: no valid (layer, token) pair found "
+            "(all positions are NaN). Falling back to (layer_idx=0, token_pos=0)."
+        )
+        return sweep_auroc, 0, 0
+
+    best_flat = int(np.nanargmax(sweep_auroc))
+    best_layer_idx = best_flat // T
+    best_token_pos = best_flat % T
+
+    logger.info(
+        f"sweep_locations: selected layer_idx={best_layer_idx} "
+        f"(layer={relevant_layers[best_layer_idx]}), "
+        f"token_pos={best_token_pos}, "
+        f"dev AUROC={sweep_auroc[best_layer_idx, best_token_pos]:.4f}"
+    )
+
+    return sweep_auroc, best_layer_idx, best_token_pos
+
+
+def train_final_probe(
+    train_cache: np.ndarray,
+    train_labels: np.ndarray,
+    layer_idx: int,
+    token_pos: int,
+    seed: int = 42,
+    C: float = 1.0,
+    max_iter: int = 1000,
+) -> LogisticRegression:
+    """Train a LogisticRegression probe on the full training set at one location.
+
+    Args:
+        train_cache: Float16 array of shape (N, L, T, H).
+        train_labels: Int array of shape (N,).
+        layer_idx: Index into the L dimension.
+        token_pos: Index into the T dimension.
+        seed: Random seed for LogisticRegression.
+        C: Regularisation strength.
+        max_iter: Max solver iterations.
+
+    Returns:
+        Fitted sklearn LogisticRegression.
+    """
+    X = train_cache[:, layer_idx, token_pos, :].astype(np.float32)  # (N, H)
+    y = np.asarray(train_labels, dtype=np.int32)
+
+    logger.info(
+        f"train_final_probe: training on {len(y)} samples at "
+        f"layer_idx={layer_idx}, token_pos={token_pos} ..."
+    )
+
+    clf = LogisticRegression(C=C, max_iter=max_iter, random_state=seed)
+    clf.fit(X, y)
+
+    logger.info("train_final_probe: done.")
+    return clf
+
+
+def eval_probe(
+    probe: LogisticRegression,
+    test_cache: np.ndarray,
+    test_labels: np.ndarray,
+    layer_idx: int,
+    token_pos: int,
+    outlier_class: int = 1,
+) -> tuple[float, np.ndarray]:
+    """Evaluate a fitted probe on the test set.
+
+    Args:
+        probe: Fitted sklearn LogisticRegression.
+        test_cache: Float16 array of shape (N_test, L, T, H).
+        test_labels: Int array of shape (N_test,).
+        layer_idx: Index into the L dimension.
+        token_pos: Index into the T dimension.
+        outlier_class: Class index treated as the positive/hallucination class.
+
+    Returns:
+        auroc: AUROC score (float).
+        scores: 1-D float32 array of shape (N_test,), probability of outlier_class.
+    """
+    X = test_cache[:, layer_idx, token_pos, :].astype(np.float32)  # (N_test, H)
+    y = np.asarray(test_labels, dtype=np.int32)
+
+    # Find the column corresponding to outlier_class in probe.classes_
+    classes = list(probe.classes_)
+    if outlier_class in classes:
+        col = classes.index(outlier_class)
+    else:
+        col = 1  # fallback
+
+    proba = probe.predict_proba(X)  # (N_test, n_classes)
+    scores = proba[:, col].astype(np.float32)
+
+    if len(np.unique(y)) < 2:
+        auroc = float("nan")
+    else:
+        auroc = float(roc_auc_score(y, scores))
+
+    logger.info(f"eval_probe: test AUROC = {auroc:.4f}")
+    return auroc, scores

--- a/configs/experiments/baseline_comparison_hotpotqa.json
+++ b/configs/experiments/baseline_comparison_hotpotqa.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_hotpotqa_qwen3.json
+++ b/configs/experiments/baseline_comparison_hotpotqa_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_hotpotqa_smollm3.json
+++ b/configs/experiments/baseline_comparison_hotpotqa_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_mmlu.json
+++ b/configs/experiments/baseline_comparison_mmlu.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_mmlu_qwen3.json
+++ b/configs/experiments/baseline_comparison_mmlu_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_mmlu_smollm3.json
+++ b/configs/experiments/baseline_comparison_mmlu_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_nq.json
+++ b/configs/experiments/baseline_comparison_nq.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_nq_qwen3.json
+++ b/configs/experiments/baseline_comparison_nq_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_nq_smollm3.json
+++ b/configs/experiments/baseline_comparison_nq_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_popqa.json
+++ b/configs/experiments/baseline_comparison_popqa.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_popqa_qwen3.json
+++ b/configs/experiments/baseline_comparison_popqa_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_popqa_smollm3.json
+++ b/configs/experiments/baseline_comparison_popqa_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_sciq.json
+++ b/configs/experiments/baseline_comparison_sciq.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_sciq_qwen3.json
+++ b/configs/experiments/baseline_comparison_sciq_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_sciq_smollm3.json
+++ b/configs/experiments/baseline_comparison_sciq_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_searchqa.json
+++ b/configs/experiments/baseline_comparison_searchqa.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_searchqa_qwen3.json
+++ b/configs/experiments/baseline_comparison_searchqa_qwen3.json
@@ -6,7 +6,8 @@
     "linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_searchqa_smollm3.json
+++ b/configs/experiments/baseline_comparison_searchqa_smollm3.json
@@ -7,7 +7,8 @@
     "multi_layer_linear_probe",
     "token_entropy",
     "logprob_baseline",
-    "saplma"
+    "saplma",
+    "llmsknow_probe"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/methods/llmsknow_probe.json
+++ b/configs/methods/llmsknow_probe.json
@@ -1,0 +1,16 @@
+{
+  "name": "llmsknow_probe",
+  "routine": "llmsknow_probe",
+  "data": {
+    "relevant_layers": "14-29",
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": false,
+    "response_logprobs_top_k": 20
+  },
+  "sweep": {
+    "dev_size": 1000,
+    "C": 1.0,
+    "max_iter": 1000
+  }
+}

--- a/scripts/assemble_baseline_table.py
+++ b/scripts/assemble_baseline_table.py
@@ -1,0 +1,274 @@
+"""Phase 6: Assemble AUROC table and compute-matched figure.
+
+Reads all score files, aligns by row_idx, computes AUROC vs binary hallu label,
+outputs CSV + PDF figure.
+
+Usage:
+    python scripts/assemble_baseline_table.py \\
+        --models meta-llama/Llama-3.1-8B-Instruct Qwen/Qwen3-8B \\
+        --output-dir output/baseline_results
+
+    # Llama only
+    python scripts/assemble_baseline_table.py \\
+        --models meta-llama/Llama-3.1-8B-Instruct
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    DATASETS,
+    MODELS,
+    SAMPLING_DATASETS,
+    eval_results_json,
+    model_name,
+    nli_matrix_path,
+    se_labels_path,
+    selfcheck_samples_path,
+    selfcheck_scores_path,
+    sep_results_path,
+    searchqa_test_cap_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Score loading helpers
+# ---------------------------------------------------------------------------
+
+def load_jsonl_by_row(path: str) -> dict:
+    """Load jsonl into {row_idx: record} dict."""
+    by_row = {}
+    p = Path(path)
+    if not p.exists():
+        return by_row
+    with open(p) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+                by_row[rec["row_idx"]] = rec
+            except Exception:
+                pass
+    return by_row
+
+
+def load_hallu_labels(dataset: str, model_id: str, split: str = "test") -> Optional[np.ndarray]:
+    eval_path = eval_results_json(dataset, model_id, split)
+    if not eval_path.exists():
+        return None
+    with open(eval_path) as f:
+        data = json.load(f)
+    return np.array(data["halu_test_res"], dtype=int)
+
+
+def load_cap_indices(dataset: str, model_id: str) -> Optional[set]:
+    if dataset != "searchqa":
+        return None
+    cap_path = searchqa_test_cap_path(model_id)
+    if not cap_path.exists():
+        return None
+    with open(cap_path) as f:
+        return set(json.load(f)["question_ids"])
+
+
+def safe_auroc(scores: list, labels: list) -> Optional[float]:
+    if len(scores) < 10:
+        return None
+    y = np.array(labels, dtype=int)
+    s = np.array(scores, dtype=float)
+    mask = np.isfinite(s)
+    if mask.sum() < 10 or len(np.unique(y[mask])) < 2:
+        return None
+    try:
+        return float(roc_auc_score(y[mask], s[mask]))
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-dataset scorer
+# ---------------------------------------------------------------------------
+
+def compute_dataset_aurocs(dataset: str, model_id: str) -> dict:
+    """Return dict of {method: auroc} for one (dataset, model) cell."""
+    result = {"dataset": dataset, "model": model_name(model_id)}
+
+    labels_all = load_hallu_labels(dataset, model_id, "test")
+    if labels_all is None:
+        return result
+
+    cap_indices = load_cap_indices(dataset, model_id)
+
+    def get_aligned(by_row: dict, score_key: str):
+        """Extract (scores, labels) aligned by row_idx, respecting cap."""
+        scores, lbls = [], []
+        for row_idx, rec in sorted(by_row.items()):
+            if cap_indices is not None and row_idx not in cap_indices:
+                continue
+            if row_idx >= len(labels_all):
+                continue
+            val = rec.get(score_key)
+            if val is None or (isinstance(val, float) and not np.isfinite(val)):
+                continue
+            scores.append(val)
+            lbls.append(labels_all[row_idx])
+        return scores, lbls
+
+    # SE (length-normalized)
+    if dataset in SAMPLING_DATASETS:
+        se_by_row = load_jsonl_by_row(str(se_labels_path(dataset, model_id, "test")))
+        scores, lbls = get_aligned(se_by_row, "length_normalized_se")
+        result["se_length_normalized"] = safe_auroc(scores, lbls)
+
+        scores, lbls = get_aligned(se_by_row, "discrete_se")
+        result["se_discrete"] = safe_auroc(scores, lbls)
+
+        # SelfCheckGPT
+        sc_by_row = load_jsonl_by_row(str(selfcheck_scores_path(dataset, model_id, "test")))
+        for key in ("nli", "bertscore", "ngram"):
+            scores, lbls = get_aligned(sc_by_row, key)
+            result[f"selfcheck_{key}"] = safe_auroc(scores, lbls)
+
+    # SEP
+    sep_path = sep_results_path(dataset, model_id)
+    if sep_path.exists():
+        with open(sep_path) as f:
+            sep_data = json.load(f)
+        result["sep_binary_auroc"] = sep_data.get("sep_binary_auroc")
+        result["sep_se_auroc"] = sep_data.get("sep_se_auroc")
+        result["sep_layer"] = sep_data.get("layer")
+        result["sep_binary_n_train"] = sep_data.get("train_size_sep_binary")
+        result["sep_se_n_train"] = sep_data.get("train_size_sep_se")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Figure
+# ---------------------------------------------------------------------------
+
+def make_compute_matched_figure(table: pd.DataFrame, output_path: str) -> None:
+    """One panel per dataset; x=forward-pass count, y=AUROC."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not installed — skipping figure.")
+        return
+
+    free_form = [d for d in SAMPLING_DATASETS if d != "mmlu"]
+    all_datasets = free_form + ["mmlu"]
+
+    n_cols = 3
+    n_rows = (len(all_datasets) + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 4 * n_rows), squeeze=False)
+
+    method_style = {
+        "Our contrastive (K=1)": dict(K=1, marker="*", color="tab:red", linestyle="none"),
+        "SEP-binary (K=1)": dict(K=1, marker="D", color="tab:orange", linestyle="none"),
+        "SEP-SE (K=1)": dict(K=1, marker="s", color="tab:purple", linestyle="none"),
+        "SelfCheckGPT-NLI (K=10)": dict(K=10, marker="o", color="tab:blue", linestyle="none"),
+        "SE length-norm (K=10)": dict(K=10, marker="^", color="tab:green", linestyle="none"),
+    }
+
+    col_map = {
+        "SEP-binary (K=1)": "sep_binary_auroc",
+        "SEP-SE (K=1)": "sep_se_auroc",
+        "SelfCheckGPT-NLI (K=10)": "selfcheck_nli",
+        "SE length-norm (K=10)": "se_length_normalized",
+    }
+
+    for ax_idx, ds in enumerate(all_datasets):
+        row, col = divmod(ax_idx, n_cols)
+        ax = axes[row][col]
+        ds_rows = table[table["dataset"] == ds]
+
+        for label, style in method_style.items():
+            if label == "Our contrastive (K=1)":
+                continue  # placeholder — no data yet in this table
+            col_key = col_map.get(label)
+            if col_key is None or col_key not in ds_rows.columns:
+                continue
+            for _, row_data in ds_rows.iterrows():
+                val = row_data.get(col_key)
+                if val is not None and np.isfinite(val):
+                    ax.scatter(
+                        style["K"],
+                        val,
+                        label=f"{label} ({model_name(row_data['model'])})",
+                        marker=style["marker"],
+                        color=style["color"],
+                        s=80,
+                        zorder=3,
+                    )
+
+        ax.set_title(ds, fontsize=11)
+        ax.set_xlabel("Forward passes at test time")
+        ax.set_ylabel("AUROC")
+        ax.set_xlim(0, 12)
+        ax.set_ylim(0.4, 1.0)
+        ax.axhline(0.5, color="gray", linestyle="--", linewidth=0.8)
+        ax.legend(fontsize=7, loc="lower right")
+
+    # Hide unused panels
+    for ax_idx in range(len(all_datasets), n_rows * n_cols):
+        r, c = divmod(ax_idx, n_cols)
+        axes[r][c].set_visible(False)
+
+    fig.suptitle("Compute-matched AUROC comparison", fontsize=13)
+    fig.tight_layout()
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    print(f"Figure saved → {output_path}")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Assemble AUROC table and figure.")
+    parser.add_argument("--models", nargs="+", default=MODELS)
+    parser.add_argument("--datasets", nargs="+", default=DATASETS, choices=DATASETS)
+    parser.add_argument("--output-dir", default="output/baseline_results")
+    parser.add_argument("--no-figure", action="store_true")
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for mid in args.models:
+        for ds in args.datasets:
+            print(f"  {ds} / {model_name(mid)}")
+            r = compute_dataset_aurocs(ds, mid)
+            rows.append(r)
+
+    table = pd.DataFrame(rows)
+
+    csv_path = out_dir / "baseline_auroc_table.csv"
+    table.to_csv(csv_path, index=False)
+    print(f"\nTable saved → {csv_path}")
+
+    # Pretty-print main table columns
+    main_cols = [
+        "dataset", "model",
+        "se_length_normalized", "selfcheck_nli",
+        "sep_se_auroc", "sep_binary_auroc",
+    ]
+    print_cols = [c for c in main_cols if c in table.columns]
+    print(table[print_cols].to_string(index=False))
+
+    if not args.no_figure:
+        make_compute_matched_figure(table, str(out_dir / "compute_matched_auroc.pdf"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_nli_matrix.py
+++ b/scripts/compute_nli_matrix.py
@@ -1,0 +1,63 @@
+"""Phase 2: Compute (K+1)x(K+1) NLI matrices from selfcheck_samples.jsonl.
+
+Outputs nli_matrix.jsonl alongside the samples file.
+GPU-accelerated; uses cross-encoder/nli-deberta-v3-base.
+
+Usage:
+    python scripts/compute_nli_matrix.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+    python scripts/compute_nli_matrix.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --batch-size 512
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.nli_scorer import NLI_MODEL_ID, NLIScorer
+from tasks.sampling_baselines.paths import (
+    SAMPLING_DATASETS,
+    model_name,
+    nli_matrix_path,
+    selfcheck_samples_path,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute NLI matrices from stochastic samples.")
+    parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
+    parser.add_argument("--split", required=True, choices=["train", "test"])
+    parser.add_argument("--model", required=True, help="HuggingFace model ID used for generation")
+    parser.add_argument("--nli-model", default=NLI_MODEL_ID)
+    parser.add_argument("--batch-size", type=int, default=256, help="NLI pairs per forward pass")
+    parser.add_argument("--device", default=None, help="cuda / cpu (auto-detected if not set)")
+    args = parser.parse_args()
+
+    samples_path = selfcheck_samples_path(args.dataset, args.model, args.split)
+    out_path = nli_matrix_path(args.dataset, args.model, args.split)
+
+    if not samples_path.exists():
+        print(f"ERROR: samples file not found: {samples_path}")
+        print("Run scripts/run_sampling_pass.py first.")
+        sys.exit(1)
+
+    print(
+        f"NLI matrix | {args.dataset}/{args.split} | {model_name(args.model)}\n"
+        f"NLI model: {args.nli_model} | batch_size: {args.batch_size}"
+    )
+
+    scorer = NLIScorer(
+        model_id=args.nli_model,
+        batch_size=args.batch_size,
+        device=args.device,
+    )
+    scorer.score_file(str(samples_path), str(out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_se.py
+++ b/scripts/compute_se.py
@@ -1,0 +1,49 @@
+"""Phase 3: Compute Semantic Entropy from NLI matrices.
+
+Outputs se_labels.jsonl with discrete_se and length_normalized_se per question.
+CPU-only; runs after Phase 2.
+
+Usage:
+    python scripts/compute_se.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    SAMPLING_DATASETS,
+    model_name,
+    nli_matrix_path,
+    se_labels_path,
+    selfcheck_samples_path,
+)
+from tasks.sampling_baselines.se import score_files
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute Semantic Entropy labels.")
+    parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
+    parser.add_argument("--split", required=True, choices=["train", "test"])
+    parser.add_argument("--model", required=True, help="HuggingFace model ID used for generation")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Bidirectional NLI threshold")
+    args = parser.parse_args()
+
+    samples = selfcheck_samples_path(args.dataset, args.model, args.split)
+    nli = nli_matrix_path(args.dataset, args.model, args.split)
+    out = se_labels_path(args.dataset, args.model, args.split)
+
+    for p, label in [(samples, "samples"), (nli, "nli_matrix")]:
+        if not p.exists():
+            print(f"ERROR: {label} file not found: {p}")
+            sys.exit(1)
+
+    print(f"SE | {args.dataset}/{args.split} | {model_name(args.model)} | threshold={args.threshold}")
+    score_files(str(samples), str(nli), str(out), threshold=args.threshold)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_selfcheck.py
+++ b/scripts/compute_selfcheck.py
@@ -1,0 +1,71 @@
+"""Phase 4: Compute SelfCheckGPT scores (NLI, BERTScore, n-gram).
+
+NLI score reuses the precomputed Phase 2 matrix — no GPU needed.
+BERTScore and n-gram are CPU-only.
+
+Outputs selfcheck_scores.jsonl with {nli, bertscore, ngram} per question.
+
+Usage:
+    python scripts/compute_selfcheck.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+    # Skip BERTScore (slow) for a quick run:
+    python scripts/compute_selfcheck.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --no-bertscore
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    SAMPLING_DATASETS,
+    model_name,
+    nli_matrix_path,
+    selfcheck_samples_path,
+    selfcheck_scores_path,
+)
+from tasks.sampling_baselines.selfcheck import score_files
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compute SelfCheckGPT scores.")
+    parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
+    parser.add_argument("--split", required=True, choices=["train", "test"])
+    parser.add_argument("--model", required=True, help="HuggingFace model ID used for generation")
+    parser.add_argument("--no-bertscore", action="store_true", help="Skip BERTScore variant")
+    parser.add_argument("--no-ngram", action="store_true", help="Skip n-gram variant")
+    parser.add_argument(
+        "--bertscore-batch-size", type=int, default=64, help="Pairs per BERTScore call"
+    )
+    args = parser.parse_args()
+
+    samples = selfcheck_samples_path(args.dataset, args.model, args.split)
+    nli = nli_matrix_path(args.dataset, args.model, args.split)
+    out = selfcheck_scores_path(args.dataset, args.model, args.split)
+
+    for p, label in [(samples, "samples"), (nli, "nli_matrix")]:
+        if not p.exists():
+            print(f"ERROR: {label} file not found: {p}")
+            sys.exit(1)
+
+    print(
+        f"SelfCheckGPT | {args.dataset}/{args.split} | {model_name(args.model)}\n"
+        f"NLI=True | BERTScore={not args.no_bertscore} | n-gram={not args.no_ngram}"
+    )
+    score_files(
+        str(samples),
+        str(nli),
+        str(out),
+        run_bertscore=not args.no_bertscore,
+        run_ngram=not args.no_ngram,
+        bertscore_batch_size=args.bertscore_batch_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_sep.py
+++ b/scripts/compute_sep.py
@@ -1,0 +1,124 @@
+"""Phase 5: Fit SEP-SE and SEP-binary probes.
+
+SEP-binary works on all 6 datasets including MMLU (no sampling needed).
+SEP-SE requires se_labels.jsonl (train split) and skips MMLU.
+
+Usage:
+    # All datasets, both models (runs after SE labels are available)
+    python scripts/compute_sep.py \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --layer 22
+
+    python scripts/compute_sep.py \\
+        --model Qwen/Qwen3-8B \\
+        --layer 24       # from layer sweep
+
+    # Single dataset
+    python scripts/compute_sep.py \\
+        --dataset hotpotqa \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --layer 22
+
+    # MMLU SEP-binary (no SE, can run any time after main inference)
+    python scripts/compute_sep.py \\
+        --dataset mmlu \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --layer 22 \\
+        --no-sep-se
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    DATASETS,
+    SAMPLING_DATASETS,
+    model_name,
+    se_labels_path,
+    sep_results_path,
+    subset_index_path,
+)
+from tasks.sampling_baselines.sep import run_sep
+
+
+def load_subset_indices(dataset: str, mid: str) -> Optional[list]:
+    idx_path = subset_index_path(dataset, mid)
+    if not idx_path.exists():
+        return None
+    with open(idx_path) as f:
+        return json.load(f)["question_ids"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fit SEP probes.")
+    parser.add_argument(
+        "--dataset",
+        nargs="+",
+        default=DATASETS,
+        choices=DATASETS,
+        help="Datasets to process (default: all)",
+    )
+    parser.add_argument("--model", required=True, help="HuggingFace model ID")
+    parser.add_argument(
+        "--layer", required=True, type=int, help="Layer index for feature extraction"
+    )
+    parser.add_argument(
+        "--no-sep-se",
+        action="store_true",
+        help="Skip SEP-SE (e.g. for MMLU or when SE labels not yet available)",
+    )
+    args = parser.parse_args()
+
+    datasets = args.dataset if isinstance(args.dataset, list) else [args.dataset]
+
+    print(f"SEP probes | {model_name(args.model)} | layer={args.layer}")
+
+    for ds in datasets:
+        print(f"\n--- {ds} ---")
+        out_path = sep_results_path(ds, args.model)
+
+        if out_path.exists():
+            print(f"  Already exists — skipping. Delete to rerun: {out_path}")
+            continue
+
+        # SEP-SE: needs train subset + SE labels; skip MMLU and when --no-sep-se
+        run_se = not args.no_sep_se and ds in SAMPLING_DATASETS
+        train_subset = None
+        se_train_path = None
+
+        if run_se:
+            train_subset = load_subset_indices(ds, args.model)
+            se_train = se_labels_path(ds, args.model, "train")
+            if not se_train.exists():
+                print(
+                    f"  WARNING: SE labels not found ({se_train}) — skipping SEP-SE for {ds}."
+                )
+                run_se = False
+            else:
+                se_train_path = str(se_train)
+
+        if not run_se:
+            train_subset = None
+            se_train_path = None
+
+        try:
+            run_sep(
+                dataset=ds,
+                model_id=args.model,
+                layer_idx=args.layer,
+                train_subset_indices=train_subset,
+                se_labels_train_path=se_train_path,
+                output_path=str(out_path),
+            )
+        except FileNotFoundError as e:
+            print(f"  SKIP: {e}")
+
+    print("\nSEP done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_sep_layer_sweep.py
+++ b/scripts/compute_sep_layer_sweep.py
@@ -1,0 +1,109 @@
+"""Phase 5a: SEP layer sweep for Qwen3-8B.
+
+Fits SEP-binary for each candidate layer on a single dataset's val split.
+Prints an AUROC table; the best layer is used in compute_sep.py.
+Llama uses layer 22 (matching existing linear probe baseline) — no sweep needed.
+
+Usage:
+    python scripts/compute_sep_layer_sweep.py \\
+        --dataset hotpotqa \\
+        --model Qwen/Qwen3-8B \\
+        --layers 16 18 20 22 24 26
+
+Results are printed to stdout and saved to:
+    output/sampling_baselines/sep/{model_name}/layer_sweep_{dataset}.json
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    DATASETS,
+    eval_results_json,
+    generation_jsonl,
+    model_name,
+    zarr_path,
+)
+from tasks.sampling_baselines.sep import layer_sweep_sep_binary
+
+DEFAULT_LAYERS = [16, 18, 20, 22, 24, 26]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SEP layer sweep.")
+    parser.add_argument("--dataset", required=True, choices=DATASETS)
+    parser.add_argument("--model", required=True, help="HuggingFace model ID")
+    parser.add_argument(
+        "--layers",
+        nargs="+",
+        type=int,
+        default=DEFAULT_LAYERS,
+        help="Layer indices to sweep",
+    )
+    parser.add_argument("--val-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    gen = generation_jsonl(args.dataset, args.model, "test")
+    zarr = zarr_path(args.dataset, args.model, "test")
+    eval_j = eval_results_json(args.dataset, args.model, "test")
+
+    for p, label in [(gen, "generation.jsonl"), (zarr, "zarr store"), (eval_j, "eval_results_for_training.json")]:
+        if not Path(p).exists():
+            print(f"ERROR: {label} not found: {p}")
+            sys.exit(1)
+
+    print(
+        f"SEP layer sweep | {args.dataset} | {model_name(args.model)}\n"
+        f"Layers: {args.layers}"
+    )
+
+    results = layer_sweep_sep_binary(
+        generation_jsonl=str(gen),
+        zarr_path=str(zarr),
+        eval_json=str(eval_j),
+        layers=args.layers,
+        val_frac=args.val_frac,
+        seed=args.seed,
+    )
+
+    print("\nLayer sweep results:")
+    print(f"{'Layer':>6}  {'Val AUROC':>10}")
+    print("-" * 20)
+    for layer in sorted(results):
+        marker = " <-- best" if layer == max(results, key=results.get) else ""
+        print(f"{layer:>6}  {results[layer]:>10.4f}{marker}")
+
+    best_layer = max(results, key=results.get)
+    print(f"\nBest layer: {best_layer} (AUROC={results[best_layer]:.4f})")
+    print(f"Pass --layer {best_layer} to compute_sep.py for {model_name(args.model)}")
+
+    out_path = (
+        Path("output")
+        / "sampling_baselines"
+        / "sep"
+        / model_name(args.model)
+        / f"layer_sweep_{args.dataset}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(
+            {
+                "dataset": args.dataset,
+                "model": args.model,
+                "layers_swept": args.layers,
+                "auroc_by_layer": results,
+                "best_layer": best_layer,
+                "seed": args.seed,
+            },
+            f,
+            indent=2,
+        )
+    print(f"Results saved → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_subsets.py
+++ b/scripts/compute_subsets.py
@@ -1,0 +1,149 @@
+"""Phase 0: Generate stratified train subset indices and SearchQA test cap indices.
+
+Outputs:
+  output/sep_subset_{dataset}_{model_name}_seed42.json   for each (dataset, model)
+  output/searchqa_test_cap_{model_name}_seed42.json       for each model
+
+Run before any GPU work. Fast, CPU-only.
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedShuffleSplit
+
+# Ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    DATASETS,
+    MODELS,
+    SAMPLING_DATASETS,
+    eval_results_json,
+    generation_jsonl,
+    model_name,
+    searchqa_test_cap_path,
+    subset_index_path,
+)
+
+SUBSET_SIZE = 5000
+SEARCHQA_TEST_CAP = 10_000
+SEED = 42
+
+
+def compute_train_subset(dataset: str, mid: str) -> dict:
+    eval_path = eval_results_json(dataset, mid, "train")
+    if not eval_path.exists():
+        print(f"  SKIP {dataset}/{model_name(mid)}: eval_results not found at {eval_path}")
+        return None
+
+    with open(eval_path) as f:
+        data = json.load(f)
+    labels = np.array(data["halu_test_res"], dtype=int)
+    n = len(labels)
+    size = min(SUBSET_SIZE, n)
+
+    if size < n:
+        # Stratified subset
+        splitter = StratifiedShuffleSplit(n_splits=1, train_size=size, random_state=SEED)
+        subset_idx, _ = next(splitter.split(np.zeros(n), labels))
+        subset_idx = sorted(subset_idx.tolist())
+    else:
+        subset_idx = list(range(n))
+
+    hallu_count = int(labels[subset_idx].sum())
+    print(
+        f"  {dataset}/{model_name(mid)}: n_total={n}, subset={len(subset_idx)}, "
+        f"hallu={hallu_count}/{len(subset_idx)} "
+        f"({'capped' if size < n else 'full'})"
+    )
+
+    return {
+        "dataset": dataset,
+        "model": mid,
+        "question_ids": subset_idx,
+        "seed": SEED,
+        "n_total": n,
+        "subset_size": len(subset_idx),
+        "hallu_count": hallu_count,
+        "stratified": size < n,
+    }
+
+
+def compute_searchqa_test_cap(mid: str) -> dict:
+    gen_path = generation_jsonl("searchqa", mid, "test")
+    if not gen_path.exists():
+        print(f"  SKIP searchqa test cap for {model_name(mid)}: {gen_path} not found")
+        return None
+
+    df = pd.read_json(gen_path, lines=True)
+    n = len(df)
+    cap = min(SEARCHQA_TEST_CAP, n)
+
+    rng = np.random.default_rng(SEED)
+    cap_idx = sorted(rng.choice(n, size=cap, replace=False).tolist())
+
+    print(f"  searchqa test cap / {model_name(mid)}: n_total={n}, cap={cap}")
+
+    return {
+        "model": mid,
+        "question_ids": cap_idx,
+        "seed": SEED,
+        "n_total": n,
+        "cap_size": cap,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate subset and cap index files.")
+    parser.add_argument(
+        "--model",
+        nargs="+",
+        default=MODELS,
+        help="HuggingFace model IDs to process (default: all)",
+    )
+    parser.add_argument(
+        "--dataset",
+        nargs="+",
+        default=SAMPLING_DATASETS,
+        help="Datasets to compute train subsets for (default: all sampling datasets)",
+    )
+    args = parser.parse_args()
+
+    Path("output").mkdir(exist_ok=True)
+
+    for mid in args.model:
+        print(f"\n=== {model_name(mid)} ===")
+
+        # Train subsets
+        for ds in args.dataset:
+            out_path = subset_index_path(ds, mid)
+            if out_path.exists():
+                print(f"  {ds}: already exists — skipping")
+                continue
+            result = compute_train_subset(ds, mid)
+            if result is not None:
+                with open(out_path, "w") as f:
+                    json.dump(result, f, indent=2)
+                print(f"  -> {out_path}")
+
+        # SearchQA test cap
+        if "searchqa" in args.dataset:
+            cap_path = searchqa_test_cap_path(mid)
+            if cap_path.exists():
+                print(f"  searchqa test cap: already exists — skipping")
+            else:
+                result = compute_searchqa_test_cap(mid)
+                if result is not None:
+                    with open(cap_path, "w") as f:
+                        json.dump(result, f, indent=2)
+                    print(f"  -> {cap_path}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1438,6 +1438,103 @@ def run_logprob_baseline(
     return eval_metrics, []
 
 
+def run_llmsknow_probe(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """LLMsKnow Probe Baseline: sweep (layer, token) on dev subset, train final probe at best location."""
+    import numpy as np
+    from activation_research.llmsknow_probe import (
+        _get_split_cache,
+        eval_probe,
+        sweep_locations,
+        train_final_probe,
+    )
+
+    data_cfg = method_cfg["data"]
+    sweep_cfg = method_cfg.get("sweep", {})
+
+    relevant_layers = parse_layer_range(data_cfg["relevant_layers"])
+    pad_length = data_cfg.get("pad_length", 63)
+
+    ds_kwargs = dict(
+        relevant_layers=relevant_layers,
+        num_views=1,
+        pad_length=pad_length,
+        preload=data_cfg.get("preload", True),
+        include_response_logprobs=False,
+        response_logprobs_top_k=data_cfg.get("response_logprobs_top_k", 20),
+        check_ram=False,
+    )
+
+    train_ds = ap.get_dataset("train", **ds_kwargs)
+    eval_ap = test_ap if test_ap is not None else ap
+    test_ds = eval_ap.get_dataset("test", **ds_kwargs)
+
+    # Access the preloaded cache — handles both direct-index and memmap-indirection paths
+    train_cache, train_labels = _get_split_cache(train_ds)
+    test_cache, test_labels = _get_split_cache(test_ds)
+
+    dev_size = sweep_cfg.get("dev_size", 1000)
+    C = sweep_cfg.get("C", 1.0)
+    max_iter = sweep_cfg.get("max_iter", 1000)
+
+    # Phase 1: sweep (layer, token) on dev subset
+    sweep_matrix, best_layer_idx, best_token_pos = sweep_locations(
+        train_cache, train_labels, relevant_layers,
+        dev_size=dev_size, seed=training_seed, C=C, max_iter=max_iter,
+    )
+
+    # Save sweep results
+    artifacts_dir = os.path.join(output_dir, "artifacts")
+    np.save(os.path.join(artifacts_dir, "sweep_auroc_matrix.npy"), sweep_matrix)
+    sweep_summary = {
+        "relevant_layers": relevant_layers,
+        "best_layer_idx": int(best_layer_idx),
+        "best_layer": int(relevant_layers[best_layer_idx]),
+        "best_token_pos": int(best_token_pos),
+        "best_dev_auroc": float(np.nanmax(sweep_matrix)) if not np.all(np.isnan(sweep_matrix)) else float("nan"),
+    }
+    with open(os.path.join(artifacts_dir, "sweep_summary.json"), "w") as f:
+        json.dump(sweep_summary, f, indent=2)
+
+    # Phase 2: train final probe on full training set
+    probe = train_final_probe(
+        train_cache, train_labels, best_layer_idx, best_token_pos,
+        seed=training_seed, C=C, max_iter=max_iter,
+    )
+
+    # Evaluate on test set
+    outlier_class = dataset_cfg.get("outlier_class", 1)
+    auroc, scores = eval_probe(probe, test_cache, test_labels, best_layer_idx, best_token_pos, outlier_class=outlier_class)
+
+    eval_metrics = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "split_seed": experiment_cfg.get("split_seed", 42),
+        "n_train": len(train_ds),
+        "n_test": len(test_ds),
+        "auroc": float(auroc),
+        "selected_layer": int(relevant_layers[best_layer_idx]),
+        "selected_token_pos": int(best_token_pos),
+        "sweep_best_dev_auroc": float(sweep_summary["best_dev_auroc"]),
+    }
+
+    predictions = [
+        {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
+        for i, (s, l) in enumerate(zip(scores, test_labels))
+    ]
+
+    return eval_metrics, predictions
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -2036,6 +2133,11 @@ def main() -> None:
                         )
                     elif routine == "saplma":
                         eval_metrics, predictions = run_saplma(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "llmsknow_probe":
+                        eval_metrics, predictions = run_llmsknow_probe(
                             ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
                             test_ap=test_ap,
                         )

--- a/scripts/run_sampling_pass.py
+++ b/scripts/run_sampling_pass.py
@@ -1,0 +1,124 @@
+"""Phase 1: K=10 stochastic sampling pass.
+
+Generates K samples per question at T=1.0 for the scoped (dataset, split, model) cells.
+Writes selfcheck_samples.jsonl to output/sampling_baselines/{dataset[_train]}/{model_name}/.
+
+Usage:
+    # Test split (all rows)
+    python scripts/run_sampling_pass.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+    # Train split (auto-loads subset index from compute_subsets.py output)
+    python scripts/run_sampling_pass.py \\
+        --dataset hotpotqa --split train \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+    # Smoke test (50 rows only, validates alignment)
+    python scripts/run_sampling_pass.py \\
+        --dataset hotpotqa --split test \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --smoketest
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    SAMPLING_DATASETS,
+    generation_jsonl,
+    model_name,
+    searchqa_test_cap_path,
+    selfcheck_samples_path,
+    subset_index_path,
+)
+from tasks.sampling_baselines.sampler import SamplingPass
+
+SMOKETEST_ROWS = 50
+
+
+def load_row_indices(dataset: str, mid: str, split: str) -> list | None:
+    """Return row indices to process, or None (= all rows)."""
+    if split == "test":
+        if dataset == "searchqa":
+            cap_path = searchqa_test_cap_path(mid)
+            if not cap_path.exists():
+                raise FileNotFoundError(
+                    f"SearchQA test cap index not found: {cap_path}\n"
+                    "Run scripts/compute_subsets.py first."
+                )
+            with open(cap_path) as f:
+                return json.load(f)["question_ids"]
+        return None  # all test rows for other datasets
+
+    # train split: load stratified subset
+    idx_path = subset_index_path(dataset, mid)
+    if not idx_path.exists():
+        raise FileNotFoundError(
+            f"Subset index not found: {idx_path}\n"
+            "Run scripts/compute_subsets.py first."
+        )
+    with open(idx_path) as f:
+        return json.load(f)["question_ids"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="K-sample stochastic generation pass.")
+    parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
+    parser.add_argument("--split", required=True, choices=["train", "test"])
+    parser.add_argument("--model", required=True, help="HuggingFace model ID")
+    parser.add_argument("--K", type=int, default=10)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument(
+        "--smoketest",
+        action="store_true",
+        help="Process only first 50 rows, then validate alignment.",
+    )
+    args = parser.parse_args()
+
+    gen_path = generation_jsonl(args.dataset, args.model, args.split)
+    if not gen_path.exists():
+        print(f"ERROR: generation.jsonl not found: {gen_path}")
+        sys.exit(1)
+
+    out_path = str(selfcheck_samples_path(args.dataset, args.model, args.split))
+
+    row_indices = load_row_indices(args.dataset, args.model, args.split)
+
+    if args.smoketest:
+        # Override to first 50 rows (or first 50 of the subset)
+        if row_indices is not None:
+            row_indices = row_indices[:SMOKETEST_ROWS]
+        else:
+            row_indices = list(range(SMOKETEST_ROWS))
+        print(f"SMOKETEST: processing {len(row_indices)} rows only.")
+
+    sampler = SamplingPass(
+        model_name=args.model,
+        K=args.K,
+        temperature=args.temperature,
+        max_tokens=args.max_tokens,
+        seed=args.seed,
+        batch_size=args.batch_size,
+    )
+
+    print(
+        f"Dataset: {args.dataset} | Split: {args.split} | Model: {model_name(args.model)}\n"
+        f"K={args.K} | T={args.temperature} | max_tokens={args.max_tokens} | seed={args.seed}"
+    )
+
+    sampler.run(str(gen_path), out_path, row_indices=row_indices)
+
+    if args.smoketest:
+        print("Validating alignment...")
+        sampler.validate_alignment(str(gen_path), out_path, n=min(SMOKETEST_ROWS, 50))
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/sampling_baselines/nli_scorer.py
+++ b/tasks/sampling_baselines/nli_scorer.py
@@ -1,0 +1,197 @@
+"""Batched NLI matrix computation using cross-encoder/nli-deberta-v3-base."""
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+NLI_MODEL_ID = "cross-encoder/nli-deberta-v3-base"
+
+# Strip leading hedges before NLI clustering (SE only; raw text preserved for SelfCheckGPT)
+_STRIP_RE = re.compile(
+    r"^(the answer is[:\s]*|answer[:\s]*|yes[,\.\s]+|no[,\.\s]+|"
+    r"therefore[,\s]+|so[,\s]+|thus[,\s]+|it is[:\s]*|that is[:\s]*)",
+    re.IGNORECASE,
+)
+
+
+def strip_surface_form(text: str) -> str:
+    return _STRIP_RE.sub("", text.strip()).strip()
+
+
+class NLIScorer:
+    """Compute (K+1)x(K+1) directed NLI matrices over {greedy}∪{K samples} per question.
+
+    Label order for cross-encoder/nli-deberta-v3-base:
+        0 = contradiction, 1 = neutral, 2 = entailment
+    Verified dynamically via model.config.id2label at load time.
+    """
+
+    def __init__(
+        self,
+        model_id: str = NLI_MODEL_ID,
+        batch_size: int = 256,
+        device: Optional[str] = None,
+    ):
+        self.model_id = model_id
+        self.batch_size = batch_size
+        self._device = device
+        self._model = None
+        self._tokenizer = None
+        self._label2idx: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compute_matrix(self, texts: List[str]) -> np.ndarray:
+        """Compute (N x N x 3) directed NLI matrix for a list of texts.
+
+        texts[0] = greedy answer, texts[1:] = K stochastic samples.
+        Returns array of shape (N, N, 3) where axis-2 = [p_contradict, p_neutral, p_entail].
+        Diagonal is undefined (set to NaN).
+        """
+        self._ensure_loaded()
+        N = len(texts)
+
+        # Build all (premise, hypothesis) pairs in row-major order, skip diagonal
+        pairs: List[Tuple[str, str]] = []
+        pair_indices: List[Tuple[int, int]] = []
+        for i in range(N):
+            for j in range(N):
+                if i == j:
+                    continue
+                pairs.append((texts[i], texts[j]))
+                pair_indices.append((i, j))
+
+        probs = self._run_nli_batched(pairs)  # (M, 3)
+
+        matrix = np.full((N, N, 3), np.nan, dtype=np.float32)
+        for k, (i, j) in enumerate(pair_indices):
+            matrix[i, j] = probs[k]
+
+        return matrix
+
+    def score_file(
+        self,
+        samples_path: str,
+        output_path: str,
+        done_rows: Optional[set] = None,
+    ) -> None:
+        """Process selfcheck_samples.jsonl → nli_matrix.jsonl."""
+        if done_rows is None:
+            done_rows = _load_done_rows(output_path)
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+        with open(samples_path) as fin, open(output_path, "a", encoding="utf-8") as fout:
+            lines = [l for l in fin if l.strip()]
+
+        pending = []
+        for line in lines:
+            rec = json.loads(line)
+            if rec["row_idx"] in done_rows:
+                continue
+            pending.append(rec)
+
+        if not pending:
+            print(f"NLI: all rows already done — skipping.")
+            return
+
+        print(f"NLI scoring {len(pending)} questions...")
+        with open(output_path, "a", encoding="utf-8") as fout:
+            for rec in tqdm(pending):
+                greedy = rec["greedy_answer"]
+                sample_texts = [s["text"] for s in rec["samples"]]
+                all_texts = [greedy] + sample_texts
+                stripped = [strip_surface_form(t) for t in all_texts]
+
+                matrix = self.compute_matrix(stripped)
+
+                out = {
+                    "row_idx": rec["row_idx"],
+                    "nli_matrix": matrix.tolist(),
+                    "texts_stripped": stripped,
+                }
+                fout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+        print(f"NLI done → {output_path}")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+        device = self._device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_id)
+        self._model = AutoModelForSequenceClassification.from_pretrained(self.model_id).to(device)
+        self._model.eval()
+
+        # Resolve label order dynamically
+        id2label = {int(k): v.lower() for k, v in self._model.config.id2label.items()}
+        for idx, name in id2label.items():
+            if "contradict" in name:
+                self._label2idx["contradiction"] = idx
+            elif "neutral" in name:
+                self._label2idx["neutral"] = idx
+            elif "entail" in name:
+                self._label2idx["entailment"] = idx
+        assert len(self._label2idx) == 3, f"Unexpected NLI labels: {id2label}"
+
+    def _run_nli_batched(self, pairs: List[Tuple[str, str]]) -> np.ndarray:
+        """Run NLI on all (premise, hypothesis) pairs in batches. Returns (M, 3) softmax probs."""
+        self._ensure_loaded()
+        device = next(self._model.parameters()).device
+        all_probs = []
+
+        for b_start in range(0, len(pairs), self.batch_size):
+            batch = pairs[b_start : b_start + self.batch_size]
+            premises = [p for p, _ in batch]
+            hypotheses = [h for _, h in batch]
+
+            enc = self._tokenizer(
+                premises,
+                hypotheses,
+                padding=True,
+                truncation=True,
+                max_length=512,
+                return_tensors="pt",
+            ).to(device)
+
+            with torch.no_grad():
+                logits = self._model(**enc).logits  # (B, 3)
+            probs = torch.softmax(logits, dim=-1).cpu().numpy()  # (B, 3)
+
+            # Reorder to [contradiction, neutral, entailment]
+            ordered = np.stack(
+                [
+                    probs[:, self._label2idx["contradiction"]],
+                    probs[:, self._label2idx["neutral"]],
+                    probs[:, self._label2idx["entailment"]],
+                ],
+                axis=1,
+            )
+            all_probs.append(ordered)
+
+        return np.concatenate(all_probs, axis=0) if all_probs else np.zeros((0, 3), dtype=np.float32)
+
+
+def _load_done_rows(path: str) -> set:
+    done = set()
+    p = Path(path)
+    if not p.exists():
+        return done
+    with open(p) as f:
+        for line in f:
+            try:
+                done.add(json.loads(line)["row_idx"])
+            except Exception:
+                pass
+    return done

--- a/tasks/sampling_baselines/paths.py
+++ b/tasks/sampling_baselines/paths.py
@@ -1,0 +1,75 @@
+"""Path resolution for sampling-baseline artefacts."""
+from pathlib import Path
+
+DATASETS = ["hotpotqa", "nq", "popqa", "sciq", "searchqa", "mmlu"]
+SAMPLING_DATASETS = ["hotpotqa", "nq", "popqa", "sciq", "searchqa"]  # MMLU skips sampling
+MODELS = [
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "Qwen/Qwen3-8B",
+]
+
+
+def model_name(model_id: str) -> str:
+    """Last component of HuggingFace model ID, matching output path convention."""
+    return model_id.split("/")[-1]
+
+
+def model_slug(model_id: str) -> str:
+    """Lowercase underscored slug used in shared/ zarr path names."""
+    return model_name(model_id).lower().replace("-", "_").replace(".", "_")
+
+
+def generation_jsonl(dataset: str, model_id: str, split: str) -> Path:
+    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    return Path("output") / ds_dir / model_name(model_id) / "generation.jsonl"
+
+
+def eval_results_json(dataset: str, model_id: str, split: str) -> Path:
+    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    return Path("output") / ds_dir / model_name(model_id) / "eval_results_for_training.json"
+
+
+def zarr_path(dataset: str, model_id: str, split: str) -> Path:
+    slug = model_slug(model_id)
+    if split == "train":
+        return Path("shared") / f"{dataset}_train_{slug}" / "activations.zarr"
+    return Path("shared") / f"{dataset}_{slug}" / "activations.zarr"
+
+
+def sampling_output_dir(dataset: str, model_id: str, split: str) -> Path:
+    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    return Path("output") / "sampling_baselines" / ds_dir / model_name(model_id)
+
+
+def selfcheck_samples_path(dataset: str, model_id: str, split: str) -> Path:
+    return sampling_output_dir(dataset, model_id, split) / "selfcheck_samples.jsonl"
+
+
+def nli_matrix_path(dataset: str, model_id: str, split: str) -> Path:
+    return sampling_output_dir(dataset, model_id, split) / "nli_matrix.jsonl"
+
+
+def se_labels_path(dataset: str, model_id: str, split: str) -> Path:
+    return sampling_output_dir(dataset, model_id, split) / "se_labels.jsonl"
+
+
+def selfcheck_scores_path(dataset: str, model_id: str, split: str) -> Path:
+    return sampling_output_dir(dataset, model_id, split) / "selfcheck_scores.jsonl"
+
+
+def sep_results_path(dataset: str, model_id: str) -> Path:
+    return (
+        Path("output")
+        / "sampling_baselines"
+        / "sep"
+        / model_name(model_id)
+        / f"{dataset}_sep_results.json"
+    )
+
+
+def subset_index_path(dataset: str, model_id: str) -> Path:
+    return Path("output") / f"sep_subset_{dataset}_{model_name(model_id)}_seed42.json"
+
+
+def searchqa_test_cap_path(model_id: str) -> Path:
+    return Path("output") / f"searchqa_test_cap_{model_name(model_id)}_seed42.json"

--- a/tasks/sampling_baselines/sampler.py
+++ b/tasks/sampling_baselines/sampler.py
@@ -1,0 +1,211 @@
+"""K-sample stochastic generation pass (text + logprobs only, no activation logging)."""
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+import torch
+from tqdm import tqdm
+
+
+class SamplingPass:
+    """Generate K stochastic samples per question at temperature T.
+
+    Writes selfcheck_samples.jsonl incrementally with resume support.
+    Does not capture hidden-state activations — logprobs only.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        K: int = 10,
+        temperature: float = 1.0,
+        max_tokens: int = 64,
+        seed: int = 42,
+        batch_size: int = 16,
+    ):
+        self.model_name = model_name
+        self.K = K
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.seed = seed
+        self.batch_size = batch_size
+        self._model = None
+        self._tokenizer = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        generation_jsonl: str,
+        output_path: str,
+        row_indices: Optional[List[int]] = None,
+    ) -> None:
+        """Generate K stochastic samples for each question.
+
+        Args:
+            generation_jsonl: Path to existing generation.jsonl.
+            output_path: Destination selfcheck_samples.jsonl.
+            row_indices: 0-based row indices to process (None = all rows).
+        """
+        self._ensure_loaded()
+
+        gendf = pd.read_json(generation_jsonl, lines=True)
+        gendf["row_idx"] = gendf.index
+
+        if row_indices is not None:
+            gendf = gendf[gendf["row_idx"].isin(set(row_indices))].reset_index(drop=True)
+
+        done_rows = self._load_done_rows(output_path)
+        remaining = gendf[~gendf["row_idx"].isin(done_rows)].reset_index(drop=True)
+
+        if len(remaining) == 0:
+            print(f"All {len(gendf)} rows already done — skipping.")
+            return
+
+        print(
+            f"Sampling {len(remaining)} questions "
+            f"({len(done_rows)} already done) | K={self.K} | T={self.temperature}"
+        )
+
+        prompts = remaining["prompt"].tolist()
+        row_idxs = remaining["row_idx"].tolist()
+        greedy_answers = (
+            remaining["generation"].tolist()
+            if "generation" in remaining.columns
+            else [""] * len(remaining)
+        )
+        question_ids = (
+            remaining["id"].tolist()
+            if "id" in remaining.columns
+            else [str(r) for r in row_idxs]
+        )
+
+        n = len(prompts)
+        all_samples: List[List[dict]] = [[] for _ in range(n)]
+
+        for k in range(self.K):
+            print(f"  Sample slot {k + 1}/{self.K}")
+            for b_start in tqdm(range(0, n, self.batch_size), desc=f"k={k}", leave=False):
+                b_end = min(b_start + self.batch_size, n)
+                batch_results = self._infer_batch(prompts[b_start:b_end], sample_idx=k)
+                for i, res in enumerate(batch_results):
+                    all_samples[b_start + i].append(res)
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "a", encoding="utf-8") as f:
+            for i in range(n):
+                record = {
+                    "row_idx": row_idxs[i],
+                    "question_id": question_ids[i],
+                    "prompt": prompts[i],
+                    "greedy_answer": greedy_answers[i],
+                    "samples": all_samples[i],
+                    "K": self.K,
+                    "temperature": self.temperature,
+                    "sampling_seed": self.seed,
+                }
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        print(f"Written {n} records → {output_path}")
+
+    # ------------------------------------------------------------------
+    # Smoke test
+    # ------------------------------------------------------------------
+
+    def validate_alignment(self, generation_jsonl: str, output_path: str, n: int = 50) -> None:
+        """Assert greedy_answer in samples matches generation.jsonl. Raises on mismatch."""
+        gendf = pd.read_json(generation_jsonl, lines=True)
+        gendf["row_idx"] = gendf.index
+
+        samples_df = pd.read_json(output_path, lines=True).head(n)
+        mismatches = 0
+        for _, row in samples_df.iterrows():
+            idx = row["row_idx"]
+            expected = gendf.iloc[idx]["generation"]
+            if row["greedy_answer"] != expected:
+                mismatches += 1
+                print(f"  MISMATCH at row_idx={idx}")
+        if mismatches:
+            raise ValueError(f"Alignment check failed: {mismatches}/{n} rows mismatched.")
+        print(f"Alignment check passed ({n} rows).")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        from activation_logging.server import get_model_and_tokenizer
+        self._model, self._tokenizer = get_model_and_tokenizer(self.model_name, None)
+
+    def _infer_batch(self, prompts: List[str], sample_idx: int) -> List[dict]:
+        """One stochastic sample for a batch of prompts."""
+        model, tokenizer = self._model, self._tokenizer
+        device = next(model.parameters()).device
+
+        tokenizer.padding_side = "left"
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        inputs = tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        ).to(device)
+
+        torch.manual_seed(self.seed + sample_idx)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=self.max_tokens,
+                temperature=self.temperature,
+                do_sample=True,
+                output_hidden_states=False,
+                output_scores=True,
+                return_dict_in_generate=True,
+                pad_token_id=tokenizer.pad_token_id,
+            )
+
+        gen_start = inputs.input_ids.shape[1]
+        results = []
+        for i in range(len(prompts)):
+            gen_ids = outputs.sequences[i, gen_start:]
+            text = tokenizer.decode(gen_ids, skip_special_tokens=True)
+
+            token_logprobs = []
+            for t, score in enumerate(outputs.scores):
+                if t >= len(gen_ids):
+                    break
+                lp = torch.log_softmax(score[i], dim=-1)
+                token_logprobs.append(lp[gen_ids[t]].item())
+
+            seq_lp = sum(token_logprobs) if token_logprobs else 0.0
+            len_norm_lp = seq_lp / max(len(token_logprobs), 1)
+
+            results.append({
+                "text": text,
+                "sequence_logprob": seq_lp,
+                "length_normalized_logprob": len_norm_lp,
+            })
+
+        del outputs
+        return results
+
+    @staticmethod
+    def _load_done_rows(output_path: str) -> set:
+        done = set()
+        p = Path(output_path)
+        if not p.exists():
+            return done
+        with open(p) as f:
+            for line in f:
+                try:
+                    done.add(json.loads(line)["row_idx"])
+                except Exception:
+                    pass
+        return done

--- a/tasks/sampling_baselines/se.py
+++ b/tasks/sampling_baselines/se.py
@@ -1,0 +1,162 @@
+"""Semantic Entropy computation from precomputed NLI matrices."""
+import json
+import math
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+
+def cluster_answers(
+    nli_matrix: np.ndarray,
+    start_idx: int = 1,
+    end_idx: Optional[int] = None,
+    threshold: float = 0.5,
+) -> List[List[int]]:
+    """Greedy bidirectional entailment clustering.
+
+    Operates on matrix indices [start_idx, end_idx).
+    Index 0 = greedy answer (excluded from clustering by default).
+    nli_matrix[i, j] = [p_contradict, p_neutral, p_entail] (i=premise, j=hypothesis).
+    Two texts cluster together iff both directions have p_entail > threshold.
+    """
+    if end_idx is None:
+        end_idx = nli_matrix.shape[0]
+
+    clusters: List[List[int]] = []
+    for i in range(start_idx, end_idx):
+        placed = False
+        for cluster in clusters:
+            rep = cluster[0]
+            p_entail_ri = nli_matrix[rep, i, 2]
+            p_entail_ir = nli_matrix[i, rep, 2]
+            if p_entail_ri > threshold and p_entail_ir > threshold:
+                cluster.append(i)
+                placed = True
+                break
+        if not placed:
+            clusters.append([i])
+
+    return clusters
+
+
+def discrete_se(clusters: List[List[int]], K: int) -> float:
+    """Discrete semantic entropy: -sum(|c|/K * log(|c|/K)) over clusters."""
+    if K == 0:
+        return 0.0
+    entropy = 0.0
+    for cluster in clusters:
+        p = len(cluster) / K
+        if p > 0:
+            entropy -= p * math.log(p)
+    return entropy
+
+
+def length_normalized_se(
+    clusters: List[List[int]],
+    samples: List[dict],
+    start_idx: int = 1,
+) -> float:
+    """Length-normalized semantic entropy (Farquhar et al. headline variant).
+
+    Uses length_normalized_logprob from the generating model.
+    Log-sum-exp within each cluster, normalize, then entropy.
+    samples is 0-indexed relative to the sample list (not matrix index).
+    """
+    if not clusters:
+        return 0.0
+
+    cluster_lp = []
+    for cluster in clusters:
+        # cluster contains matrix indices; samples are at matrix_idx - start_idx
+        sample_lps = [samples[idx - start_idx]["length_normalized_logprob"] for idx in cluster]
+        cluster_lp.append(_logsumexp(sample_lps))
+
+    total = _logsumexp(cluster_lp)
+    probs = [math.exp(lp - total) for lp in cluster_lp]
+
+    entropy = 0.0
+    for p in probs:
+        if p > 0:
+            entropy -= p * math.log(p)
+    return entropy
+
+
+def compute_se_for_record(record: dict, nli_matrix: np.ndarray, threshold: float = 0.5) -> dict:
+    """Compute both SE variants for one question.
+
+    Args:
+        record: one row from selfcheck_samples.jsonl
+        nli_matrix: (K+1, K+1, 3) array from nli_matrix.jsonl
+        threshold: bidirectional entailment threshold
+
+    Returns dict with discrete_se, length_normalized_se, n_clusters, cluster_assignments.
+    """
+    K = record["K"]
+    samples = record["samples"]
+
+    clusters = cluster_answers(nli_matrix, start_idx=1, end_idx=K + 1, threshold=threshold)
+    d_se = discrete_se(clusters, K)
+    ln_se = length_normalized_se(clusters, samples, start_idx=1)
+
+    return {
+        "row_idx": record["row_idx"],
+        "discrete_se": d_se,
+        "length_normalized_se": ln_se,
+        "n_clusters": len(clusters),
+        "cluster_assignments": clusters,
+    }
+
+
+def score_files(
+    samples_path: str,
+    nli_matrix_path: str,
+    output_path: str,
+    threshold: float = 0.5,
+) -> None:
+    """Process selfcheck_samples.jsonl + nli_matrix.jsonl → se_labels.jsonl."""
+    done_rows = _load_done_rows(output_path)
+
+    # Load NLI matrices indexed by row_idx
+    nli_by_row = {}
+    with open(nli_matrix_path) as f:
+        for line in f:
+            rec = json.loads(line)
+            nli_by_row[rec["row_idx"]] = np.array(rec["nli_matrix"], dtype=np.float32)
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with open(samples_path) as fin, open(output_path, "a", encoding="utf-8") as fout:
+        for line in fin:
+            rec = json.loads(line)
+            row_idx = rec["row_idx"]
+            if row_idx in done_rows:
+                continue
+            if row_idx not in nli_by_row:
+                continue
+            result = compute_se_for_record(rec, nli_by_row[row_idx], threshold)
+            fout.write(json.dumps(result, ensure_ascii=False) + "\n")
+            written += 1
+
+    print(f"SE done: {written} rows written → {output_path}")
+
+
+def _logsumexp(values: List[float]) -> float:
+    if not values:
+        return float("-inf")
+    m = max(values)
+    return m + math.log(sum(math.exp(v - m) for v in values))
+
+
+def _load_done_rows(path: str) -> set:
+    done = set()
+    p = Path(path)
+    if not p.exists():
+        return done
+    with open(p) as f:
+        for line in f:
+            try:
+                done.add(json.loads(line)["row_idx"])
+            except Exception:
+                pass
+    return done

--- a/tasks/sampling_baselines/selfcheck.py
+++ b/tasks/sampling_baselines/selfcheck.py
@@ -1,0 +1,210 @@
+"""SelfCheckGPT variants: NLI, BERTScore, n-gram."""
+import json
+import math
+from collections import Counter
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# NLI variant (uses precomputed matrix — no GPU)
+# ---------------------------------------------------------------------------
+
+def selfcheck_nli_score(nli_matrix: np.ndarray, K: int) -> float:
+    """Mean P(contradict) with sample_i as premise, greedy as hypothesis.
+
+    nli_matrix[i, j, 0] = P(contradict) for premise=texts[i], hypothesis=texts[j].
+    Greedy is at index 0. Samples are at indices 1..K.
+    High score = predicted hallucination.
+    """
+    scores = [nli_matrix[i, 0, 0] for i in range(1, K + 1) if not np.isnan(nli_matrix[i, 0, 0])]
+    return float(np.mean(scores)) if scores else float("nan")
+
+
+# ---------------------------------------------------------------------------
+# BERTScore variant (CPU, uses bert-score library)
+# ---------------------------------------------------------------------------
+
+def selfcheck_bertscore(greedy: str, sample_texts: List[str]) -> float:
+    """1 - mean BERTScore F1(greedy, sample_i) over K samples.
+
+    Requires: pip install bert-score==0.3.13
+    High score = predicted hallucination.
+    """
+    try:
+        from bert_score import score as bert_score_fn
+    except ImportError:
+        raise ImportError("Install bert-score==0.3.13 for BERTScore SelfCheckGPT.")
+
+    K = len(sample_texts)
+    if K == 0:
+        return float("nan")
+
+    _, _, F1 = bert_score_fn(
+        cands=[greedy] * K,
+        refs=sample_texts,
+        lang="en",
+        model_type="roberta-large",
+        verbose=False,
+    )
+    return float(1.0 - F1.mean().item())
+
+
+# ---------------------------------------------------------------------------
+# n-gram variant (unigram LM, CPU)
+# ---------------------------------------------------------------------------
+
+def selfcheck_ngram(greedy: str, sample_texts: List[str]) -> float:
+    """Unigram LM trained on K samples; score = -log P_unigram(greedy) (length-normalized).
+
+    Laplace smoothing. High score = predicted hallucination.
+    """
+    if not sample_texts:
+        return float("nan")
+
+    # Build unigram LM from all sample tokens
+    tokens = [t for s in sample_texts for t in s.lower().split()]
+    counter = Counter(tokens)
+    vocab_size = len(counter)
+    total = sum(counter.values())
+
+    greedy_tokens = greedy.lower().split()
+    if not greedy_tokens:
+        return float("nan")
+
+    log_prob = sum(
+        math.log((counter.get(t, 0) + 1) / (total + vocab_size))
+        for t in greedy_tokens
+    ) / len(greedy_tokens)
+
+    return -log_prob
+
+
+# ---------------------------------------------------------------------------
+# File-level scorer
+# ---------------------------------------------------------------------------
+
+def score_files(
+    samples_path: str,
+    nli_matrix_path: str,
+    output_path: str,
+    run_bertscore: bool = True,
+    run_ngram: bool = True,
+    bertscore_batch_size: int = 64,
+) -> None:
+    """Process selfcheck_samples.jsonl + nli_matrix.jsonl → selfcheck_scores.jsonl.
+
+    Args:
+        run_bertscore: Compute BERTScore variant (slow, CPU).
+        run_ngram: Compute n-gram variant (fast, CPU).
+    """
+    done_rows = _load_done_rows(output_path)
+
+    # Index NLI matrices
+    nli_by_row = {}
+    with open(nli_matrix_path) as f:
+        for line in f:
+            rec = json.loads(line)
+            nli_by_row[rec["row_idx"]] = np.array(rec["nli_matrix"], dtype=np.float32)
+
+    # Collect pending records
+    pending = []
+    with open(samples_path) as f:
+        for line in f:
+            rec = json.loads(line)
+            if rec["row_idx"] not in done_rows and rec["row_idx"] in nli_by_row:
+                pending.append(rec)
+
+    if not pending:
+        print("SelfCheck: all rows already done — skipping.")
+        return
+
+    print(f"SelfCheck scoring {len(pending)} questions...")
+
+    # BERTScore: batch all greedy+sample pairs at once for efficiency
+    bertscore_results: Optional[dict] = None
+    if run_bertscore:
+        bertscore_results = _compute_bertscore_batched(pending, bertscore_batch_size)
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "a", encoding="utf-8") as fout:
+        for rec in pending:
+            row_idx = rec["row_idx"]
+            K = rec["K"]
+            greedy = rec["greedy_answer"]
+            sample_texts = [s["text"] for s in rec["samples"]]
+            matrix = nli_by_row[row_idx]
+
+            result = {
+                "row_idx": row_idx,
+                "nli": selfcheck_nli_score(matrix, K),
+            }
+
+            if run_bertscore and bertscore_results is not None:
+                result["bertscore"] = bertscore_results.get(row_idx, float("nan"))
+
+            if run_ngram:
+                result["ngram"] = selfcheck_ngram(greedy, sample_texts)
+
+            fout.write(json.dumps(result, ensure_ascii=False) + "\n")
+
+    print(f"SelfCheck done → {output_path}")
+
+
+def _compute_bertscore_batched(records: list, batch_size: int) -> dict:
+    """BERTScore all (greedy, sample_i) pairs at once. Returns {row_idx: score}."""
+    try:
+        from bert_score import score as bert_score_fn
+    except ImportError:
+        raise ImportError("Install bert-score==0.3.13 for BERTScore SelfCheckGPT.")
+
+    all_cands = []
+    all_refs = []
+    row_idx_per_pair = []
+
+    for rec in records:
+        greedy = rec["greedy_answer"]
+        for s in rec["samples"]:
+            all_cands.append(greedy)
+            all_refs.append(s["text"])
+            row_idx_per_pair.append(rec["row_idx"])
+
+    if not all_cands:
+        return {}
+
+    print(f"  BERTScore: {len(all_cands)} pairs...")
+    _, _, F1 = bert_score_fn(
+        cands=all_cands,
+        refs=all_refs,
+        lang="en",
+        model_type="roberta-large",
+        batch_size=batch_size,
+        verbose=False,
+    )
+    f1_list = F1.tolist()
+
+    # Average F1 per row_idx
+    from collections import defaultdict
+    sums: dict = defaultdict(float)
+    counts: dict = defaultdict(int)
+    for row_idx, f1 in zip(row_idx_per_pair, f1_list):
+        sums[row_idx] += f1
+        counts[row_idx] += 1
+
+    return {r: 1.0 - sums[r] / counts[r] for r in sums}
+
+
+def _load_done_rows(path: str) -> set:
+    done = set()
+    p = Path(path)
+    if not p.exists():
+        return done
+    with open(p) as f:
+        for line in f:
+            try:
+                done.add(json.loads(line)["row_idx"])
+            except Exception:
+                pass
+    return done

--- a/tasks/sampling_baselines/sep.py
+++ b/tasks/sampling_baselines/sep.py
@@ -1,0 +1,262 @@
+"""Semantic Entropy Probes (SEP): linear probes on cached greedy activations."""
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+# ---------------------------------------------------------------------------
+
+def extract_last_token_features(
+    generation_jsonl: str,
+    zarr_path: str,
+    layer_idx: int,
+    row_indices: Optional[List[int]] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract last-response-token hidden state at layer_idx from greedy zarr store.
+
+    Args:
+        generation_jsonl: Path to generation.jsonl for prompt→hash mapping.
+        zarr_path: Path to zarr activation store.
+        layer_idx: Layer to read.
+        row_indices: Subset of row indices to extract (None = all).
+
+    Returns:
+        (X, valid_row_indices) where X has shape (n_valid, hidden_dim).
+        Rows with missing activations are silently dropped.
+    """
+    from activation_logging.zarr_activations_logger import ZarrActivationsLogger
+
+    gendf = pd.read_json(generation_jsonl, lines=True)
+    gendf["row_idx"] = gendf.index
+    gendf["prompt_hash"] = gendf["prompt"].apply(
+        lambda x: hashlib.sha256(x.encode("utf-8")).hexdigest()
+    )
+
+    if row_indices is not None:
+        gendf = gendf[gendf["row_idx"].isin(set(row_indices))].reset_index(drop=True)
+
+    zarr_logger = ZarrActivationsLogger(zarr_path=str(zarr_path), read_only=True, verbose=False)
+
+    features = []
+    valid_indices = []
+
+    for _, row in gendf.iterrows():
+        key = row["prompt_hash"]
+        act = zarr_logger.get_layer_activation(key, layer_idx, sequence_mode="response")
+        if act is None:
+            continue
+        # act: (1, seq_len, hidden) — take last token
+        last_tok = act[0, -1, :].numpy().astype(np.float32)
+        features.append(last_tok)
+        valid_indices.append(int(row["row_idx"]))
+
+    zarr_logger.close() if hasattr(zarr_logger, "close") else None
+
+    if not features:
+        return np.zeros((0, 0), dtype=np.float32), np.array([], dtype=np.int64)
+
+    return np.array(features, dtype=np.float32), np.array(valid_indices, dtype=np.int64)
+
+
+# ---------------------------------------------------------------------------
+# Probe fitting
+# ---------------------------------------------------------------------------
+
+def fit_sep_se(X_train: np.ndarray, y_se: np.ndarray, alpha: float = 1.0) -> Pipeline:
+    """Ridge regression probe predicting length-normalized SE."""
+    pipe = Pipeline([("scaler", StandardScaler()), ("ridge", Ridge(alpha=alpha))])
+    pipe.fit(X_train, y_se)
+    return pipe
+
+
+def fit_sep_binary(X_train: np.ndarray, y_binary: np.ndarray) -> Pipeline:
+    """Logistic regression probe predicting binary hallucination label."""
+    pipe = Pipeline(
+        [
+            ("scaler", StandardScaler()),
+            ("logreg", LogisticRegression(max_iter=1000, C=1.0)),
+        ]
+    )
+    pipe.fit(X_train, y_binary.astype(int))
+    return pipe
+
+
+def eval_auroc(pipe: Pipeline, X_test: np.ndarray, y_binary: np.ndarray, is_regression: bool) -> float:
+    """AUROC of a fitted probe against binary hallucination labels."""
+    if is_regression:
+        scores = pipe.predict(X_test)
+    else:
+        scores = pipe.predict_proba(X_test)[:, 1]
+    return float(roc_auc_score(y_binary.astype(int), scores))
+
+
+# ---------------------------------------------------------------------------
+# Layer sweep (for Qwen3-8B)
+# ---------------------------------------------------------------------------
+
+def layer_sweep_sep_binary(
+    generation_jsonl: str,
+    zarr_path: str,
+    eval_json: str,
+    layers: List[int],
+    val_frac: float = 0.2,
+    seed: int = 42,
+) -> Dict[int, float]:
+    """Fit SEP-binary for each layer; return {layer: val_auroc}."""
+    from sklearn.model_selection import train_test_split
+
+    with open(eval_json) as f:
+        eval_data = json.load(f)
+    all_labels = np.array(eval_data["halu_test_res"], dtype=bool)
+
+    results: Dict[int, float] = {}
+    for layer in layers:
+        print(f"  Layer {layer}...", end=" ")
+        X, valid_idx = extract_last_token_features(generation_jsonl, zarr_path, layer)
+        if len(X) == 0:
+            print("no activations — skipped")
+            continue
+
+        y = all_labels[valid_idx]
+
+        try:
+            X_train, X_val, y_train, y_val = train_test_split(
+                X, y, test_size=val_frac, stratify=y, random_state=seed
+            )
+        except ValueError:
+            X_train, X_val, y_train, y_val = train_test_split(
+                X, y, test_size=val_frac, random_state=seed
+            )
+
+        pipe = fit_sep_binary(X_train, y_train)
+        auroc = eval_auroc(pipe, X_val, y_val, is_regression=False)
+        results[layer] = auroc
+        print(f"AUROC={auroc:.4f}")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Full SEP run
+# ---------------------------------------------------------------------------
+
+def run_sep(
+    dataset: str,
+    model_id: str,
+    layer_idx: int,
+    train_subset_indices: Optional[List[int]],
+    se_labels_train_path: Optional[str],
+    output_path: str,
+) -> dict:
+    """Fit SEP-SE and SEP-binary probes; return result dict.
+
+    Args:
+        train_subset_indices: Row indices for SEP-SE training (5k stratified subset).
+            If None, SEP-SE is skipped (e.g. MMLU).
+        se_labels_train_path: Path to se_labels.jsonl for train split.
+            Required when train_subset_indices is not None.
+    """
+    from tasks.sampling_baselines.paths import (
+        generation_jsonl,
+        eval_results_json,
+        zarr_path as get_zarr_path,
+    )
+
+    gen_train = str(generation_jsonl(dataset, model_id, "train"))
+    gen_test = str(generation_jsonl(dataset, model_id, "test"))
+    eval_train = str(eval_results_json(dataset, model_id, "train"))
+    eval_test = str(eval_results_json(dataset, model_id, "test"))
+    zarr_train = str(get_zarr_path(dataset, model_id, "train"))
+    zarr_test = str(get_zarr_path(dataset, model_id, "test"))
+
+    # Load binary labels
+    with open(eval_train) as f:
+        train_eval = json.load(f)
+    with open(eval_test) as f:
+        test_eval = json.load(f)
+
+    train_labels_full = np.array(train_eval["halu_test_res"], dtype=bool)
+    test_labels = np.array(test_eval["halu_test_res"], dtype=bool)
+
+    result = {
+        "dataset": dataset,
+        "model": model_id,
+        "layer": layer_idx,
+    }
+
+    # --- SEP-binary (full train split) ---
+    print(f"Extracting test features (layer {layer_idx})...")
+    X_test, test_valid_idx = extract_last_token_features(gen_test, zarr_test, layer_idx)
+    y_test = test_labels[test_valid_idx]
+
+    print(f"Extracting train features for SEP-binary (layer {layer_idx})...")
+    X_train_full, train_valid_idx_full = extract_last_token_features(gen_train, zarr_train, layer_idx)
+    y_train_full = train_labels_full[train_valid_idx_full]
+
+    pipe_binary = fit_sep_binary(X_train_full, y_train_full)
+    auroc_binary = eval_auroc(pipe_binary, X_test, y_test, is_regression=False)
+
+    result["sep_binary_auroc"] = auroc_binary
+    result["train_size_sep_binary"] = len(X_train_full)
+    print(f"SEP-binary AUROC: {auroc_binary:.4f} (n_train={len(X_train_full)})")
+
+    # --- SEP-SE (5k stratified subset) ---
+    if train_subset_indices is not None and se_labels_train_path is not None:
+        se_by_row = _load_se_labels(se_labels_train_path)
+        # Only keep rows present in both SE labels and valid activations
+        subset_set = set(train_subset_indices)
+
+        print(f"Extracting subset features for SEP-SE ({len(subset_set)} rows)...")
+        X_subset, subset_valid_idx = extract_last_token_features(
+            gen_train, zarr_train, layer_idx, row_indices=train_subset_indices
+        )
+
+        # Align SE labels with extracted features
+        y_se = np.array(
+            [se_by_row[r]["length_normalized_se"] for r in subset_valid_idx if r in se_by_row],
+            dtype=np.float32,
+        )
+        X_se = X_subset[[i for i, r in enumerate(subset_valid_idx) if r in se_by_row]]
+        se_test_valid = np.array(
+            [r in se_by_row for r in subset_valid_idx], dtype=bool
+        )
+        kept = se_test_valid.sum()
+
+        if kept > 0:
+            pipe_se = fit_sep_se(X_se, y_se)
+            auroc_se = eval_auroc(pipe_se, X_test, y_test, is_regression=True)
+            result["sep_se_auroc"] = auroc_se
+            result["train_size_sep_se"] = int(kept)
+            print(f"SEP-SE AUROC: {auroc_se:.4f} (n_train={kept})")
+        else:
+            result["sep_se_auroc"] = None
+            result["train_size_sep_se"] = 0
+    else:
+        result["sep_se_auroc"] = None
+        result["train_size_sep_se"] = 0
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"SEP results → {output_path}")
+
+    return result
+
+
+def _load_se_labels(se_labels_path: str) -> dict:
+    by_row = {}
+    with open(se_labels_path) as f:
+        for line in f:
+            rec = json.loads(line)
+            by_row[rec["row_idx"]] = rec
+    return by_row


### PR DESCRIPTION
## Summary

- Implements the LLMsKnow Probe Baseline from Orgad et al. 2024 (#52)
- Sweeps all 1,008 `(layer, token_pos)` combinations (16 layers × 63 positions) on a stratified 1,000-sample dev subset using sklearn `LogisticRegression`, recording AUROC for each pair
- Selects the best pair by dev AUROC, then trains a final probe on the full training set at that location
- Adds `selected_layer`, `selected_token_pos`, and `sweep_best_dev_auroc` to `eval_metrics.json` for interpretability
- Saves `sweep_auroc_matrix.npy` and `sweep_summary.json` to the run's `artifacts/` directory

## Files changed

- **`activation_research/llmsknow_probe.py`** (new): `sweep_locations()`, `train_final_probe()`, `eval_probe()`, `_get_split_cache()` helper
- **`configs/methods/llmsknow_probe.json`** (new): method config (layers 14-29, pad_length 63, dev_size 1000)
- **`scripts/run_experiment.py`**: `run_llmsknow_probe()` runner + `elif routine == "llmsknow_probe"` dispatch
- **All 18 `configs/experiments/baseline_comparison_*.json`**: added `"llmsknow_probe"` to methods list

## Test plan

- [ ] `python -c "import ast; ast.parse(open('activation_research/llmsknow_probe.py').read())"` — passes (verified)
- [ ] `python -c "import ast; ast.parse(open('scripts/run_experiment.py').read())"` — passes (verified)
- [ ] All 18 experiment configs contain `"llmsknow_probe"` in their methods array
- [ ] Run `python scripts/run_experiment.py --experiment configs/experiments/baseline_comparison_mmlu.json --methods llmsknow_probe --seeds 0 --max-epochs 1` on GPU to confirm end-to-end execution
- [ ] Verify `eval_metrics.json` includes `auroc`, `selected_layer`, `selected_token_pos`, `sweep_best_dev_auroc`
- [ ] Verify sweep AUROC ≥ 0.55 on at least one dataset (acceptance criterion from issue)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)