### PR TITLE
feat(#49): align Semantic Entropy with jlko/semantic_uncertainty reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ exploratory_work/
 
 # Ephemeral smoketest outputs (logs, GPU samples, time -v dumps)
 reports/smoketest_*/
+
+# Ephemeral sampling-baseline run outputs (cell/shard logs, fanout TSVs)
+reports/sampling_baselines_runs/

--- a/configs/nodes.json
+++ b/configs/nodes.json
@@ -5,105 +5,170 @@
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu04",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu08",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu23",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu13",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu19",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu12",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu05",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu22",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"]
+      "tags": [
+        "training",
+        "inference"
+      ]
     },
     {
       "hostname": "alphagpu16",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference"],
+      "tags": [
+        "training",
+        "inference"
+      ],
       "jupyter_url": "http://alphagpu16:8889",
       "jupyter_password": "123"
     },
     {
-      "name": "alphagpu01-8887",
-      "hostname": "alphagpu01",
+      "name": "alphagpu04-8884",
+      "hostname": "alphagpu04",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference", "jupyter-only"],
-      "jupyter_url": "http://alphagpu01:8887",
+      "tags": [
+        "training",
+        "inference",
+        "jupyter-only"
+      ],
+      "jupyter_url": "http://alphagpu04:8884",
       "jupyter_password": "123",
-      "source": "squeue"
+      "source": "squeue",
+      "slurm_job_id": "945791",
+      "slurm_time_left": "2-23:17:18"
     },
     {
-      "name": "alphagpu01-8888",
-      "hostname": "alphagpu01",
+      "name": "alphagpu03-8887",
+      "hostname": "alphagpu03",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference", "jupyter-only"],
-      "jupyter_url": "http://alphagpu01:8888",
+      "tags": [
+        "training",
+        "inference",
+        "jupyter-only"
+      ],
+      "jupyter_url": "http://alphagpu03:8887",
       "jupyter_password": "123",
-      "source": "squeue"
+      "source": "squeue",
+      "slurm_job_id": "945457",
+      "slurm_time_left": "2-23:17:24"
     },
     {
-      "name": "alphagpu01-8889",
-      "hostname": "alphagpu01",
+      "name": "alphagpu03-8888",
+      "hostname": "alphagpu03",
       "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
       "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
       "max_concurrent_jobs": 1,
-      "tags": ["training", "inference", "jupyter-only"],
-      "jupyter_url": "http://alphagpu01:8889",
+      "tags": [
+        "training",
+        "inference",
+        "jupyter-only"
+      ],
+      "jupyter_url": "http://alphagpu03:8888",
       "jupyter_password": "123",
-      "source": "squeue"
+      "source": "squeue",
+      "slurm_job_id": "945136",
+      "slurm_time_left": "2-23:17:18"
+    },
+    {
+      "name": "alphagpu03-8889",
+      "hostname": "alphagpu03",
+      "python": "/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python",
+      "project_root": "/mnt/home/hyang1/LLM_research/HalluLens",
+      "max_concurrent_jobs": 1,
+      "tags": [
+        "training",
+        "inference",
+        "jupyter-only"
+      ],
+      "jupyter_url": "http://alphagpu03:8889",
+      "jupyter_password": "123",
+      "source": "squeue",
+      "slurm_job_id": "945140",
+      "slurm_time_left": "2-23:17:18"
     }
   ],
   "defaults": {

--- a/reports/benchmark_nli_throughput/bench_20260513_190219.json
+++ b/reports/benchmark_nli_throughput/bench_20260513_190219.json
@@ -1,0 +1,39 @@
+{
+  "model": "microsoft/deberta-v2-xlarge-mnli",
+  "dtype": "fp32",
+  "max_length": 512,
+  "device": "NVIDIA H100 80GB HBM3",
+  "warmup_batches": 2,
+  "measured_batches": 5,
+  "results": [
+    {
+      "batch_size": 256,
+      "max_length": 512,
+      "mean_wall_sec": 1.3261,
+      "pairs_per_sec": 193.1,
+      "sec_per_row": 0.5698,
+      "peak_alloc_gb": 13.24
+    },
+    {
+      "batch_size": 512,
+      "max_length": 512,
+      "mean_wall_sec": 2.4493,
+      "pairs_per_sec": 209.0,
+      "sec_per_row": 0.5262,
+      "peak_alloc_gb": 23.13
+    },
+    {
+      "batch_size": 1024,
+      "max_length": 512,
+      "mean_wall_sec": 4.9745,
+      "pairs_per_sec": 205.8,
+      "sec_per_row": 0.5344,
+      "peak_alloc_gb": 44.15
+    },
+    {
+      "batch_size": 2048,
+      "max_length": 512,
+      "oom": true
+    }
+  ]
+}

--- a/reports/benchmark_sampling_batch/bench_Llama-3.1-8B-Instruct_20260513_174436.json
+++ b/reports/benchmark_sampling_batch/bench_Llama-3.1-8B-Instruct_20260513_174436.json
@@ -1,0 +1,93 @@
+{
+  "model": "meta-llama/Llama-3.1-8B-Instruct",
+  "dataset": "hotpotqa",
+  "split": "test",
+  "max_tokens": 64,
+  "temperature": 1.0,
+  "warmup_batches": 2,
+  "measured_batches": 5,
+  "device": "NVIDIA H100 80GB HBM3",
+  "vram_total_gb": 79.2,
+  "rows": [
+    {
+      "batch_size": 16,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        1.873,
+        1.885,
+        2.004,
+        2.022,
+        1.878
+      ],
+      "mean_wall_sec": 1.932,
+      "rows_per_sec": 8.28,
+      "peak_alloc_gb": 15.84,
+      "peak_reserved_gb": 15.88
+    },
+    {
+      "batch_size": 32,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        1.923,
+        1.974,
+        1.949,
+        1.927,
+        1.884
+      ],
+      "mean_wall_sec": 1.931,
+      "rows_per_sec": 16.57,
+      "peak_alloc_gb": 16.68,
+      "peak_reserved_gb": 17.12
+    },
+    {
+      "batch_size": 64,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        1.938,
+        2.028,
+        2.043,
+        1.884,
+        2.067
+      ],
+      "mean_wall_sec": 1.992,
+      "rows_per_sec": 32.13,
+      "peak_alloc_gb": 18.37,
+      "peak_reserved_gb": 19.04
+    },
+    {
+      "batch_size": 128,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        2.355,
+        2.315,
+        2.326,
+        2.374,
+        2.35
+      ],
+      "mean_wall_sec": 2.344,
+      "rows_per_sec": 54.61,
+      "peak_alloc_gb": 21.5,
+      "peak_reserved_gb": 23.12
+    },
+    {
+      "batch_size": 256,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        3.526,
+        3.508,
+        3.516,
+        3.51,
+        3.702
+      ],
+      "mean_wall_sec": 3.552,
+      "rows_per_sec": 72.06,
+      "peak_alloc_gb": 28.27,
+      "peak_reserved_gb": 32.4
+    }
+  ]
+}

--- a/reports/benchmark_sampling_batch/bench_Llama-3.1-8B-Instruct_20260513_175753.json
+++ b/reports/benchmark_sampling_batch/bench_Llama-3.1-8B-Instruct_20260513_175753.json
@@ -1,0 +1,45 @@
+{
+  "model": "meta-llama/Llama-3.1-8B-Instruct",
+  "dataset": "hotpotqa",
+  "split": "test",
+  "max_tokens": 64,
+  "temperature": 1.0,
+  "warmup_batches": 2,
+  "measured_batches": 5,
+  "device": "NVIDIA H100 80GB HBM3",
+  "vram_total_gb": 79.2,
+  "rows": [
+    {
+      "batch_size": 384,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        4.866,
+        4.861,
+        5.187,
+        5.462,
+        4.92
+      ],
+      "mean_wall_sec": 5.059,
+      "rows_per_sec": 75.9,
+      "peak_alloc_gb": 35.33,
+      "peak_reserved_gb": 43.46
+    },
+    {
+      "batch_size": 512,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        6.151,
+        6.526,
+        6.968,
+        6.146,
+        6.577
+      ],
+      "mean_wall_sec": 6.474,
+      "rows_per_sec": 79.09,
+      "peak_alloc_gb": 42.11,
+      "peak_reserved_gb": 52.71
+    }
+  ]
+}

--- a/reports/benchmark_sampling_batch/bench_Qwen3-8B_20260513_174436.json
+++ b/reports/benchmark_sampling_batch/bench_Qwen3-8B_20260513_174436.json
@@ -1,0 +1,93 @@
+{
+  "model": "Qwen/Qwen3-8B",
+  "dataset": "hotpotqa",
+  "split": "test",
+  "max_tokens": 64,
+  "temperature": 1.0,
+  "warmup_batches": 2,
+  "measured_batches": 5,
+  "device": "NVIDIA H100 80GB HBM3",
+  "vram_total_gb": 79.2,
+  "rows": [
+    {
+      "batch_size": 16,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        2.59,
+        2.464,
+        2.568,
+        2.631,
+        2.477
+      ],
+      "mean_wall_sec": 2.546,
+      "rows_per_sec": 6.28,
+      "peak_alloc_gb": 16.25,
+      "peak_reserved_gb": 16.45
+    },
+    {
+      "batch_size": 32,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        2.474,
+        2.575,
+        2.503,
+        2.578,
+        2.604
+      ],
+      "mean_wall_sec": 2.547,
+      "rows_per_sec": 12.56,
+      "peak_alloc_gb": 17.29,
+      "peak_reserved_gb": 17.5
+    },
+    {
+      "batch_size": 64,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        2.54,
+        2.648,
+        2.641,
+        2.586,
+        2.654
+      ],
+      "mean_wall_sec": 2.614,
+      "rows_per_sec": 24.48,
+      "peak_alloc_gb": 19.26,
+      "peak_reserved_gb": 19.67
+    },
+    {
+      "batch_size": 128,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        2.958,
+        2.928,
+        2.986,
+        2.79,
+        2.957
+      ],
+      "mean_wall_sec": 2.924,
+      "rows_per_sec": 43.78,
+      "peak_alloc_gb": 22.94,
+      "peak_reserved_gb": 23.98
+    },
+    {
+      "batch_size": 256,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        4.104,
+        4.024,
+        4.063,
+        4.058,
+        4.243
+      ],
+      "mean_wall_sec": 4.098,
+      "rows_per_sec": 62.46,
+      "peak_alloc_gb": 30.74,
+      "peak_reserved_gb": 32.95
+    }
+  ]
+}

--- a/reports/benchmark_sampling_batch/bench_Qwen3-8B_20260513_175753.json
+++ b/reports/benchmark_sampling_batch/bench_Qwen3-8B_20260513_175753.json
@@ -1,0 +1,45 @@
+{
+  "model": "Qwen/Qwen3-8B",
+  "dataset": "hotpotqa",
+  "split": "test",
+  "max_tokens": 64,
+  "temperature": 1.0,
+  "warmup_batches": 2,
+  "measured_batches": 5,
+  "device": "NVIDIA H100 80GB HBM3",
+  "vram_total_gb": 79.2,
+  "rows": [
+    {
+      "batch_size": 384,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        5.564,
+        5.57,
+        5.843,
+        6.233,
+        5.681
+      ],
+      "mean_wall_sec": 5.778,
+      "rows_per_sec": 66.46,
+      "peak_alloc_gb": 38.93,
+      "peak_reserved_gb": 43.34
+    },
+    {
+      "batch_size": 512,
+      "n_warmup": 2,
+      "n_measured": 5,
+      "batch_walls_sec": [
+        7.025,
+        7.38,
+        7.824,
+        7.139,
+        7.555
+      ],
+      "mean_wall_sec": 7.385,
+      "rows_per_sec": 69.33,
+      "peak_alloc_gb": 46.8,
+      "peak_reserved_gb": 52.67
+    }
+  ]
+}

--- a/reports/profile_nli_lengths/profile_20260513_190503.json
+++ b/reports/profile_nli_lengths/profile_20260513_190503.json
@@ -1,0 +1,193 @@
+{
+  "tokenizer": "microsoft/deberta-v2-xlarge-mnli",
+  "max_rows_per_cell": 5000,
+  "per_cell": [
+    {
+      "split": "test",
+      "dataset": "hotpotqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 57,
+      "p90": 62,
+      "p95": 64,
+      "p99": 66,
+      "max": 88
+    },
+    {
+      "split": "test",
+      "dataset": "hotpotqa",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 58,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 76
+    },
+    {
+      "split": "test",
+      "dataset": "popqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 2854,
+      "p50": 115,
+      "p90": 124,
+      "p95": 126,
+      "p99": 130,
+      "max": 154
+    },
+    {
+      "split": "test",
+      "dataset": "popqa",
+      "model": "Qwen3-8B",
+      "n": 2854,
+      "p50": 59,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 73
+    },
+    {
+      "split": "test",
+      "dataset": "sciq",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 1000,
+      "p50": 116,
+      "p90": 125,
+      "p95": 127,
+      "p99": 132,
+      "max": 156
+    },
+    {
+      "split": "test",
+      "dataset": "sciq",
+      "model": "Qwen3-8B",
+      "n": 1000,
+      "p50": 61,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 73
+    },
+    {
+      "split": "test",
+      "dataset": "searchqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 116,
+      "p90": 127,
+      "p95": 130,
+      "p99": 141,
+      "max": 171
+    },
+    {
+      "split": "test",
+      "dataset": "searchqa",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 59,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 74
+    },
+    {
+      "split": "train",
+      "dataset": "hotpotqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 57,
+      "p90": 62,
+      "p95": 64,
+      "p99": 66,
+      "max": 87
+    },
+    {
+      "split": "train",
+      "dataset": "hotpotqa",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 58,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 77
+    },
+    {
+      "split": "train",
+      "dataset": "popqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 116,
+      "p90": 125,
+      "p95": 127,
+      "p99": 131,
+      "max": 181
+    },
+    {
+      "split": "train",
+      "dataset": "popqa",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 60,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 78
+    },
+    {
+      "split": "train",
+      "dataset": "sciq",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 116,
+      "p90": 125,
+      "p95": 127,
+      "p99": 131,
+      "max": 205
+    },
+    {
+      "split": "train",
+      "dataset": "sciq",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 61,
+      "p90": 64,
+      "p95": 65,
+      "p99": 67,
+      "max": 74
+    },
+    {
+      "split": "train",
+      "dataset": "searchqa",
+      "model": "Llama-3.1-8B-Instruct",
+      "n": 5000,
+      "p50": 116,
+      "p90": 127,
+      "p95": 130,
+      "p99": 142,
+      "max": 191
+    },
+    {
+      "split": "train",
+      "dataset": "searchqa",
+      "model": "Qwen3-8B",
+      "n": 5000,
+      "p50": 60,
+      "p90": 64,
+      "p95": 65,
+      "p99": 68,
+      "max": 76
+    }
+  ],
+  "pooled": {
+    "n": 67708,
+    "p50": 62,
+    "p90": 120,
+    "p95": 124,
+    "p99": 130,
+    "max": 205
+  },
+  "pair_max_tokens": 413,
+  "margin": 1.5,
+  "suggested_max_length": 640
+}

--- a/scripts/assemble_baseline_table.py
+++ b/scripts/assemble_baseline_table.py
@@ -121,9 +121,13 @@ def compute_dataset_aurocs(dataset: str, model_id: str) -> dict:
             lbls.append(labels_all[row_idx])
         return scores, lbls
 
-    # SE (length-normalized)
+    # SE — headline is `semantic_entropy` (rao over logsumexp_by_id, raw sequence_logprob).
+    # length-normalized and discrete kept as auxiliary metrics.
     if dataset in SAMPLING_DATASETS:
         se_by_row = load_jsonl_by_row(str(se_labels_path(dataset, model_id, "test")))
+        scores, lbls = get_aligned(se_by_row, "semantic_entropy")
+        result["semantic_entropy"] = safe_auroc(scores, lbls)
+
         scores, lbls = get_aligned(se_by_row, "length_normalized_se")
         result["se_length_normalized"] = safe_auroc(scores, lbls)
 

--- a/scripts/backfill_qwen3_eval_for_training.sh
+++ b/scripts/backfill_qwen3_eval_for_training.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Backfill missing eval_results_for_training.json for Qwen3 train splits, then
+# re-run compute_subsets.py to generate the 3 missing subset index files.
+#
+# Safe to --force-concurrent alongside a running GPU job — this is pure CPU.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+LOG_DIR=reports/sampling_baselines_runs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$LOG_DIR/backfill_qwen3_${STAMP}.log"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "Backfill Qwen3 eval_results_for_training.json" | tee -a "$LOG_FILE"
+echo "Started: $(date) | Host: $(hostname)"         | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+$PYTHON - 2>&1 <<'PY' | tee -a "$LOG_FILE"
+import json
+from pathlib import Path
+
+# Slim schema (matches Llama eval_results_for_training.json shape).
+KEEP_KEYS = [
+    "evaluator_abstantion", "evaluator_hallucination",
+    "abstantion", "halu_test_res",
+    "total_count", "accurate_count", "hallu_count", "refusal_count",
+    "correct_rate", "halu_Rate", "refusal_Rate",
+]
+
+for ds in ("popqa", "sciq", "searchqa"):
+    src = Path(f"output/{ds}_train/Qwen3-8B/eval_results.json")
+    dst = Path(f"output/{ds}_train/Qwen3-8B/eval_results_for_training.json")
+    if dst.exists():
+        print(f"  {dst}: already exists, skipping.")
+        continue
+    if not src.exists():
+        print(f"  WARN {src}: missing — cannot backfill {dst}")
+        continue
+    d = json.load(open(src))
+    out = {k: d[k] for k in KEEP_KEYS if k in d}
+    # Sanity: halu_test_res is what compute_subsets reads.
+    n = len(out.get("halu_test_res", []))
+    print(f"  {dst}: writing slim schema ({len(out)} keys, {n} rows)")
+    with open(dst, "w") as f:
+        json.dump(out, f)
+PY
+
+echo                                                 | tee -a "$LOG_FILE"
+echo "--- Re-running Phase 0 (compute_subsets.py) ---" | tee -a "$LOG_FILE"
+$PYTHON scripts/compute_subsets.py 2>&1 | tee -a "$LOG_FILE"
+
+echo                                                 | tee -a "$LOG_FILE"
+echo "--- Verifying subset files exist ---"          | tee -a "$LOG_FILE"
+MISSING=0
+for ds in popqa sciq searchqa; do
+    f="output/sep_subset_${ds}_Qwen3-8B_seed42.json"
+    if [[ -f "$f" ]]; then
+        echo "  OK: $f"                              | tee -a "$LOG_FILE"
+    else
+        echo "  MISSING: $f"                         | tee -a "$LOG_FILE"
+        MISSING=$((MISSING+1))
+    fi
+done
+
+echo                                                 | tee -a "$LOG_FILE"
+echo "DONE: $(date) missing=$MISSING"                | tee -a "$LOG_FILE"
+exit $MISSING

--- a/scripts/benchmark_nli_throughput.py
+++ b/scripts/benchmark_nli_throughput.py
@@ -1,0 +1,163 @@
+"""NLI throughput batch-size sweep (fp32, paper-faithful).
+
+Measures rows/sec + peak VRAM at increasing batch sizes for the production
+NLI scorer config. Per size: 2 warmup + 5 measured batches. Stops on OOM.
+
+dtype stays fp32 to match the jlko/semantic_uncertainty reference (which loads
+via from_pretrained without dtype kwarg).
+
+Usage:
+    python scripts/benchmark_nli_throughput.py \
+        --batch-sizes 256,512,1024,2048
+"""
+import argparse
+import gc
+import json
+import sys
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import generation_jsonl
+
+K = 10
+PAIRS_PER_ROW = (K + 1) * (K + 1) - (K + 1)  # 110
+WARMUP_BATCHES = 2
+MEASURED_BATCHES = 5
+
+
+def load_texts(dataset: str, model_id: str, split: str, n: int) -> list:
+    path = generation_jsonl(dataset, model_id, split)
+    if not path.exists():
+        raise FileNotFoundError(f"No generation.jsonl at {path}")
+    texts = []
+    with open(path) as f:
+        for line in f:
+            t = (json.loads(line).get("generation") or "").strip()
+            if t:
+                texts.append(t)
+            if len(texts) >= n:
+                break
+    while len(texts) < n:
+        texts.extend(texts)
+    return texts[:n]
+
+
+def build_pairs(texts: list, n_rows: int) -> List[Tuple[str, str]]:
+    pairs = []
+    pool = len(texts)
+    for r in range(n_rows):
+        row_texts = [texts[(r * (K + 1) + j) % pool] for j in range(K + 1)]
+        for i in range(K + 1):
+            for j in range(K + 1):
+                if i != j:
+                    pairs.append((row_texts[i], row_texts[j]))
+    return pairs
+
+
+def run_batch(tok, model, batch: list, max_length: int):
+    premises = [p for p, _ in batch]
+    hypotheses = [h for _, h in batch]
+    enc = tok(premises, hypotheses, padding=True, truncation=True,
+              max_length=max_length, return_tensors="pt").to("cuda")
+    with torch.no_grad():
+        _ = model(**enc).logits
+
+
+def benchmark_size(tok, model, pairs, batch_size: int, max_length: int) -> dict:
+    needed = (WARMUP_BATCHES + MEASURED_BATCHES) * batch_size
+    pool = (pairs * ((needed // len(pairs)) + 1))[:needed]
+    for w in range(WARMUP_BATCHES):
+        run_batch(tok, model, pool[w * batch_size : (w + 1) * batch_size], max_length)
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    times = []
+    for i in range(MEASURED_BATCHES):
+        s = WARMUP_BATCHES + i
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        run_batch(tok, model, pool[s * batch_size : (s + 1) * batch_size], max_length)
+        torch.cuda.synchronize()
+        times.append(time.perf_counter() - t0)
+
+    peak = torch.cuda.max_memory_allocated() / (1024 ** 3)
+    mean_wall = sum(times) / len(times)
+    pairs_per_sec = batch_size / mean_wall
+    return {
+        "batch_size": batch_size,
+        "max_length": max_length,
+        "mean_wall_sec": round(mean_wall, 4),
+        "pairs_per_sec": round(pairs_per_sec, 1),
+        "sec_per_row": round(PAIRS_PER_ROW / pairs_per_sec, 4),
+        "peak_alloc_gb": round(peak, 2),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="microsoft/deberta-v2-xlarge-mnli")
+    parser.add_argument("--gen-model", default="meta-llama/Llama-3.1-8B-Instruct")
+    parser.add_argument("--dataset", default="hotpotqa")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--batch-sizes", default="256,512,1024,2048")
+    parser.add_argument("--max-length", type=int, default=512,
+                        help="NLI tokenizer max_length (paper default 512).")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    batch_sizes = sorted(int(b) for b in args.batch_sizes.split(",") if b.strip())
+
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    print(f"Loading NLI model: {args.model} (fp32)")
+    tok = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForSequenceClassification.from_pretrained(args.model).to("cuda").eval()
+
+    biggest = max(batch_sizes)
+    n_rows = (WARMUP_BATCHES + MEASURED_BATCHES) * biggest // PAIRS_PER_ROW + 2
+    n_texts = n_rows * (K + 1)
+    print(f"Loading {n_texts} answer strings from {args.dataset}/{args.split}...")
+    texts = load_texts(args.dataset, args.gen_model, args.split, n_texts)
+    pairs = build_pairs(texts, n_rows)
+    print(f"  Built {len(pairs)} pairs across {n_rows} synthetic rows.")
+
+    results = []
+    print()
+    print(f"{'batch':>6} {'maxL':>5} {'mean wall':>10} {'pairs/s':>10} "
+          f"{'sec/row':>10} {'peak GB':>10}")
+    print("-" * 60)
+    for bs in batch_sizes:
+        gc.collect(); torch.cuda.empty_cache()
+        try:
+            r = benchmark_size(tok, model, pairs, bs, args.max_length)
+            results.append(r)
+            print(f"{r['batch_size']:>6} {r['max_length']:>5} "
+                  f"{r['mean_wall_sec']:>10.4f} {r['pairs_per_sec']:>10.1f} "
+                  f"{r['sec_per_row']:>10.4f} {r['peak_alloc_gb']:>10.2f}")
+        except torch.cuda.OutOfMemoryError:
+            print(f"{bs:>6} {args.max_length:>5} OOM — stopping")
+            results.append({"batch_size": bs, "max_length": args.max_length, "oom": True})
+            break
+
+    out = {
+        "model": args.model,
+        "dtype": "fp32",
+        "max_length": args.max_length,
+        "device": str(torch.cuda.get_device_name(0)) if torch.cuda.is_available() else "cpu",
+        "warmup_batches": WARMUP_BATCHES,
+        "measured_batches": MEASURED_BATCHES,
+        "results": results,
+    }
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w") as f:
+            json.dump(out, f, indent=2)
+        print(f"\nWrote: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_nli_throughput.sh
+++ b/scripts/benchmark_nli_throughput.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# NLI throughput batch-size sweep (fp32, paper-faithful).
+#
+# Dispatch:
+#   python scripts/gpu_dispatch.py run --jupyter --node alphagpu04-8884 -- \
+#       bash scripts/benchmark_nli_throughput.sh
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+BATCH_SIZES="${BATCH_SIZES:-256,512,1024,2048}"
+MAX_LENGTH="${MAX_LENGTH:-512}"
+DATASET=hotpotqa
+SPLIT=test
+GEN_MODEL=meta-llama/Llama-3.1-8B-Instruct
+
+OUT_DIR=reports/benchmark_nli_throughput
+mkdir -p "$OUT_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$OUT_DIR/bench_${STAMP}.log"
+JSON_OUT="$OUT_DIR/bench_${STAMP}.json"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "NLI batch-size throughput sweep"              | tee -a "$LOG_FILE"
+echo "Started:    $(date)"                           | tee -a "$LOG_FILE"
+echo "Host:       $(hostname)"                       | tee -a "$LOG_FILE"
+echo "GPU:        $(nvidia-smi --query-gpu=name,memory.free --format=csv,noheader 2>/dev/null | head -1)" | tee -a "$LOG_FILE"
+echo "Batches:    $BATCH_SIZES"                      | tee -a "$LOG_FILE"
+echo "max_length: $MAX_LENGTH"                       | tee -a "$LOG_FILE"
+echo "Log:        $LOG_FILE"                         | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+export PYTHONUNBUFFERED=1
+$PYTHON scripts/benchmark_nli_throughput.py \
+    --batch-sizes "$BATCH_SIZES" \
+    --max-length "$MAX_LENGTH" \
+    --gen-model "$GEN_MODEL" \
+    --dataset "$DATASET" \
+    --split "$SPLIT" \
+    --out "$JSON_OUT" 2>&1 | tee -a "$LOG_FILE"
+
+echo                                                | tee -a "$LOG_FILE"
+echo "DONE: $(date)"                                | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"

--- a/scripts/benchmark_sampling_batch.py
+++ b/scripts/benchmark_sampling_batch.py
@@ -1,0 +1,194 @@
+"""Benchmark Phase 1 sampling throughput vs. batch size.
+
+For each batch size: 2 warmup batches + 5 measured batches. Reports mean
+rows/sec, mean wall per batch, and peak VRAM across the measured batches.
+Stops on CUDA OOM. Uses real hotpotqa prompts from generation.jsonl to keep
+prompt-length distribution realistic.
+
+Usage:
+    python scripts/benchmark_sampling_batch.py \
+        --model meta-llama/Llama-3.1-8B-Instruct \
+        --batch-sizes 16,32,64,128,256
+"""
+import argparse
+import gc
+import json
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import generation_jsonl, model_name
+
+WARMUP_BATCHES = 2
+MEASURED_BATCHES = 5
+MAX_TOKENS = 64
+TEMPERATURE = 1.0
+SEED = 42
+
+
+def load_prompts(dataset: str, model_id: str, split: str, n: int) -> list:
+    path = generation_jsonl(dataset, model_id, split)
+    if not path.exists():
+        raise FileNotFoundError(f"No generation.jsonl at {path}")
+    prompts = []
+    with open(path) as f:
+        for line in f:
+            prompts.append(json.loads(line)["prompt"])
+            if len(prompts) >= n:
+                break
+    # Cycle if we still need more (smoke fixtures rarely smaller than 100, but be safe)
+    while len(prompts) < n:
+        prompts.extend(prompts)
+    return prompts[:n]
+
+
+def run_one_batch(model, tokenizer, prompts: list) -> None:
+    """Match SamplingPass._infer_batch generation kwargs exactly."""
+    tokenizer.padding_side = "left"
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    device = next(model.parameters()).device
+    inputs = tokenizer(prompts, return_tensors="pt", padding=True, truncation=True).to(device)
+
+    torch.manual_seed(SEED)
+    with torch.no_grad():
+        _ = model.generate(
+            **inputs,
+            max_new_tokens=MAX_TOKENS,
+            temperature=TEMPERATURE,
+            do_sample=True,
+            output_hidden_states=False,
+            output_scores=True,
+            return_dict_in_generate=True,
+            pad_token_id=tokenizer.pad_token_id,
+        )
+
+
+def benchmark_batch_size(model, tokenizer, prompts: list, batch_size: int) -> dict:
+    """Run warmup + measured batches at one batch_size. Returns metrics dict.
+
+    Raises torch.cuda.OutOfMemoryError on OOM.
+    """
+    needed = (WARMUP_BATCHES + MEASURED_BATCHES) * batch_size
+    pool = (prompts * ((needed // len(prompts)) + 1))[:needed]
+
+    # Warmup
+    for w in range(WARMUP_BATCHES):
+        batch = pool[w * batch_size : (w + 1) * batch_size]
+        run_one_batch(model, tokenizer, batch)
+
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+
+    times = []
+    for i in range(MEASURED_BATCHES):
+        start = WARMUP_BATCHES + i
+        batch = pool[start * batch_size : (start + 1) * batch_size]
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        run_one_batch(model, tokenizer, batch)
+        torch.cuda.synchronize()
+        times.append(time.perf_counter() - t0)
+
+    peak_alloc_gb = torch.cuda.max_memory_allocated() / (1024 ** 3)
+    peak_reserved_gb = torch.cuda.max_memory_reserved() / (1024 ** 3)
+    mean_wall = sum(times) / len(times)
+    rows_per_sec = batch_size / mean_wall
+
+    return {
+        "batch_size": batch_size,
+        "n_warmup": WARMUP_BATCHES,
+        "n_measured": MEASURED_BATCHES,
+        "batch_walls_sec": [round(t, 3) for t in times],
+        "mean_wall_sec": round(mean_wall, 3),
+        "rows_per_sec": round(rows_per_sec, 2),
+        "peak_alloc_gb": round(peak_alloc_gb, 2),
+        "peak_reserved_gb": round(peak_reserved_gb, 2),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark sampling batch size vs throughput.")
+    parser.add_argument("--model", default="meta-llama/Llama-3.1-8B-Instruct")
+    parser.add_argument("--dataset", default="hotpotqa")
+    parser.add_argument("--split", default="test")
+    parser.add_argument(
+        "--batch-sizes",
+        default="16,32,64,128,256",
+        help="Comma-separated batch sizes to try (ascending).",
+    )
+    parser.add_argument("--out", default=None, help="Optional path to write JSON results")
+    args = parser.parse_args()
+
+    batch_sizes = [int(b) for b in args.batch_sizes.split(",") if b.strip()]
+    assert batch_sizes == sorted(batch_sizes), "Batch sizes must be ascending"
+
+    # Defer model load until after CLI parse
+    from activation_logging.server import get_model_and_tokenizer
+
+    print(f"Loading model: {args.model}")
+    model, tokenizer = get_model_and_tokenizer(args.model, None)
+    model.eval()
+
+    print(f"Loading prompts from {args.dataset}/{args.split}")
+    max_bs = max(batch_sizes)
+    needed = (WARMUP_BATCHES + MEASURED_BATCHES) * max_bs
+    prompts = load_prompts(args.dataset, args.model, args.split, needed)
+    print(f"  Loaded {len(prompts)} prompts (mean tokens: "
+          f"{sum(len(tokenizer.encode(p)) for p in prompts[:50]) // 50})")
+
+    results = {
+        "model": args.model,
+        "dataset": args.dataset,
+        "split": args.split,
+        "max_tokens": MAX_TOKENS,
+        "temperature": TEMPERATURE,
+        "warmup_batches": WARMUP_BATCHES,
+        "measured_batches": MEASURED_BATCHES,
+        "device": str(torch.cuda.get_device_name(0)) if torch.cuda.is_available() else "cpu",
+        "vram_total_gb": round(torch.cuda.get_device_properties(0).total_memory / (1024 ** 3), 1)
+                          if torch.cuda.is_available() else None,
+        "rows": [],
+    }
+
+    print()
+    print(f"{'batch':>6} {'mean wall':>10} {'rows/sec':>10} {'peak GB':>10} {'rsv GB':>10}")
+    print("-" * 50)
+
+    for bs in batch_sizes:
+        gc.collect()
+        torch.cuda.empty_cache()
+        try:
+            r = benchmark_batch_size(model, tokenizer, prompts, bs)
+            results["rows"].append(r)
+            print(f"{r['batch_size']:>6} {r['mean_wall_sec']:>10.3f} "
+                  f"{r['rows_per_sec']:>10.2f} {r['peak_alloc_gb']:>10.2f} "
+                  f"{r['peak_reserved_gb']:>10.2f}")
+        except torch.cuda.OutOfMemoryError:
+            print(f"{bs:>6} OOM — stopping")
+            results["rows"].append({"batch_size": bs, "oom": True})
+            torch.cuda.empty_cache()
+            break
+        except Exception as e:
+            print(f"{bs:>6} ERROR: {type(e).__name__}: {e}")
+            results["rows"].append({"batch_size": bs, "error": str(e)})
+            break
+
+    print()
+    print("=" * 50)
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"Wrote: {args.out}")
+    else:
+        print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_sampling_batch.sh
+++ b/scripts/benchmark_sampling_batch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Run scripts/benchmark_sampling_batch.py on a Jupyter GPU node.
+# Reports rows/sec + peak VRAM at each batch size for both supported models.
+#
+# Dispatch:
+#   python scripts/gpu_dispatch.py run --jupyter --node alphagpu04-8884 -- \
+#       bash scripts/benchmark_sampling_batch.sh
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+BATCH_SIZES="${BATCH_SIZES:-16,32,64,128,256}"
+MODELS=("meta-llama/Llama-3.1-8B-Instruct" "Qwen/Qwen3-8B")
+DATASET=hotpotqa
+SPLIT=test
+
+OUT_DIR=reports/benchmark_sampling_batch
+mkdir -p "$OUT_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$OUT_DIR/bench_${STAMP}.log"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "sampling batch-size benchmark"               | tee -a "$LOG_FILE"
+echo "Started:    $(date)"                          | tee -a "$LOG_FILE"
+echo "Host:       $(hostname)"                      | tee -a "$LOG_FILE"
+echo "GPU:        $(nvidia-smi --query-gpu=name,memory.free --format=csv,noheader 2>/dev/null | head -1)" | tee -a "$LOG_FILE"
+echo "Models:     ${MODELS[*]}"                     | tee -a "$LOG_FILE"
+echo "Batches:    $BATCH_SIZES"                     | tee -a "$LOG_FILE"
+echo "Dataset:    $DATASET/$SPLIT"                  | tee -a "$LOG_FILE"
+echo "Log:        $LOG_FILE"                        | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+export PYTHONUNBUFFERED=1
+for MODEL in "${MODELS[@]}"; do
+    MNAME=$(basename "$MODEL")
+    JSON_OUT="$OUT_DIR/bench_${MNAME}_${STAMP}.json"
+    echo                                                       | tee -a "$LOG_FILE"
+    echo "--- $MODEL ---"                                      | tee -a "$LOG_FILE"
+    $PYTHON scripts/benchmark_sampling_batch.py \
+        --model "$MODEL" \
+        --dataset "$DATASET" \
+        --split "$SPLIT" \
+        --batch-sizes "$BATCH_SIZES" \
+        --out "$JSON_OUT" 2>&1 | tee -a "$LOG_FILE"
+done
+
+echo                                                            | tee -a "$LOG_FILE"
+echo "DONE: $(date)"                                            | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"

--- a/scripts/compute_nli_matrix.py
+++ b/scripts/compute_nli_matrix.py
@@ -34,7 +34,14 @@ def main():
     parser.add_argument("--split", required=True, choices=["train", "test"])
     parser.add_argument("--model", required=True, help="HuggingFace model ID used for generation")
     parser.add_argument("--nli-model", default=NLI_MODEL_ID)
-    parser.add_argument("--batch-size", type=int, default=256, help="NLI pairs per forward pass")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=512,
+        help="NLI pairs per forward pass. 512 is the throughput sweet spot at fp32 "
+             "for deberta-v2-xlarge-mnli on H100 80GB (see "
+             "reports/benchmark_nli_throughput/); 1024 was slower.",
+    )
     parser.add_argument("--device", default=None, help="cuda / cpu (auto-detected if not set)")
     args = parser.parse_args()
 

--- a/scripts/compute_se.py
+++ b/scripts/compute_se.py
@@ -29,7 +29,12 @@ def main():
     parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
     parser.add_argument("--split", required=True, choices=["train", "test"])
     parser.add_argument("--model", required=True, help="HuggingFace model ID used for generation")
-    parser.add_argument("--threshold", type=float, default=0.5, help="Bidirectional NLI threshold")
+    parser.add_argument(
+        "--strict-entailment",
+        action="store_true",
+        help="Use the reference's strict rule (both directions argmax==entailment). "
+             "Default is the reference's loose rule (no contradiction, not both neutral).",
+    )
     args = parser.parse_args()
 
     samples = selfcheck_samples_path(args.dataset, args.model, args.split)
@@ -41,8 +46,11 @@ def main():
             print(f"ERROR: {label} file not found: {p}")
             sys.exit(1)
 
-    print(f"SE | {args.dataset}/{args.split} | {model_name(args.model)} | threshold={args.threshold}")
-    score_files(str(samples), str(nli), str(out), threshold=args.threshold)
+    print(
+        f"SE | {args.dataset}/{args.split} | {model_name(args.model)} | "
+        f"strict_entailment={args.strict_entailment}"
+    )
+    score_files(str(samples), str(nli), str(out), strict_entailment=args.strict_entailment)
 
 
 if __name__ == "__main__":

--- a/scripts/fanout_sampling_baselines.py
+++ b/scripts/fanout_sampling_baselines.py
@@ -1,0 +1,131 @@
+"""Fan out the 20 sampling-baseline cells across available jupyter GPU slots.
+
+Each node gets ONE dispatched job that runs its assigned cells sequentially
+(via scripts/run_sampling_baselines_shard.sh). Cells are written to a per-node
+TSV file under reports/sampling_baselines_runs/fanout_<stamp>/. Resumable: a
+shard that fails mid-way picks up the next cell on the next dispatch.
+
+Usage:
+    python scripts/fanout_sampling_baselines.py --dry-run
+    python scripts/fanout_sampling_baselines.py --nodes alphagpu04-8884
+    python scripts/fanout_sampling_baselines.py \
+        --nodes alphagpu04-8884,alphagpu03-8887 \
+        --models meta-llama/Llama-3.1-8B-Instruct
+"""
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_DATASETS = ["hotpotqa", "nq", "popqa", "sciq", "searchqa"]
+DEFAULT_MODELS = ["meta-llama/Llama-3.1-8B-Instruct", "Qwen/Qwen3-8B"]
+DEFAULT_SPLITS = ["test", "train"]
+
+
+def build_cells(datasets, splits, models):
+    cells = []
+    for ds in datasets:
+        for split in splits:
+            for model in models:
+                cells.append((ds, split, model))
+    return cells
+
+
+def assign_round_robin(cells, nodes):
+    """Round-robin cells across nodes. Returns {node: [cell, ...]}."""
+    bins = {n: [] for n in nodes}
+    for i, c in enumerate(cells):
+        bins[nodes[i % len(nodes)]].append(c)
+    return bins
+
+
+def write_shard_file(path: Path, cells) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("# dataset\tsplit\tmodel\n")
+        for ds, split, model in cells:
+            f.write(f"{ds}\t{split}\t{model}\n")
+
+
+def dispatch_shard(node: str, cells_file: Path, dry_run: bool) -> str:
+    cmd = [
+        "python", "scripts/gpu_dispatch.py", "run",
+        "--jupyter", "--node", node,
+        "--",
+        "env", f"CELLS_FILE={cells_file}",
+        "bash", "scripts/run_sampling_baselines_shard.sh",
+    ]
+    if dry_run:
+        print(f"  [dry-run] {' '.join(cmd)}")
+        return ""
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if out.returncode != 0:
+        print(f"  FAILED ({node}): {out.stderr}", file=sys.stderr)
+        return ""
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("Job ID:"):
+            return line.split(":", 1)[1].strip()
+    print(f"  WARNING ({node}): dispatched but no job id found", file=sys.stderr)
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--datasets", default=",".join(DEFAULT_DATASETS))
+    parser.add_argument("--splits", default=",".join(DEFAULT_SPLITS))
+    parser.add_argument("--models", default=",".join(DEFAULT_MODELS))
+    parser.add_argument("--nodes", required=True,
+                        help="Comma-separated jupyter node names (e.g. alphagpu04-8884,...).")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    datasets = [s.strip() for s in args.datasets.split(",") if s.strip()]
+    splits = [s.strip() for s in args.splits.split(",") if s.strip()]
+    models = [s.strip() for s in args.models.split(",") if s.strip()]
+    nodes = [s.strip() for s in args.nodes.split(",") if s.strip()]
+
+    cells = build_cells(datasets, splits, models)
+    bins = assign_round_robin(cells, nodes)
+
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    fanout_dir = Path("reports/sampling_baselines_runs") / f"fanout_{stamp}"
+
+    print(f"Cells: {len(cells)} | Nodes: {len(nodes)} | Stamp: {stamp}")
+    for n, ncells in bins.items():
+        print(f"  {n}: {len(ncells)} cells")
+        for ds, split, model in ncells:
+            print(f"    - {ds}/{split}/{model.split('/')[-1]}")
+    print()
+
+    # Write per-node shard files
+    job_ids = []
+    for node, ncells in bins.items():
+        cells_file = fanout_dir / f"cells_{node}.tsv"
+        write_shard_file(cells_file, ncells)
+        jid = dispatch_shard(node, cells_file, dry_run=args.dry_run)
+        if jid:
+            job_ids.append((jid, node, cells_file, len(ncells)))
+
+    if args.dry_run:
+        print(f"\nDRY-RUN. Would have written shard files in {fanout_dir} and dispatched {len(bins)} shard jobs.")
+        return
+
+    if job_ids:
+        manifest = fanout_dir / "dispatch.txt"
+        with open(manifest, "w") as f:
+            f.write(f"# fanout dispatch {stamp}\n")
+            for jid, node, cf, n in job_ids:
+                f.write(f"{jid}\t{node}\t{n}\t{cf}\n")
+        print(f"\nDispatched {len(job_ids)}/{len(bins)} shards.")
+        for jid, node, _, n in job_ids:
+            print(f"  {jid}  {node}  ({n} cells)")
+        print(f"\nManifest: {manifest}")
+        print(f"\nMonitor:")
+        print(f"  python scripts/gpu_dispatch.py jobs")
+        print(f"  tail -f reports/sampling_baselines_runs/shard_*.log")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_nli_input_lengths.py
+++ b/scripts/profile_nli_input_lengths.py
@@ -1,0 +1,152 @@
+"""Audit token-length distribution of NLI inputs (CPU, no GPU needed).
+
+Loads the DeBERTa-v2-xlarge-mnli tokenizer (~2 MB, no model weights) and
+tokenizes the *greedy generations* across all 5 sampling datasets × both
+models. The K=10 stochastic samples are produced with max_new_tokens=64 from
+the same prompts, so greedy length is a reasonable proxy for the per-sample
+length distribution. Each NLI pair is (sample_i, sample_j), so the relevant
+input length is roughly 2 × per-sample tokens + 3 special tokens.
+
+Output:
+  - Per-cell percentile table (p50/p90/p95/p99/max)
+  - Pooled overall stats
+  - Recommended max_length cap = ceil((2 * overall_max + 3) * margin) rounded
+    to the next power of 2 or 32 boundary for tidiness.
+
+Usage:
+    python scripts/profile_nli_input_lengths.py
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.sampling_baselines.paths import (
+    SAMPLING_DATASETS,
+    generation_jsonl,
+    model_name,
+)
+
+PERCENTILES = (50, 90, 95, 99)
+NLI_MODEL = "microsoft/deberta-v2-xlarge-mnli"
+MAX_ROWS_PER_CELL = 5000
+
+
+def load_texts(dataset: str, model_id: str, split: str, n_max: int) -> list:
+    path = generation_jsonl(dataset, model_id, split)
+    if not path.exists():
+        return []
+    texts = []
+    with open(path) as f:
+        for line in f:
+            t = (json.loads(line).get("generation") or "").strip()
+            if t:
+                texts.append(t)
+            if len(texts) >= n_max:
+                break
+    return texts
+
+
+def round_up_to(n: int, granularity: int = 32) -> int:
+    return ((n + granularity - 1) // granularity) * granularity
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokenizer", default=NLI_MODEL)
+    parser.add_argument(
+        "--models",
+        default="meta-llama/Llama-3.1-8B-Instruct,Qwen/Qwen3-8B",
+    )
+    parser.add_argument("--datasets", default=",".join(SAMPLING_DATASETS))
+    parser.add_argument("--splits", default="test,train",
+                        help="Comma-separated splits to audit.")
+    parser.add_argument("--margin", type=float, default=1.5,
+                        help="Multiplicative safety margin over observed 2× max.")
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    from transformers import AutoTokenizer
+    print(f"Loading tokenizer: {args.tokenizer} (CPU)")
+    tok = AutoTokenizer.from_pretrained(args.tokenizer)
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
+    splits = [s.strip() for s in args.splits.split(",") if s.strip()]
+
+    print()
+    print(f"{'split':>6} {'dataset':>10} {'model':>26} {'n':>6} "
+          f"{'p50':>5} {'p90':>5} {'p95':>5} {'p99':>5} {'max':>5}")
+    print("-" * 86)
+
+    per_cell = []
+    all_lens = []
+    for split in splits:
+        for ds in datasets:
+            for mid in models:
+                texts = load_texts(ds, mid, split, MAX_ROWS_PER_CELL)
+                if not texts:
+                    print(f"{split:>6} {ds:>10} {model_name(mid):>26} "
+                          f"{'-':>6} (missing)")
+                    continue
+                lens = [len(tok.encode(t, add_special_tokens=False)) for t in texts]
+                arr = np.array(lens)
+                stats = {
+                    "split": split, "dataset": ds, "model": model_name(mid),
+                    "n": len(lens),
+                    "p50": int(np.percentile(arr, 50)),
+                    "p90": int(np.percentile(arr, 90)),
+                    "p95": int(np.percentile(arr, 95)),
+                    "p99": int(np.percentile(arr, 99)),
+                    "max": int(arr.max()),
+                }
+                per_cell.append(stats)
+                all_lens.extend(lens)
+                print(f"{split:>6} {ds:>10} {model_name(mid):>26} "
+                      f"{stats['n']:>6} {stats['p50']:>5} {stats['p90']:>5} "
+                      f"{stats['p95']:>5} {stats['p99']:>5} {stats['max']:>5}")
+
+    if not all_lens:
+        print("\nNo data — aborting.")
+        return
+
+    pooled = np.array(all_lens)
+    print()
+    print("=== Pooled across all cells ===")
+    print(f"  n             = {len(pooled)}")
+    for p in PERCENTILES:
+        print(f"  p{p:>2}           = {int(np.percentile(pooled, p))}")
+    print(f"  max           = {int(pooled.max())}")
+
+    pair_max = 2 * int(pooled.max()) + 3  # premise + hypothesis + [CLS][SEP][SEP]
+    suggested = round_up_to(int(np.ceil(pair_max * args.margin)), granularity=32)
+    print(f"\nNLI pair length upper bound (2*max + 3 specials): {pair_max}")
+    print(f"Recommended max_length (×{args.margin} margin, rounded to 32): {suggested}")
+    print(f"  (current production value: 512; reference paper uses 512)")
+
+    summary = {
+        "tokenizer": args.tokenizer,
+        "max_rows_per_cell": MAX_ROWS_PER_CELL,
+        "per_cell": per_cell,
+        "pooled": {
+            "n": len(pooled),
+            **{f"p{p}": int(np.percentile(pooled, p)) for p in PERCENTILES},
+            "max": int(pooled.max()),
+        },
+        "pair_max_tokens": pair_max,
+        "margin": args.margin,
+        "suggested_max_length": suggested,
+    }
+    if args.out:
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.out, "w") as f:
+            json.dump(summary, f, indent=2)
+        print(f"\nWrote: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_nli_input_lengths.sh
+++ b/scripts/profile_nli_input_lengths.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# CPU-only NLI input-length profile. Safe to --force-concurrent alongside a
+# GPU job since this only loads the DeBERTa tokenizer (~2 MB, no model weights)
+# and tokenizes greedy generations on CPU.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+OUT_DIR=reports/profile_nli_lengths
+mkdir -p "$OUT_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$OUT_DIR/profile_${STAMP}.log"
+JSON_OUT="$OUT_DIR/profile_${STAMP}.json"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "NLI input-length profile (CPU-only)"          | tee -a "$LOG_FILE"
+echo "Started:    $(date)"                           | tee -a "$LOG_FILE"
+echo "Host:       $(hostname)"                       | tee -a "$LOG_FILE"
+echo "Log:        $LOG_FILE"                         | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+export PYTHONUNBUFFERED=1
+$PYTHON scripts/profile_nli_input_lengths.py --out "$JSON_OUT" 2>&1 | tee -a "$LOG_FILE"
+
+echo                                                 | tee -a "$LOG_FILE"
+echo "DONE: $(date)"                                 | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"

--- a/scripts/run_baseline_llama3_seed4_no_llmsknow.sh
+++ b/scripts/run_baseline_llama3_seed4_no_llmsknow.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Resume wrapper around run_baseline_llama3_seed4.sh that excludes llmsknow_probe.
+# See run_baseline_qwen3_seed4_no_llmsknow.sh for rationale.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+METHODS="contrastive_logprob_recon,linear_probe,token_entropy,logprob_baseline,saplma"
+
+for TASK in hotpotqa mmlu nq popqa sciq searchqa; do
+    echo "============================================"
+    echo "baseline_comparison_${TASK} — seed 4 (Llama-3.1-8B-Instruct) — no llmsknow_probe"
+    echo "Started: $(date)"
+    echo "============================================"
+
+    $PYTHON scripts/run_experiment.py \
+        --experiment configs/experiments/baseline_comparison_${TASK}.json \
+        --methods "$METHODS" \
+        --seeds 4 \
+        --device cuda
+
+    echo ""
+done
+
+echo "============================================"
+echo "ALL DONE: $(date)"
+echo "============================================"

--- a/scripts/run_baseline_qwen3_seed3_no_llmsknow.sh
+++ b/scripts/run_baseline_qwen3_seed3_no_llmsknow.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Resume wrapper around run_baseline_qwen3_seed3.sh that excludes llmsknow_probe.
+# See run_baseline_qwen3_seed4_no_llmsknow.sh for rationale.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+METHODS="contrastive_logprob_recon,linear_probe,token_entropy,logprob_baseline,saplma"
+
+for TASK in hotpotqa mmlu nq popqa sciq searchqa; do
+    echo "============================================"
+    echo "baseline_comparison_${TASK}_qwen3 — seed 3 (Qwen3) — no llmsknow_probe"
+    echo "Started: $(date)"
+    echo "============================================"
+
+    $PYTHON scripts/run_experiment.py \
+        --experiment configs/experiments/baseline_comparison_${TASK}_qwen3.json \
+        --methods "$METHODS" \
+        --seeds 3 \
+        --device cuda
+
+    echo ""
+done
+
+echo "============================================"
+echo "ALL DONE: $(date)"
+echo "============================================"

--- a/scripts/run_baseline_qwen3_seed4_no_llmsknow.sh
+++ b/scripts/run_baseline_qwen3_seed4_no_llmsknow.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Resume wrapper around run_baseline_qwen3_seed4.sh that excludes llmsknow_probe.
+# Why: my llmsknow_probe fanout is already running on alphagpu01 and writes to
+# the same runs/<exp>/<dataset>/llmsknow_probe/ path. Letting two hosts race
+# the same non-learned cell would corrupt eval_metrics.json.
+# Behaviour: the runner skips any (dataset, method, seed) cell whose
+# eval_metrics.json exists, so completed cells are no-ops; only the partial
+# contrastive_logprob_recon cell that was killed on alphagpu01 will actually
+# retrain.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+METHODS="contrastive_logprob_recon,linear_probe,token_entropy,logprob_baseline,saplma"
+
+for TASK in hotpotqa mmlu nq popqa sciq searchqa; do
+    echo "============================================"
+    echo "baseline_comparison_${TASK}_qwen3 — seed 4 (Qwen3) — no llmsknow_probe"
+    echo "Started: $(date)"
+    echo "============================================"
+
+    $PYTHON scripts/run_experiment.py \
+        --experiment configs/experiments/baseline_comparison_${TASK}_qwen3.json \
+        --methods "$METHODS" \
+        --seeds 4 \
+        --device cuda
+
+    echo ""
+done
+
+echo "============================================"
+echo "ALL DONE: $(date)"
+echo "============================================"

--- a/scripts/run_phase0_subsets.sh
+++ b/scripts/run_phase0_subsets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Phase 0: build stratified 5k train subsets + SearchQA 10k test cap.
+# CPU-only but dispatched to a GPU node per the no-local-workloads policy.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+LOG_DIR=reports/sampling_baselines_runs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$LOG_DIR/phase0_${STAMP}.log"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "Phase 0: subset + cap index files"            | tee -a "$LOG_FILE"
+echo "Started: $(date) | Host: $(hostname)"         | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+export PYTHONUNBUFFERED=1
+$PYTHON scripts/compute_subsets.py 2>&1 | tee -a "$LOG_FILE"
+
+echo                                                | tee -a "$LOG_FILE"
+echo "--- Resulting index files ---"                | tee -a "$LOG_FILE"
+ls -1 output/sep_subset_*.json output/searchqa_test_cap_*.json 2>&1 | tee -a "$LOG_FILE"
+echo "DONE: $(date)"                                | tee -a "$LOG_FILE"

--- a/scripts/run_sampling_baselines_cell.sh
+++ b/scripts/run_sampling_baselines_cell.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Run Phase 1-4 of the sampling baselines pipeline for one (dataset, split, model)
+# cell. Each phase is resumable — re-running an already-complete cell is a no-op.
+#
+# Usage (via gpu_dispatch):
+#   python scripts/gpu_dispatch.py run --jupyter --node <NODE> -- \
+#       env DATASET=hotpotqa SPLIT=test MODEL=meta-llama/Llama-3.1-8B-Instruct \
+#       bash scripts/run_sampling_baselines_cell.sh
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+: "${DATASET:?DATASET env var required (hotpotqa|nq|popqa|sciq|searchqa)}"
+: "${SPLIT:?SPLIT env var required (test|train)}"
+: "${MODEL:?MODEL env var required (meta-llama/Llama-3.1-8B-Instruct|Qwen/Qwen3-8B)}"
+
+MODEL_NAME=$(basename "$MODEL")
+LOG_DIR=reports/sampling_baselines_runs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$LOG_DIR/cell_${DATASET}_${SPLIT}_${MODEL_NAME}_${STAMP}.log"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "sampling baselines cell"                       | tee -a "$LOG_FILE"
+echo "Cell:    $DATASET / $SPLIT / $MODEL_NAME"       | tee -a "$LOG_FILE"
+echo "Started: $(date) | Host: $(hostname)"           | tee -a "$LOG_FILE"
+echo "GPU:     $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1)" | tee -a "$LOG_FILE"
+echo "Log:     $LOG_FILE"                             | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+export PYTHONUNBUFFERED=1
+TIME_FILE="$LOG_DIR/cell_${DATASET}_${SPLIT}_${MODEL_NAME}_${STAMP}.time"
+
+phase () {
+    local label="$1"; shift
+    echo                                              | tee -a "$LOG_FILE"
+    echo "--- $label ---"                             | tee -a "$LOG_FILE"
+    "$@" 2>&1 | tee -a "$LOG_FILE"
+}
+
+/usr/bin/time -v -o "$TIME_FILE" bash -c "
+    set -eo pipefail
+    cd '$(pwd)'
+    phase () {
+        local label=\"\$1\"; shift
+        echo; echo \"--- \$label ---\"
+        \"\$@\"
+    }
+    phase 'Phase 1 sampling' $PYTHON scripts/run_sampling_pass.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL'
+    phase 'Phase 2 NLI matrix' $PYTHON scripts/compute_nli_matrix.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL'
+    phase 'Phase 3 SE' $PYTHON scripts/compute_se.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL'
+    phase 'Phase 4 SelfCheck' $PYTHON scripts/compute_selfcheck.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL' --no-bertscore
+" 2>&1 | tee -a "$LOG_FILE"
+
+EXIT=$?
+echo                                                  | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+echo "DONE: $(date) exit=$EXIT"                      | tee -a "$LOG_FILE"
+echo "--- time -v ---"                                | tee -a "$LOG_FILE"
+cat "$TIME_FILE"                                      | tee -a "$LOG_FILE" || true
+echo "============================================" | tee -a "$LOG_FILE"
+exit $EXIT

--- a/scripts/run_sampling_baselines_shard.sh
+++ b/scripts/run_sampling_baselines_shard.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Run a shard of sampling-baseline cells sequentially on one GPU.
+# Cells are read from $CELLS_FILE (TSV: dataset \t split \t model per line).
+# Each cell is fully resumable, so failures don't lose progress within a cell.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+: "${CELLS_FILE:?CELLS_FILE env var required (TSV: dataset\\tsplit\\tmodel)}"
+if [[ ! -f "$CELLS_FILE" ]]; then
+    echo "ERROR: cells file not found: $CELLS_FILE" >&2
+    exit 1
+fi
+
+LOG_DIR=reports/sampling_baselines_runs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+SHARD_LOG="$LOG_DIR/shard_${STAMP}.log"
+
+N_CELLS=$(grep -cv '^\s*\(#.*\)\?$' "$CELLS_FILE" || echo 0)
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+echo "============================================" | tee "$SHARD_LOG"
+echo "sampling baselines shard"                      | tee -a "$SHARD_LOG"
+echo "Started: $(date) | Host: $(hostname)"          | tee -a "$SHARD_LOG"
+echo "Cells:   $N_CELLS (from $CELLS_FILE)"          | tee -a "$SHARD_LOG"
+echo "Log:     $SHARD_LOG"                            | tee -a "$SHARD_LOG"
+echo "============================================" | tee -a "$SHARD_LOG"
+
+# Phase 0: ensure stratified subset + SearchQA cap index files exist.
+# Idempotent — compute_subsets.py skips cells whose output already exists.
+echo                                                  | tee -a "$SHARD_LOG"
+echo "--- Phase 0 (subsets + caps) ---"               | tee -a "$SHARD_LOG"
+$PYTHON scripts/compute_subsets.py 2>&1 | tee -a "$SHARD_LOG"
+
+FAILED_CELLS=()
+i=0
+while IFS=$'\t' read -r ds split model; do
+    # Skip blank/comment lines
+    case "$ds" in ''|\#*) continue ;; esac
+    i=$((i+1))
+    echo                                              | tee -a "$SHARD_LOG"
+    echo ">>> [$i/$N_CELLS] $ds / $split / $(basename "$model")" | tee -a "$SHARD_LOG"
+    echo "    started: $(date)"                       | tee -a "$SHARD_LOG"
+    if DATASET="$ds" SPLIT="$split" MODEL="$model" \
+       bash scripts/run_sampling_baselines_cell.sh; then
+        echo "    OK"                                 | tee -a "$SHARD_LOG"
+    else
+        rc=$?
+        echo "    FAILED (exit=$rc) — continuing with next cell" | tee -a "$SHARD_LOG"
+        FAILED_CELLS+=("$ds/$split/$(basename "$model")")
+    fi
+done < "$CELLS_FILE"
+
+echo                                                  | tee -a "$SHARD_LOG"
+echo "============================================" | tee -a "$SHARD_LOG"
+echo "Shard DONE: $(date)"                            | tee -a "$SHARD_LOG"
+if [[ ${#FAILED_CELLS[@]} -gt 0 ]]; then
+    echo "Failed cells (${#FAILED_CELLS[@]}):"        | tee -a "$SHARD_LOG"
+    printf '  %s\n' "${FAILED_CELLS[@]}"              | tee -a "$SHARD_LOG"
+    exit 1
+fi
+echo "All $i cells succeeded."                        | tee -a "$SHARD_LOG"

--- a/scripts/run_sampling_pass.py
+++ b/scripts/run_sampling_pass.py
@@ -74,7 +74,14 @@ def main():
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--max-tokens", type=int, default=64)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=384,
+        help="Sampling batch size. 384 is the throughput sweet spot on H100 80GB "
+             "for both Llama-3.1-8B and Qwen3-8B at max_tokens=64 (see "
+             "reports/benchmark_sampling_batch/).",
+    )
     parser.add_argument(
         "--smoketest",
         action="store_true",

--- a/scripts/smoketest_sampling_baselines.sh
+++ b/scripts/smoketest_sampling_baselines.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Smoketest for the sampling-based baselines pipeline (PR #49, #56).
+# Chains all four phases on a single (dataset, model, split) cell at 50 rows:
+#
+#   Phase 1 — run_sampling_pass.py --smoketest      (GPU; K=10 stochastic samples)
+#   Phase 2 — compute_nli_matrix.py                  (GPU; DeBERTa-v2-xlarge-mnli)
+#   Phase 3 — compute_se.py                          (CPU; cluster + entropy)
+#   Phase 4 — compute_selfcheck.py --no-bertscore    (CPU; NLI + n-gram variants)
+#
+# Each phase output is asserted to have exactly 50 lines.
+# Logs + timing + GPU samples land in reports/smoketest_sampling_baselines/.
+#
+# Run on a Jupyter GPU node (e.g. alphagpu04-8884):
+#   python scripts/gpu_dispatch.py run --jupyter --node alphagpu04-8884 -- \
+#       bash scripts/smoketest_sampling_baselines.sh
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+DATASET="${DATASET:-hotpotqa}"
+SPLIT="${SPLIT:-test}"
+MODEL="${MODEL:-meta-llama/Llama-3.1-8B-Instruct}"
+MODEL_NAME=$(basename "$MODEL")
+EXPECTED_ROWS=50
+
+OUT_DIR="output/sampling_baselines/${DATASET}/${MODEL_NAME}"
+SAMPLES="${OUT_DIR}/selfcheck_samples.jsonl"
+NLI="${OUT_DIR}/nli_matrix.jsonl"
+SE="${OUT_DIR}/se_labels.jsonl"
+SELFCHECK="${OUT_DIR}/selfcheck_scores.jsonl"
+
+LOG_DIR=reports/smoketest_sampling_baselines
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$LOG_DIR/smoketest_${STAMP}.log"
+GPU_LOG="$LOG_DIR/gpu_${STAMP}.log"
+TIME_FILE="$LOG_DIR/time_${STAMP}.txt"
+
+# Clean previous smoke artifacts so resume logic doesn't pre-fill the smoke output.
+# (Phase scripts append on resume; for a fresh smoke we want known empty state.)
+rm -f "$SAMPLES" "$NLI" "$SE" "$SELFCHECK"
+
+echo "============================================" | tee "$LOG_FILE"
+echo "sampling_baselines smoketest"                  | tee -a "$LOG_FILE"
+echo "Started:    $(date)"                            | tee -a "$LOG_FILE"
+echo "Host:       $(hostname)"                        | tee -a "$LOG_FILE"
+echo "GPU:        $(nvidia-smi --query-gpu=name,memory.free --format=csv,noheader 2>/dev/null | head -1)" | tee -a "$LOG_FILE"
+echo "Dataset:    $DATASET | Split: $SPLIT"           | tee -a "$LOG_FILE"
+echo "Model:      $MODEL"                             | tee -a "$LOG_FILE"
+echo "Rows:       $EXPECTED_ROWS"                     | tee -a "$LOG_FILE"
+echo "Out dir:    $OUT_DIR"                           | tee -a "$LOG_FILE"
+echo "Log:        $LOG_FILE"                          | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+
+# Background GPU sampler
+(
+    while true; do
+        ts=$(date +%H:%M:%S)
+        nvidia-smi --query-gpu=index,utilization.gpu,memory.used --format=csv,noheader,nounits \
+            2>/dev/null | sed "s/^/$ts /" >> "$GPU_LOG" || true
+        sleep 5
+    done
+) &
+SAMPLER_PID=$!
+trap "kill $SAMPLER_PID 2>/dev/null || true" EXIT
+
+export PYTHONUNBUFFERED=1
+PHASE_FAIL=0
+
+run_phase () {
+    local label="$1"; shift
+    echo                                                        | tee -a "$LOG_FILE"
+    echo "--- $label ---"                                       | tee -a "$LOG_FILE"
+    echo "+ $*"                                                 | tee -a "$LOG_FILE"
+    if ! "$@" 2>&1 | tee -a "$LOG_FILE"; then
+        echo "FAIL: $label exited non-zero"                     | tee -a "$LOG_FILE"
+        PHASE_FAIL=1
+        return 1
+    fi
+}
+
+assert_rows () {
+    local label="$1"; local path="$2"; local expected="$3"
+    if [[ ! -f "$path" ]]; then
+        echo "FAIL: $label output missing: $path"               | tee -a "$LOG_FILE"
+        PHASE_FAIL=1
+        return 1
+    fi
+    local actual
+    actual=$(wc -l < "$path")
+    if [[ "$actual" -ne "$expected" ]]; then
+        echo "FAIL: $label expected $expected lines, got $actual ($path)" | tee -a "$LOG_FILE"
+        PHASE_FAIL=1
+        return 1
+    fi
+    echo "OK:   $label has $actual lines ($path)"               | tee -a "$LOG_FILE"
+}
+
+/usr/bin/time -v -o "$TIME_FILE" bash -c "
+    set -eo pipefail
+    cd '$(pwd)'
+
+    $PYTHON scripts/run_sampling_pass.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL' --smoketest 2>&1 | tee -a '$LOG_FILE'
+
+    $PYTHON scripts/compute_nli_matrix.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL' 2>&1 | tee -a '$LOG_FILE'
+
+    $PYTHON scripts/compute_se.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL' 2>&1 | tee -a '$LOG_FILE'
+
+    $PYTHON scripts/compute_selfcheck.py \
+        --dataset '$DATASET' --split '$SPLIT' --model '$MODEL' --no-bertscore 2>&1 | tee -a '$LOG_FILE'
+" || PHASE_FAIL=1
+
+echo                                                            | tee -a "$LOG_FILE"
+echo "--- Row-count assertions ---"                             | tee -a "$LOG_FILE"
+assert_rows "Phase 1 sampling"  "$SAMPLES"   "$EXPECTED_ROWS" || true
+assert_rows "Phase 2 NLI"       "$NLI"       "$EXPECTED_ROWS" || true
+assert_rows "Phase 3 SE"        "$SE"        "$EXPECTED_ROWS" || true
+assert_rows "Phase 4 SelfCheck" "$SELFCHECK" "$EXPECTED_ROWS" || true
+
+echo                                                            | tee -a "$LOG_FILE"
+echo "--- SE label sanity (first row) ---"                      | tee -a "$LOG_FILE"
+$PYTHON - <<PY | tee -a "$LOG_FILE"
+import json
+with open("$SE") as f:
+    rec = json.loads(f.readline())
+print("Keys:", sorted(rec.keys()))
+for k in ("semantic_entropy", "length_normalized_se", "discrete_se", "n_clusters", "strict_entailment"):
+    print(f"  {k}: {rec.get(k)}")
+PY
+
+echo                                                            | tee -a "$LOG_FILE"
+echo "============================================" | tee -a "$LOG_FILE"
+echo "DONE: $(date) phase_fail=$PHASE_FAIL"        | tee -a "$LOG_FILE"
+echo "--- time -v output ---"                       | tee -a "$LOG_FILE"
+cat "$TIME_FILE"                                    | tee -a "$LOG_FILE"
+echo "--- gpu samples (head/tail) ---"              | tee -a "$LOG_FILE"
+head -n 5 "$GPU_LOG" 2>/dev/null                    | tee -a "$LOG_FILE" || true
+echo "..."                                          | tee -a "$LOG_FILE"
+tail -n 10 "$GPU_LOG" 2>/dev/null                   | tee -a "$LOG_FILE" || true
+echo "============================================" | tee -a "$LOG_FILE"
+
+exit $PHASE_FAIL

--- a/tasks/sampling_baselines/nli_scorer.py
+++ b/tasks/sampling_baselines/nli_scorer.py
@@ -1,6 +1,5 @@
-"""Batched NLI matrix computation using cross-encoder/nli-deberta-v3-base."""
+"""Batched NLI matrix computation matching jlko/semantic_uncertainty reference."""
 import json
-import re
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -8,24 +7,14 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
-NLI_MODEL_ID = "cross-encoder/nli-deberta-v3-base"
-
-# Strip leading hedges before NLI clustering (SE only; raw text preserved for SelfCheckGPT)
-_STRIP_RE = re.compile(
-    r"^(the answer is[:\s]*|answer[:\s]*|yes[,\.\s]+|no[,\.\s]+|"
-    r"therefore[,\s]+|so[,\s]+|thus[,\s]+|it is[:\s]*|that is[:\s]*)",
-    re.IGNORECASE,
-)
-
-
-def strip_surface_form(text: str) -> str:
-    return _STRIP_RE.sub("", text.strip()).strip()
+# Matches the reference impl (jlko/semantic_uncertainty EntailmentDeberta).
+NLI_MODEL_ID = "microsoft/deberta-v2-xlarge-mnli"
 
 
 class NLIScorer:
     """Compute (K+1)x(K+1) directed NLI matrices over {greedy}∪{K samples} per question.
 
-    Label order for cross-encoder/nli-deberta-v3-base:
+    Label order for deberta-v2-xlarge-mnli:
         0 = contradiction, 1 = neutral, 2 = entailment
     Verified dynamically via model.config.id2label at load time.
     """
@@ -107,14 +96,13 @@ class NLIScorer:
                 greedy = rec["greedy_answer"]
                 sample_texts = [s["text"] for s in rec["samples"]]
                 all_texts = [greedy] + sample_texts
-                stripped = [strip_surface_form(t) for t in all_texts]
 
-                matrix = self.compute_matrix(stripped)
+                matrix = self.compute_matrix(all_texts)
 
                 out = {
                     "row_idx": rec["row_idx"],
                     "nli_matrix": matrix.tolist(),
-                    "texts_stripped": stripped,
+                    "texts": all_texts,
                 }
                 fout.write(json.dumps(out, ensure_ascii=False) + "\n")
 

--- a/tasks/sampling_baselines/nli_scorer.py
+++ b/tasks/sampling_baselines/nli_scorer.py
@@ -22,7 +22,7 @@ class NLIScorer:
     def __init__(
         self,
         model_id: str = NLI_MODEL_ID,
-        batch_size: int = 256,
+        batch_size: int = 512,
         device: Optional[str] = None,
     ):
         self.model_id = model_id

--- a/tasks/sampling_baselines/paths.py
+++ b/tasks/sampling_baselines/paths.py
@@ -8,6 +8,16 @@ MODELS = [
     "Qwen/Qwen3-8B",
 ]
 
+# Canonical dataset names → on-disk directory stems. Most datasets are 1:1, but
+# `nq` shipped with directories named `natural_questions[_train]`.
+_DATASET_DIR_STEM = {
+    "nq": "natural_questions",
+}
+
+
+def _dir_stem(dataset: str) -> str:
+    return _DATASET_DIR_STEM.get(dataset, dataset)
+
 
 def model_name(model_id: str) -> str:
     """Last component of HuggingFace model ID, matching output path convention."""
@@ -20,24 +30,28 @@ def model_slug(model_id: str) -> str:
 
 
 def generation_jsonl(dataset: str, model_id: str, split: str) -> Path:
-    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    stem = _dir_stem(dataset)
+    ds_dir = f"{stem}_train" if split == "train" else stem
     return Path("output") / ds_dir / model_name(model_id) / "generation.jsonl"
 
 
 def eval_results_json(dataset: str, model_id: str, split: str) -> Path:
-    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    stem = _dir_stem(dataset)
+    ds_dir = f"{stem}_train" if split == "train" else stem
     return Path("output") / ds_dir / model_name(model_id) / "eval_results_for_training.json"
 
 
 def zarr_path(dataset: str, model_id: str, split: str) -> Path:
+    stem = _dir_stem(dataset)
     slug = model_slug(model_id)
     if split == "train":
-        return Path("shared") / f"{dataset}_train_{slug}" / "activations.zarr"
-    return Path("shared") / f"{dataset}_{slug}" / "activations.zarr"
+        return Path("shared") / f"{stem}_train_{slug}" / "activations.zarr"
+    return Path("shared") / f"{stem}_{slug}" / "activations.zarr"
 
 
 def sampling_output_dir(dataset: str, model_id: str, split: str) -> Path:
-    ds_dir = f"{dataset}_train" if split == "train" else dataset
+    stem = _dir_stem(dataset)
+    ds_dir = f"{stem}_train" if split == "train" else stem
     return Path("output") / "sampling_baselines" / ds_dir / model_name(model_id)
 
 

--- a/tasks/sampling_baselines/se.py
+++ b/tasks/sampling_baselines/se.py
@@ -1,123 +1,193 @@
-"""Semantic Entropy computation from precomputed NLI matrices."""
+"""Semantic Entropy — paper-faithful port of jlko/semantic_uncertainty.
+
+Reference: https://github.com/jlko/semantic_uncertainty/blob/master/semantic_uncertainty/
+           uncertainty/uncertainty_measures/semantic_entropy.py
+
+Procedure (per Kuhn/Gal/Farquhar 2023 + Farquhar Nature 2024):
+
+  1. NLI matrix M[i,j,:] = P(contradict | neutral | entail) for premise=text_i,
+     hypothesis=text_j (produced upstream by nli_scorer).
+  2. Bidirectional entailment clustering via get_semantic_ids — greedy assignment
+     with reference's loose-vs-strict rule on argmax labels.
+  3. Per-cluster log-likelihood via logsumexp_by_id (sum-normalized).
+  4. Headline entropy: predictive_entropy_rao over those cluster log-likelihoods.
+     Auxiliary: cluster_assignment_entropy (discrete) and length-normalized variant
+     kept for back-compat with assemble_baseline_table.py and compute_sep.py.
+"""
 import json
 import math
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence
 
 import numpy as np
 
+# Index convention in the (K+1, K+1, 3) NLI matrix (verified at load time by NLIScorer)
+CONTRADICTION = 0
+NEUTRAL = 1
+ENTAILMENT = 2
 
-def cluster_answers(
+
+# ---------------------------------------------------------------------------
+# Clustering (port of get_semantic_ids from reference)
+# ---------------------------------------------------------------------------
+
+def _are_equivalent(
     nli_matrix: np.ndarray,
-    start_idx: int = 1,
-    end_idx: Optional[int] = None,
-    threshold: float = 0.5,
-) -> List[List[int]]:
-    """Greedy bidirectional entailment clustering.
+    i: int,
+    j: int,
+    strict_entailment: bool,
+) -> bool:
+    """Bidirectional equivalence using the reference's argmax-based rule."""
+    impl_ij = int(np.argmax(nli_matrix[i, j]))
+    impl_ji = int(np.argmax(nli_matrix[j, i]))
 
-    Operates on matrix indices [start_idx, end_idx).
-    Index 0 = greedy answer (excluded from clustering by default).
-    nli_matrix[i, j] = [p_contradict, p_neutral, p_entail] (i=premise, j=hypothesis).
-    Two texts cluster together iff both directions have p_entail > threshold.
+    if strict_entailment:
+        return impl_ij == ENTAILMENT and impl_ji == ENTAILMENT
+
+    impls = (impl_ij, impl_ji)
+    # Loose default: no direction is contradiction, and not both neutral.
+    return (CONTRADICTION not in impls) and (impls != (NEUTRAL, NEUTRAL))
+
+
+def get_semantic_ids(
+    nli_matrix: np.ndarray,
+    start_idx: int,
+    end_idx: int,
+    strict_entailment: bool = False,
+) -> List[int]:
+    """Greedy semantic-id assignment over matrix rows [start_idx, end_idx).
+
+    Reference algorithm: assign next id to the first unlabeled element, then
+    forward-scan and propagate that id to every unlabeled element it equivales.
+
+    Returns a list of length (end_idx - start_idx) with ids starting from 0.
     """
-    if end_idx is None:
-        end_idx = nli_matrix.shape[0]
-
-    clusters: List[List[int]] = []
-    for i in range(start_idx, end_idx):
-        placed = False
-        for cluster in clusters:
-            rep = cluster[0]
-            p_entail_ri = nli_matrix[rep, i, 2]
-            p_entail_ir = nli_matrix[i, rep, 2]
-            if p_entail_ri > threshold and p_entail_ir > threshold:
-                cluster.append(i)
-                placed = True
-                break
-        if not placed:
-            clusters.append([i])
-
-    return clusters
-
-
-def discrete_se(clusters: List[List[int]], K: int) -> float:
-    """Discrete semantic entropy: -sum(|c|/K * log(|c|/K)) over clusters."""
-    if K == 0:
-        return 0.0
-    entropy = 0.0
-    for cluster in clusters:
-        p = len(cluster) / K
-        if p > 0:
-            entropy -= p * math.log(p)
-    return entropy
+    n = end_idx - start_idx
+    semantic_ids = [-1] * n
+    next_id = 0
+    for i in range(n):
+        if semantic_ids[i] != -1:
+            continue
+        semantic_ids[i] = next_id
+        m_i = start_idx + i
+        for j in range(i + 1, n):
+            if semantic_ids[j] != -1:
+                continue
+            m_j = start_idx + j
+            if _are_equivalent(nli_matrix, m_i, m_j, strict_entailment):
+                semantic_ids[j] = next_id
+        next_id += 1
+    assert -1 not in semantic_ids
+    return semantic_ids
 
 
-def length_normalized_se(
-    clusters: List[List[int]],
-    samples: List[dict],
-    start_idx: int = 1,
-) -> float:
-    """Length-normalized semantic entropy (Farquhar et al. headline variant).
+# ---------------------------------------------------------------------------
+# Per-cluster log-likelihood aggregation (port of logsumexp_by_id)
+# ---------------------------------------------------------------------------
 
-    Uses length_normalized_logprob from the generating model.
-    Log-sum-exp within each cluster, normalize, then entropy.
-    samples is 0-indexed relative to the sample list (not matrix index).
+def logsumexp_by_id(
+    semantic_ids: Sequence[int],
+    log_likelihoods: Sequence[float],
+) -> List[float]:
+    """Aggregate sample log-likelihoods into per-cluster log-likelihoods.
+
+    Uses the reference's `sum_normalized` aggregation: normalize each sample
+    log-prob by the total log-prob across all samples, then log-sum-exp within
+    each cluster.
     """
-    if not clusters:
+    unique_ids = sorted(set(semantic_ids))
+    assert unique_ids == list(range(len(unique_ids))), f"non-contiguous ids: {unique_ids}"
+
+    lp_arr = np.asarray(log_likelihoods, dtype=np.float64)
+    total_log = float(np.log(np.sum(np.exp(lp_arr))))  # log-Z over all samples
+
+    cluster_log_likelihoods: List[float] = []
+    for uid in unique_ids:
+        idx = [k for k, s in enumerate(semantic_ids) if s == uid]
+        normed = lp_arr[idx] - total_log
+        cluster_log_likelihoods.append(float(np.log(np.sum(np.exp(normed)))))
+    return cluster_log_likelihoods
+
+
+# ---------------------------------------------------------------------------
+# Entropy estimators (port from reference)
+# ---------------------------------------------------------------------------
+
+def predictive_entropy_rao(log_probs: Sequence[float]) -> float:
+    """Reference's headline estimator: -sum(p * log p) where p = exp(log_p).
+
+    Matches predictive_entropy_rao in the reference. Inputs are *cluster*
+    log-likelihoods (already normalized to sum-to-one via logsumexp_by_id).
+    """
+    lp = np.asarray(log_probs, dtype=np.float64)
+    return float(-np.sum(np.exp(lp) * lp))
+
+
+def cluster_assignment_entropy(semantic_ids: Sequence[int]) -> float:
+    """Discrete categorical entropy over empirical cluster-assignment counts."""
+    if len(semantic_ids) == 0:
         return 0.0
-
-    cluster_lp = []
-    for cluster in clusters:
-        # cluster contains matrix indices; samples are at matrix_idx - start_idx
-        sample_lps = [samples[idx - start_idx]["length_normalized_logprob"] for idx in cluster]
-        cluster_lp.append(_logsumexp(sample_lps))
-
-    total = _logsumexp(cluster_lp)
-    probs = [math.exp(lp - total) for lp in cluster_lp]
-
-    entropy = 0.0
-    for p in probs:
-        if p > 0:
-            entropy -= p * math.log(p)
-    return entropy
+    counts = np.bincount(semantic_ids)
+    probs = counts / counts.sum()
+    nz = probs[probs > 0]
+    return float(-np.sum(nz * np.log(nz)))
 
 
-def compute_se_for_record(record: dict, nli_matrix: np.ndarray, threshold: float = 0.5) -> dict:
-    """Compute both SE variants for one question.
+# ---------------------------------------------------------------------------
+# Per-record dispatch (used by file-level scorer + tests)
+# ---------------------------------------------------------------------------
 
-    Args:
-        record: one row from selfcheck_samples.jsonl
-        nli_matrix: (K+1, K+1, 3) array from nli_matrix.jsonl
-        threshold: bidirectional entailment threshold
+def compute_se_for_record(
+    record: dict,
+    nli_matrix: np.ndarray,
+    strict_entailment: bool = False,
+) -> dict:
+    """Compute paper-faithful SE plus back-compat fields for one question.
 
-    Returns dict with discrete_se, length_normalized_se, n_clusters, cluster_assignments.
+    Output keys:
+        semantic_entropy            — headline (rao over logsumexp_by_id on raw sequence_logprob)
+        semantic_entropy_lennorm    — same recipe using length_normalized_logprob
+        discrete_se                 — cluster_assignment_entropy (= back-compat key)
+        length_normalized_se        — same as semantic_entropy_lennorm, kept for back-compat
+        n_clusters, semantic_ids, strict_entailment
     """
     K = record["K"]
     samples = record["samples"]
+    seq_lp = [s["sequence_logprob"] for s in samples]
+    len_lp = [s["length_normalized_logprob"] for s in samples]
 
-    clusters = cluster_answers(nli_matrix, start_idx=1, end_idx=K + 1, threshold=threshold)
-    d_se = discrete_se(clusters, K)
-    ln_se = length_normalized_se(clusters, samples, start_idx=1)
+    # Cluster matrix indices 1..K+1 (index 0 is the greedy, excluded from SE).
+    semantic_ids = get_semantic_ids(nli_matrix, start_idx=1, end_idx=K + 1,
+                                    strict_entailment=strict_entailment)
+
+    cluster_lp_raw = logsumexp_by_id(semantic_ids, seq_lp)
+    cluster_lp_len = logsumexp_by_id(semantic_ids, len_lp)
 
     return {
         "row_idx": record["row_idx"],
-        "discrete_se": d_se,
-        "length_normalized_se": ln_se,
-        "n_clusters": len(clusters),
-        "cluster_assignments": clusters,
+        "semantic_entropy": predictive_entropy_rao(cluster_lp_raw),
+        "semantic_entropy_lennorm": predictive_entropy_rao(cluster_lp_len),
+        "length_normalized_se": predictive_entropy_rao(cluster_lp_len),
+        "discrete_se": cluster_assignment_entropy(semantic_ids),
+        "n_clusters": len(set(semantic_ids)),
+        "semantic_ids": semantic_ids,
+        "strict_entailment": strict_entailment,
     }
 
+
+# ---------------------------------------------------------------------------
+# File-level scorer
+# ---------------------------------------------------------------------------
 
 def score_files(
     samples_path: str,
     nli_matrix_path: str,
     output_path: str,
-    threshold: float = 0.5,
+    strict_entailment: bool = False,
 ) -> None:
     """Process selfcheck_samples.jsonl + nli_matrix.jsonl → se_labels.jsonl."""
     done_rows = _load_done_rows(output_path)
 
-    # Load NLI matrices indexed by row_idx
     nli_by_row = {}
     with open(nli_matrix_path) as f:
         for line in f:
@@ -134,18 +204,11 @@ def score_files(
                 continue
             if row_idx not in nli_by_row:
                 continue
-            result = compute_se_for_record(rec, nli_by_row[row_idx], threshold)
+            result = compute_se_for_record(rec, nli_by_row[row_idx], strict_entailment)
             fout.write(json.dumps(result, ensure_ascii=False) + "\n")
             written += 1
 
     print(f"SE done: {written} rows written → {output_path}")
-
-
-def _logsumexp(values: List[float]) -> float:
-    if not values:
-        return float("-inf")
-    m = max(values)
-    return m + math.log(sum(math.exp(v - m) for v in values))
 
 
 def _load_done_rows(path: str) -> set:

--- a/tests/test_se_paper_fidelity.py
+++ b/tests/test_se_paper_fidelity.py
@@ -1,0 +1,262 @@
+"""Fidelity tests: our SE pipeline produces the same outputs as the reference.
+
+Reference: jlko/semantic_uncertainty
+    semantic_uncertainty/uncertainty/uncertainty_measures/semantic_entropy.py
+
+The reference's NLI model (microsoft/deberta-v2-xlarge-mnli) is a large
+download; we don't run it in tests. Instead we synthesize NLI matrices and
+log-probabilities, then check that our clustering, aggregation, and entropy
+functions match the reference's algorithms bit-for-bit.
+
+The vendored reference functions below are copied verbatim from the reference
+repo (BSD-3 license, file noted above) and are the ground-truth against which
+our implementations are compared.
+"""
+import numpy as np
+import pytest
+
+from tasks.sampling_baselines.se import (
+    CONTRADICTION,
+    ENTAILMENT,
+    NEUTRAL,
+    cluster_assignment_entropy as ours_cluster_entropy,
+    compute_se_for_record,
+    get_semantic_ids as ours_get_semantic_ids,
+    logsumexp_by_id as ours_logsumexp_by_id,
+    predictive_entropy_rao as ours_predictive_entropy_rao,
+)
+
+
+# ---------------------------------------------------------------------------
+# Vendored reference functions (jlko/semantic_uncertainty, BSD-3)
+# Adapted minimally: `check_implication` is replaced by a closure over a
+# precomputed argmax-implications matrix so we don't need to run the NLI model.
+# ---------------------------------------------------------------------------
+
+def ref_get_semantic_ids(strings_list, impl_matrix, strict_entailment=False):
+    """Reference get_semantic_ids; impl_matrix[i,j] = argmax label for (i,j)."""
+    def are_equivalent(i, j):
+        implication_1 = int(impl_matrix[i, j])
+        implication_2 = int(impl_matrix[j, i])
+        assert (implication_1 in [0, 1, 2]) and (implication_2 in [0, 1, 2])
+        if strict_entailment:
+            return (implication_1 == 2) and (implication_2 == 2)
+        implications = [implication_1, implication_2]
+        return (0 not in implications) and ([1, 1] != implications)
+
+    semantic_set_ids = [-1] * len(strings_list)
+    next_id = 0
+    for i, _ in enumerate(strings_list):
+        if semantic_set_ids[i] == -1:
+            semantic_set_ids[i] = next_id
+            for j in range(i + 1, len(strings_list)):
+                if are_equivalent(i, j):
+                    semantic_set_ids[j] = next_id
+            next_id += 1
+    assert -1 not in semantic_set_ids
+    return semantic_set_ids
+
+
+def ref_logsumexp_by_id(semantic_ids, log_likelihoods):
+    """Reference logsumexp_by_id with agg='sum_normalized'."""
+    unique_ids = sorted(list(set(semantic_ids)))
+    assert unique_ids == list(range(len(unique_ids)))
+    out = []
+    for uid in unique_ids:
+        idx = [pos for pos, x in enumerate(semantic_ids) if x == uid]
+        id_lp = [log_likelihoods[i] for i in idx]
+        log_lik_norm = np.asarray(id_lp) - np.log(np.sum(np.exp(np.asarray(log_likelihoods))))
+        out.append(np.log(np.sum(np.exp(log_lik_norm))))
+    return out
+
+
+def ref_predictive_entropy_rao(log_probs):
+    lp = np.asarray(log_probs)
+    return float(-np.sum(np.exp(lp) * lp))
+
+
+def ref_cluster_assignment_entropy(semantic_ids):
+    n = len(semantic_ids)
+    counts = np.bincount(semantic_ids)
+    probs = counts / n
+    return float(-(probs * np.log(probs)).sum())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_nli_matrix_from_argmax(impl: np.ndarray) -> np.ndarray:
+    """Build a (N, N, 3) prob matrix whose argmax is `impl` (deterministic)."""
+    N = impl.shape[0]
+    m = np.full((N, N, 3), 0.05, dtype=np.float32)
+    for i in range(N):
+        for j in range(N):
+            if i == j:
+                m[i, j] = np.nan
+                continue
+            m[i, j, int(impl[i, j])] = 0.9
+            # Renormalize to sum to 1 across the 3 classes
+            m[i, j] /= m[i, j].sum()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fixture_two_clusters():
+    """5 samples: indices {0,1,2} mutually entail; {3,4} mutually entail; cross = contradiction."""
+    N = 5
+    impl = np.full((N, N), NEUTRAL, dtype=int)
+    cluster_a = [0, 1, 2]
+    cluster_b = [3, 4]
+    for i in cluster_a:
+        for j in cluster_a:
+            if i != j:
+                impl[i, j] = ENTAILMENT
+    for i in cluster_b:
+        for j in cluster_b:
+            if i != j:
+                impl[i, j] = ENTAILMENT
+    for i in cluster_a:
+        for j in cluster_b:
+            impl[i, j] = CONTRADICTION
+            impl[j, i] = CONTRADICTION
+    return impl
+
+
+@pytest.fixture
+def fixture_mixed_loose_vs_strict():
+    """Pair that's `(entail, neutral)` — equivalent under loose, not under strict."""
+    N = 3
+    impl = np.full((N, N), NEUTRAL, dtype=int)
+    impl[0, 1] = ENTAILMENT
+    impl[1, 0] = NEUTRAL  # one-way only
+    impl[0, 2] = CONTRADICTION
+    impl[2, 0] = CONTRADICTION
+    impl[1, 2] = NEUTRAL
+    impl[2, 1] = NEUTRAL
+    return impl
+
+
+# --- clustering ---
+
+def test_clustering_matches_reference_loose(fixture_two_clusters):
+    impl = fixture_two_clusters
+    nli = make_nli_matrix_from_argmax(impl)
+
+    ours = ours_get_semantic_ids(nli, start_idx=0, end_idx=impl.shape[0], strict_entailment=False)
+    ref = ref_get_semantic_ids(list(range(impl.shape[0])), impl, strict_entailment=False)
+    assert ours == ref, f"loose clustering diverged: ours={ours} ref={ref}"
+    # Sanity: two clusters
+    assert len(set(ours)) == 2
+
+
+def test_clustering_matches_reference_strict(fixture_two_clusters):
+    impl = fixture_two_clusters
+    nli = make_nli_matrix_from_argmax(impl)
+
+    ours = ours_get_semantic_ids(nli, start_idx=0, end_idx=impl.shape[0], strict_entailment=True)
+    ref = ref_get_semantic_ids(list(range(impl.shape[0])), impl, strict_entailment=True)
+    assert ours == ref
+    assert len(set(ours)) == 2
+
+
+def test_strict_vs_loose_diverge_when_asymmetric(fixture_mixed_loose_vs_strict):
+    impl = fixture_mixed_loose_vs_strict
+    nli = make_nli_matrix_from_argmax(impl)
+    N = impl.shape[0]
+
+    loose_ours = ours_get_semantic_ids(nli, 0, N, strict_entailment=False)
+    strict_ours = ours_get_semantic_ids(nli, 0, N, strict_entailment=True)
+    loose_ref = ref_get_semantic_ids(list(range(N)), impl, strict_entailment=False)
+    strict_ref = ref_get_semantic_ids(list(range(N)), impl, strict_entailment=True)
+
+    assert loose_ours == loose_ref
+    assert strict_ours == strict_ref
+    assert loose_ours != strict_ours, "(entail, neutral) pair must split under strict"
+
+
+def test_clustering_start_idx_skips_greedy(fixture_two_clusters):
+    """SE skips index 0 (greedy answer). Ensure start_idx=1 produces ids over rows 1..N."""
+    impl = fixture_two_clusters
+    nli = make_nli_matrix_from_argmax(impl)
+    N = impl.shape[0]
+
+    ours_skip = ours_get_semantic_ids(nli, start_idx=1, end_idx=N, strict_entailment=False)
+    # Equivalent to running the reference over only rows 1..N-1
+    sub_impl = impl[1:, 1:]
+    ref_skip = ref_get_semantic_ids(list(range(N - 1)), sub_impl, strict_entailment=False)
+    assert ours_skip == ref_skip
+
+
+# --- aggregation ---
+
+def test_logsumexp_by_id_matches_reference():
+    rng = np.random.default_rng(0)
+    semantic_ids = [0, 0, 1, 2, 1, 2, 2]
+    log_probs = rng.uniform(-5.0, -0.1, size=len(semantic_ids)).tolist()
+
+    ours = ours_logsumexp_by_id(semantic_ids, log_probs)
+    ref = ref_logsumexp_by_id(semantic_ids, log_probs)
+
+    np.testing.assert_allclose(ours, ref, rtol=1e-8, atol=1e-10)
+
+
+# --- entropy estimators ---
+
+def test_predictive_entropy_rao_matches_reference():
+    rng = np.random.default_rng(1)
+    log_probs = (-np.abs(rng.standard_normal(5))).tolist()
+    np.testing.assert_allclose(
+        ours_predictive_entropy_rao(log_probs),
+        ref_predictive_entropy_rao(log_probs),
+        rtol=1e-12, atol=1e-12,
+    )
+
+
+def test_cluster_assignment_entropy_matches_reference():
+    ids = [0, 0, 1, 2, 2, 2]
+    np.testing.assert_allclose(
+        ours_cluster_entropy(ids),
+        ref_cluster_assignment_entropy(ids),
+        rtol=1e-12, atol=1e-12,
+    )
+
+
+# --- end-to-end per-record ---
+
+def test_compute_se_for_record_matches_reference_pipeline(fixture_two_clusters):
+    """End-to-end: cluster + logsumexp + rao matches the reference pipeline."""
+    impl = fixture_two_clusters
+    # 5 stochastic samples + a greedy at index 0. impl is 5x5; embed into 6x6 with greedy.
+    K = impl.shape[0]
+    N = K + 1
+    full_impl = np.full((N, N), NEUTRAL, dtype=int)
+    full_impl[1:, 1:] = impl
+    nli = make_nli_matrix_from_argmax(full_impl)
+
+    rng = np.random.default_rng(2)
+    seq_lp = (-np.abs(rng.standard_normal(K))).tolist()
+    len_lp = (-np.abs(rng.standard_normal(K))).tolist()
+
+    record = {
+        "row_idx": 7,
+        "K": K,
+        "samples": [
+            {"text": f"s{i}", "sequence_logprob": seq_lp[i], "length_normalized_logprob": len_lp[i]}
+            for i in range(K)
+        ],
+    }
+    out = compute_se_for_record(record, nli, strict_entailment=False)
+
+    # Reference pipeline applied to the same K samples (skipping the greedy):
+    ref_ids = ref_get_semantic_ids(list(range(K)), impl, strict_entailment=False)
+    ref_cluster_lp = ref_logsumexp_by_id(ref_ids, seq_lp)
+    expected_se = ref_predictive_entropy_rao(ref_cluster_lp)
+
+    np.testing.assert_allclose(out["semantic_entropy"], expected_se, rtol=1e-10, atol=1e-12)
+    assert out["n_clusters"] == len(set(ref_ids))
+    assert out["semantic_ids"] == ref_ids


### PR DESCRIPTION
## Summary

Closes the six methodology gaps between our Semantic Entropy implementation and the canonical reference [jlko/semantic_uncertainty](https://github.com/jlko/semantic_uncertainty) (by Jannik Kossen, co-author of both SE papers — Kuhn et al. 2023 ICLR and Farquhar et al. 2024 Nature). Detail and motivation in #49.

### Six alignment changes

| # | What | Before | After |
|---|---|---|---|
| 1 | NLI model | `cross-encoder/nli-deberta-v3-base` (~184M) | `microsoft/deberta-v2-xlarge-mnli` (~900M) |
| 2 | Text preprocessing | regex-strips "the answer is", "yes", etc. | none — matches reference |
| 3 | Bidirectional rule | `p_entail > 0.5` in both directions | reference's argmax rule with `strict`/`loose` modes via `--strict-entailment` |
| 4 | Clustering algorithm | representative-of-cluster matching | port of reference's `get_semantic_ids` (forward-scan greedy assignment) |
| 5 | Entropy headline | length-normalized variant | `predictive_entropy_rao` over `logsumexp_by_id(sum_normalized)` on raw `sequence_logprob` |
| 6 | Fidelity test | none | `tests/test_se_paper_fidelity.py` (8 tests, vendored reference functions) |

### Back-compat preserved

- `se_labels.jsonl` keeps the existing `length_normalized_se` and `discrete_se` keys — `compute_sep.py` (for SEP-SE training target) and existing analysis scripts continue to work unchanged.
- New `semantic_entropy` key is now the headline; `assemble_baseline_table.py` reports it alongside the legacy keys.
- SelfCheckGPT-NLI path (`compute_selfcheck.py`) is unaffected — it reads raw `P(contradict)` from the NLI matrix and doesn't depend on the clustering/entropy changes (only the NLI model swap, which is intended).

### What requires re-running

- **Phase 2 (NLI matrices)** — new NLI model produces different probabilities. ~1.6 GB checkpoint download on first run; ~5× slower than the previous DeBERTa-v3-base but still cheap vs. sampling.
- **Phase 3 (SE)** — CPU-only, seconds to re-run.
- Phase 1 (sampling) and SEP-binary unchanged.

## Test plan

- [x] `pytest tests/test_se_paper_fidelity.py -v` — 8/8 pass. Verifies clustering (loose + strict), aggregation, both entropy estimators, and end-to-end per-record pipeline match vendored reference functions bit-for-bit.
- [ ] Smoke B (GPU): re-run Phase 1 sampling + Phase 2 NLI on hotpotqa test 50-row smoke. Verifies new NLI model loads and `id2label` resolver still works.
- [ ] Smoke C (CPU): run Phase 3 SE + Phase 4 SelfCheckGPT against the smoke artifacts; confirm `se_labels.jsonl` has the new `semantic_entropy` key and downstream readers still parse it.

## Out of scope (separate follow-up)

- SEP-SE methodology fix (Ridge → binarized-SE + LogisticRegression, per earlier #49 discussion).
- SEP-binary drop / rename — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
