### PR TITLE
fix(#57): honor --seeds for llmsknow_probe via explicit `seeded` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ _memmap_cache/
 
 # Experiment run outputs
 runs/
+runs_archive/
 
 # Exploratory work (scratch notebooks, experiments)
 exploratory_work/
@@ -85,3 +86,6 @@ reports/smoketest_*/
 
 # Ephemeral sampling-baseline run outputs (cell/shard logs, fanout TSVs)
 reports/sampling_baselines_runs/
+
+# Ephemeral llmsknow_probe re-run outputs (shard logs, fanout TSVs)
+reports/llmsknow_probe_runs/

--- a/PAPER_ROADMAP.md
+++ b/PAPER_ROADMAP.md
@@ -1,6 +1,7 @@
 # Paper Roadmap — EMNLP Submission
 
-**Last updated:** 2026-05-12 (SAPLMA baseline added to grid; semantic-entropy item rescoped to a sampling-based baselines bundle — SE + SelfCheckGPT + SEP-SE + SEP-binary across 5–6 datasets, see #49)
+**Last updated:** 2026-05-14 (extended-metrics row scoped to AUPRC + ECE + FPR@95 + bootstrap 95% CIs as a pure-CPU recompute on existing `predictions.csv` — see #59; llmsknow_probe seed bug fixed in #58, archived seed=null runs and dispatched 5-seed re-runs across 3 GPU nodes)
+**Previously:** 2026-05-12 (SAPLMA baseline added to grid; semantic-entropy item rescoped to a sampling-based baselines bundle — SE + SelfCheckGPT + SEP-SE + SEP-binary across 5–6 datasets, see #49)
 **Target venue:** EMNLP 2026 (Main / Findings)
 **Submission window:** ~4 weeks from today
 **Status:** seed-0 sweep complete; multi-seed expansion + second-model + missing baselines in flight
@@ -40,7 +41,7 @@ If any of those clauses fails to hold up empirically, the framing changes — th
 | P(true) baseline | ❌ not started | Cheap; one extra prompt per example. Tracked in [#50](https://github.com/hyang0129/HalluLens/issues/50). Output-space only — does not need activation logging; can run concurrently with the seed sweeps. |
 | Sampling-based baselines bundle (SE + SelfCheckGPT + SEP-SE + SEP-binary) | ❌ not started | One K=10 sampling pass produces 4 baselines. 5 free-form datasets {HotpotQA, NQ, PopQA, SciQ, SearchQA} for SE/SelfCheckGPT/SEP-SE; 6 datasets for SEP-binary (MMLU added — SEP-binary is activation-space and survives the NLI-clustering degeneracy on letter tokens that excludes MMLU from SE/SelfCheckGPT). SearchQA capped 10k test / 5k train. SEP-SE trained on 5k stratified train subset (Kossen-faithful regression on SE labels); SEP-binary trained on full train split with binary hallu labels — free byproduct, apples-to-apples with linear probe. Tracked in [#49](https://github.com/hyang0129/HalluLens/issues/49). Sampling pass is output-space only — can run concurrently with the seed sweeps on a separate GPU. |
 | Cross-dataset transfer table | ❌ not started | Train→test pairs across datasets, no new training |
-| AUPRC, ECE, bootstrap 95% CIs | ❌ not started | Pure analysis; zero compute |
+| AUPRC, ECE, FPR@95, bootstrap 95% CIs | ❌ not started | Pure CPU recompute on existing `predictions.csv` (zero GPU). FPR@95 = standard operational detection metric (lower is better). Tracked in [#59](https://github.com/hyang0129/HalluLens/issues/59). |
 | Ablation: SimCLR-only vs +logprob-recon | ✅ tried | Unsupervised SimCLR features + linear probe on top → ~random guessing. Logprob-recon aux loss is load-bearing. Need to log the run + write it up; no further compute. |
 | Ablation: layer-pair sensitivity | ❌ not started | Reuses cached activations |
 | Paper draft | ❌ not started | Target ~16h student time; LaTeX from week 3 |

--- a/configs/methods/llmsknow_probe.json
+++ b/configs/methods/llmsknow_probe.json
@@ -1,6 +1,7 @@
 {
   "name": "llmsknow_probe",
   "routine": "llmsknow_probe",
+  "seeded": true,
   "data": {
     "relevant_layers": "14-29",
     "pad_length": 63,

--- a/scripts/experiment_status.py
+++ b/scripts/experiment_status.py
@@ -40,6 +40,7 @@ from scripts.experiment_utils import (
     classify_run,
     count_summary,
     enumerate_runs,
+    is_seeded_method,
     load_experiment_config,
 )
 
@@ -155,7 +156,9 @@ def _print_status_matrix(
         n_learned = sum(
             1
             for m in methods_seen
-            if experiment_cfg.get("method_configs", {}).get(m, {}).get("training") is not None
+            if is_seeded_method(
+                experiment_cfg.get("method_configs", {}).get(m, {})
+            )
         )
         n_non_learned = len(methods_seen) - n_learned
         total = (n_learned * len(seeds) + n_non_learned) * len(datasets_seen)

--- a/scripts/experiment_utils.py
+++ b/scripts/experiment_utils.py
@@ -27,7 +27,21 @@ class RunSpec:
     method_name: str
     seed: Optional[int]
     run_dir: str
-    is_learned: bool
+    is_learned: bool  # True if the method runs once per seed (has a training block OR seeded: true)
+
+
+def is_seeded_method(method_cfg: dict) -> bool:
+    """True iff the method should produce one run per seed.
+
+    A method is seeded if either:
+      - it has a ``training`` block (gradient-trained learned methods), or
+      - it sets ``seeded: true`` explicitly (e.g. sklearn-based probes whose
+        train/dev split and ``random_state`` depend on the seed but have no
+        gradient training block).
+    """
+    if method_cfg.get("training") is not None:
+        return True
+    return bool(method_cfg.get("seeded", False))
 
 
 def load_experiment_config(
@@ -92,8 +106,8 @@ def enumerate_runs(
     """Produce the full list of expected runs from an experiment config.
 
     Replicates the directory path construction from run_experiment.py:
-      - Learned methods (those with "training" in their config): one run per seed
-      - Non-learned methods: one run with seed=None
+      - Seeded methods (training block OR ``seeded: true``): one run per seed
+      - Non-seeded methods: one run with seed=None
       - Path: {output_base}/{exp_name}/{dataset}/{method}/seed_{seed}
               or {output_base}/{exp_name}/{dataset}/{method}
     """
@@ -114,7 +128,7 @@ def enumerate_runs(
     for dataset_name in datasets:
         for method_name in methods:
             method_cfg = method_configs.get(method_name, {})
-            is_learned = method_cfg.get("training") is not None
+            is_learned = is_seeded_method(method_cfg)
             seeds = training_seeds if is_learned else [None]
 
             for seed in seeds:

--- a/scripts/fanout_llmsknow_probe.py
+++ b/scripts/fanout_llmsknow_probe.py
@@ -1,0 +1,185 @@
+"""Fan out llmsknow_probe re-runs across Jupyter GPU nodes (issue #57 / PR #58).
+
+We split work by **(dataset, model) cache unit** — each unit is one
+``baseline_comparison_*.json`` experiment config. All 5 seeds for a unit
+run in the same ``run_experiment.py`` invocation so the preloaded
+activation memmap is shared across seeds (the dev-subset materialization
+is the heavy I/O step; splitting seeds across nodes would force each
+node to re-warm ~60 GB of cache per seed).
+
+Default plan: 12 cache units (6 datasets × 2 models) round-robin'd
+across 3 nodes → 4 units per node, each running 5 seeds serially.
+
+Usage::
+
+    # Dry-run to see the plan
+    python scripts/fanout_llmsknow_probe.py --dry-run \\
+        --nodes alphagpu01-8888,alphagpu03-8887,alphagpu04-8884
+
+    # Dispatch all three shards
+    python scripts/fanout_llmsknow_probe.py \\
+        --nodes alphagpu01-8888,alphagpu03-8887,alphagpu04-8884
+
+    # Only re-run Qwen3 results
+    python scripts/fanout_llmsknow_probe.py \\
+        --nodes alphagpu01-8888,alphagpu03-8887,alphagpu04-8884 \\
+        --models Qwen/Qwen3-8B
+
+Each shard writes its assigned units to
+``reports/llmsknow_probe_runs/fanout_<stamp>/units_<node>.tsv`` and is
+dispatched via ``gpu_dispatch.py run --jupyter --node <node>``.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Default 6 datasets × 2 models matches the shipped baseline_comparison_* configs.
+DEFAULT_DATASETS = ["hotpotqa", "mmlu", "nq", "popqa", "sciq", "searchqa"]
+DEFAULT_MODELS = ["meta-llama/Llama-3.1-8B-Instruct", "Qwen/Qwen3-8B"]
+
+# Map HF model id -> experiment-config suffix used by configs/experiments/baseline_comparison_<ds><suffix>.json
+MODEL_SUFFIX = {
+    "meta-llama/Llama-3.1-8B-Instruct": "",       # baseline_comparison_<ds>.json
+    "Qwen/Qwen3-8B": "_qwen3",                    # baseline_comparison_<ds>_qwen3.json
+}
+
+
+def build_units(datasets, models, project_root: Path):
+    """Return list of (label, experiment_config_path) tuples, validating each
+    config exists on disk."""
+    units = []
+    missing = []
+    for ds in datasets:
+        for model in models:
+            suffix = MODEL_SUFFIX.get(model)
+            if suffix is None:
+                raise ValueError(
+                    f"Unknown model {model!r}: extend MODEL_SUFFIX in "
+                    f"scripts/fanout_llmsknow_probe.py to map it to an experiment-config suffix."
+                )
+            cfg_path = project_root / "configs" / "experiments" / f"baseline_comparison_{ds}{suffix}.json"
+            label = f"{ds}/{model.split('/')[-1]}"
+            if not cfg_path.exists():
+                missing.append((label, cfg_path))
+                continue
+            units.append((label, str(cfg_path.relative_to(project_root))))
+    if missing:
+        for lbl, p in missing:
+            print(f"  WARNING: missing config for {lbl}: {p}", file=sys.stderr)
+    return units
+
+
+def assign_round_robin(units, nodes):
+    """Round-robin units across nodes. Returns {node: [(label, cfg_path), ...]}."""
+    bins = {n: [] for n in nodes}
+    for i, u in enumerate(units):
+        bins[nodes[i % len(nodes)]].append(u)
+    return bins
+
+
+def write_units_file(path: Path, units) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("# experiment_config_path  (one per line; comments start with #)\n")
+        for label, cfg in units:
+            f.write(f"{cfg}\t# {label}\n")
+
+
+def dispatch_shard(node: str, units_file: Path, seeds: str, dry_run: bool) -> str:
+    cmd = [
+        "python", "scripts/gpu_dispatch.py", "run",
+        "--jupyter", "--node", node,
+        "--",
+        "env", f"UNITS_FILE={units_file}", f"SEEDS={seeds}",
+        "bash", "scripts/run_llmsknow_probe_shard.sh",
+    ]
+    if dry_run:
+        print(f"  [dry-run] {' '.join(cmd)}")
+        return ""
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if out.returncode != 0:
+        print(f"  FAILED ({node}): {out.stderr}", file=sys.stderr)
+        return ""
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("Job ID:"):
+            return line.split(":", 1)[1].strip()
+    print(f"  WARNING ({node}): dispatched but no job id found", file=sys.stderr)
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--datasets", default=",".join(DEFAULT_DATASETS),
+                        help=f"Comma-separated datasets (default: {','.join(DEFAULT_DATASETS)})")
+    parser.add_argument("--models", default=",".join(DEFAULT_MODELS),
+                        help=f"Comma-separated HF model ids (default: {','.join(DEFAULT_MODELS)})")
+    parser.add_argument("--nodes", required=True,
+                        help="Comma-separated jupyter node names (e.g. alphagpu01-8888,alphagpu03-8887,alphagpu04-8884)")
+    parser.add_argument("--seeds", default="0,1,2,3,4",
+                        help="Comma-separated training seeds (default: 0,1,2,3,4)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the plan and exit without dispatching")
+    args = parser.parse_args()
+
+    project_root = Path(__file__).parent.parent
+
+    datasets = [s.strip() for s in args.datasets.split(",") if s.strip()]
+    models = [s.strip() for s in args.models.split(",") if s.strip()]
+    nodes = [s.strip() for s in args.nodes.split(",") if s.strip()]
+
+    units = build_units(datasets, models, project_root)
+    if not units:
+        print("No units to dispatch (all configs missing?).", file=sys.stderr)
+        sys.exit(1)
+    bins = assign_round_robin(units, nodes)
+
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    fanout_dir = project_root / "reports" / "llmsknow_probe_runs" / f"fanout_{stamp}"
+
+    print(f"Units: {len(units)} | Nodes: {len(nodes)} | Seeds: {args.seeds} | Stamp: {stamp}")
+    print(f"Cache-unit granularity: (dataset, model) — all seeds share preloaded activation cache.\n")
+    for n, nunits in bins.items():
+        print(f"  {n}: {len(nunits)} units")
+        for label, _ in nunits:
+            print(f"    - {label}")
+    print()
+
+    job_ids = []
+    for node, nunits in bins.items():
+        if not nunits:
+            continue
+        units_file = fanout_dir / f"units_{node}.tsv"
+        write_units_file(units_file, nunits)
+        jid = dispatch_shard(node, units_file, args.seeds, dry_run=args.dry_run)
+        if jid:
+            job_ids.append((jid, node, units_file, len(nunits)))
+
+    if args.dry_run:
+        print(f"\nDRY-RUN. Would have written shard files in {fanout_dir} and dispatched {len(bins)} shard jobs.")
+        return
+
+    if job_ids:
+        manifest = fanout_dir / "dispatch.txt"
+        with open(manifest, "w") as f:
+            f.write(f"# fanout dispatch {stamp}\n")
+            for jid, node, cf, n in job_ids:
+                f.write(f"{jid}\t{node}\t{n}\t{cf}\n")
+        print(f"\nDispatched {len(job_ids)}/{len(bins)} shards.")
+        for jid, node, _, n in job_ids:
+            print(f"  {jid}  {node}  ({n} units)")
+        print(f"\nManifest: {manifest}")
+        print(f"\nMonitor:")
+        print(f"  python scripts/gpu_dispatch.py jobs")
+        print(f"  tail -f reports/llmsknow_probe_runs/shard_*.log")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fanout_llmsknow_probe.py
+++ b/scripts/fanout_llmsknow_probe.py
@@ -90,9 +90,12 @@ def write_units_file(path: Path, units) -> None:
 
 
 def dispatch_shard(node: str, units_file: Path, seeds: str, dry_run: bool) -> str:
+    # --force-concurrent: llmsknow_probe is CPU-only (sklearn LR + numpy memmap),
+    # so it's safe to co-tenant with an already-running GPU-bound job on the
+    # same slot. The default max_concurrent_jobs=1 guard would otherwise block.
     cmd = [
         "python", "scripts/gpu_dispatch.py", "run",
-        "--jupyter", "--node", node,
+        "--jupyter", "--node", node, "--force-concurrent",
         "--",
         "env", f"UNITS_FILE={units_file}", f"SEEDS={seeds}",
         "bash", "scripts/run_llmsknow_probe_shard.sh",

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2032,10 +2032,12 @@ def main() -> None:
                     method_cfg["training"] = dict(method_cfg["training"])
                     method_cfg["training"]["max_epochs"] = max_epochs_override
 
-                is_learned = method_cfg.get("training") is not None
+                from scripts.experiment_utils import is_seeded_method
+
+                is_learned = is_seeded_method(method_cfg)
 
                 if not is_learned:
-                    # Non-learned methods run exactly once across the entire seed sweep.
+                    # Non-seeded methods run exactly once across the entire seed sweep.
                     if method_name in completed_nonlearned:
                         continue
                     effective_seed = None

--- a/scripts/run_llmsknow_probe_shard.sh
+++ b/scripts/run_llmsknow_probe_shard.sh
@@ -43,7 +43,10 @@ echo "============================================" | tee -a "$SHARD_LOG"
 
 FAILED_UNITS=()
 i=0
-while IFS=$'\t' read -r experiment_cfg; do
+# TSV format (written by scripts/fanout_llmsknow_probe.py):
+#   <experiment_config_path>\t# <human-readable label>
+# Split on TAB so the trailing label comment goes into the (ignored) second field.
+while IFS=$'\t' read -r experiment_cfg _label_comment; do
     case "$experiment_cfg" in ''|\#*) continue ;; esac
     i=$((i+1))
     unit_name=$(basename "$experiment_cfg" .json)

--- a/scripts/run_llmsknow_probe_shard.sh
+++ b/scripts/run_llmsknow_probe_shard.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Run a shard of llmsknow_probe re-runs sequentially on one GPU node.
+#
+# Each "unit" in the shard is one (dataset, model) cache unit — i.e. one
+# baseline_comparison_*.json experiment config. We invoke run_experiment.py
+# once per unit with --methods llmsknow_probe --seeds 0,1,2,3,4 so all five
+# seeds share the in-memory activation cache (the dev-subset materialization
+# is the heavy I/O step; reloading per seed wastes ~10-30 min/dataset).
+#
+# Units are read from $UNITS_FILE (TSV: experiment_config_path per line).
+# Each unit is fully resumable via run_experiment.py's own seed_N/eval_metrics
+# resume logic; failures within a unit don't lose progress on other seeds.
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+: "${UNITS_FILE:?UNITS_FILE env var required (TSV: experiment_config_path)}"
+if [[ ! -f "$UNITS_FILE" ]]; then
+    echo "ERROR: units file not found: $UNITS_FILE" >&2
+    exit 1
+fi
+
+SEEDS="${SEEDS:-0,1,2,3,4}"
+METHODS="${METHODS:-llmsknow_probe}"
+DEVICE="${DEVICE:-cuda}"
+
+LOG_DIR=reports/llmsknow_probe_runs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+SHARD_LOG="$LOG_DIR/shard_${STAMP}.log"
+
+N_UNITS=$(grep -cv '^\s*\(#.*\)\?$' "$UNITS_FILE" || echo 0)
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+echo "============================================" | tee "$SHARD_LOG"
+echo "llmsknow_probe shard"                          | tee -a "$SHARD_LOG"
+echo "Started: $(date) | Host: $(hostname)"          | tee -a "$SHARD_LOG"
+echo "Units:   $N_UNITS (from $UNITS_FILE)"          | tee -a "$SHARD_LOG"
+echo "Seeds:   $SEEDS"                               | tee -a "$SHARD_LOG"
+echo "Methods: $METHODS"                             | tee -a "$SHARD_LOG"
+echo "Device:  $DEVICE"                              | tee -a "$SHARD_LOG"
+echo "Log:     $SHARD_LOG"                           | tee -a "$SHARD_LOG"
+echo "============================================" | tee -a "$SHARD_LOG"
+
+FAILED_UNITS=()
+i=0
+while IFS=$'\t' read -r experiment_cfg; do
+    case "$experiment_cfg" in ''|\#*) continue ;; esac
+    i=$((i+1))
+    unit_name=$(basename "$experiment_cfg" .json)
+    echo                                              | tee -a "$SHARD_LOG"
+    echo ">>> [$i/$N_UNITS] $unit_name"               | tee -a "$SHARD_LOG"
+    echo "    started: $(date)"                       | tee -a "$SHARD_LOG"
+    if $PYTHON scripts/run_experiment.py \
+            --experiment "$experiment_cfg" \
+            --methods "$METHODS" \
+            --seeds "$SEEDS" \
+            --device "$DEVICE" 2>&1 | tee -a "$SHARD_LOG"; then
+        echo "    OK"                                 | tee -a "$SHARD_LOG"
+    else
+        rc=${PIPESTATUS[0]}
+        echo "    FAILED (exit=$rc) — continuing with next unit" | tee -a "$SHARD_LOG"
+        FAILED_UNITS+=("$unit_name")
+    fi
+done < "$UNITS_FILE"
+
+echo                                                  | tee -a "$SHARD_LOG"
+echo "============================================" | tee -a "$SHARD_LOG"
+echo "Shard DONE: $(date)"                            | tee -a "$SHARD_LOG"
+if [[ ${#FAILED_UNITS[@]} -gt 0 ]]; then
+    echo "Failed units (${#FAILED_UNITS[@]}):"        | tee -a "$SHARD_LOG"
+    printf '  %s\n' "${FAILED_UNITS[@]}"              | tee -a "$SHARD_LOG"
+    exit 1
+fi
+echo "All $i units succeeded."                        | tee -a "$SHARD_LOG"

--- a/tests/test_experiment_seeded_flag.py
+++ b/tests/test_experiment_seeded_flag.py
@@ -1,0 +1,139 @@
+"""Tests for the ``seeded`` flag plumbing (issue #57).
+
+Methods like ``llmsknow_probe`` have no ``training`` block but still produce
+seed-dependent results (sklearn train/dev split, LogisticRegression
+``random_state``). They must therefore be iterated across ``training_seeds``
+the same way gradient-trained learned methods are. The runner gates this on
+:func:`scripts.experiment_utils.is_seeded_method`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.experiment_utils import (
+    RunSpec,
+    enumerate_runs,
+    is_seeded_method,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_seeded_method
+# ---------------------------------------------------------------------------
+
+
+def test_is_seeded_method_training_block():
+    assert is_seeded_method({"training": {"max_epochs": 10}}) is True
+
+
+def test_is_seeded_method_explicit_flag():
+    assert is_seeded_method({"seeded": True}) is True
+
+
+def test_is_seeded_method_no_training_no_flag():
+    assert is_seeded_method({"sweep": {"dev_size": 2000}}) is False
+
+
+def test_is_seeded_method_explicit_false_flag():
+    assert is_seeded_method({"seeded": False}) is False
+
+
+def test_is_seeded_method_training_block_with_falsey_seeded():
+    # A method with training is always seeded, even if seeded: false sneaks in.
+    assert is_seeded_method({"training": {"lr": 1.0}, "seeded": False}) is True
+
+
+def test_is_seeded_method_empty():
+    assert is_seeded_method({}) is False
+
+
+# ---------------------------------------------------------------------------
+# enumerate_runs respects the flag (regression for issue #57)
+# ---------------------------------------------------------------------------
+
+
+def _exp_cfg(method_configs):
+    return {
+        "experiment_name": "test_exp",
+        "datasets": ["hotpotqa"],
+        "methods": list(method_configs.keys()),
+        "training_seeds": [0, 1, 2, 3, 4],
+        "output_dir": "runs",
+        "method_configs": method_configs,
+    }
+
+
+def test_enumerate_runs_seeded_flag_produces_one_run_per_seed():
+    """Method with seeded:true but no training block must produce one run per seed."""
+    cfg = _exp_cfg({"llmsknow_probe": {"name": "llmsknow_probe", "seeded": True}})
+    specs = enumerate_runs(cfg, output_base="runs")
+
+    seeds_seen = sorted(s.seed for s in specs)
+    assert seeds_seen == [0, 1, 2, 3, 4]
+    for s in specs:
+        assert s.is_learned is True
+        assert s.method_name == "llmsknow_probe"
+        # Path must include a seed_{n} segment
+        assert s.run_dir.endswith(f"seed_{s.seed}")
+
+
+def test_enumerate_runs_unflagged_non_training_method_runs_once():
+    """A method with neither training nor seeded:true still runs once with seed=None."""
+    cfg = _exp_cfg({"token_entropy": {"name": "token_entropy"}})
+    specs = enumerate_runs(cfg, output_base="runs")
+
+    assert len(specs) == 1
+    assert specs[0].seed is None
+    assert specs[0].is_learned is False
+    # No seed_ segment in the path
+    assert "/seed_" not in specs[0].run_dir.replace("\\", "/")
+
+
+def test_enumerate_runs_training_block_unchanged():
+    """Regression guard: methods with a training block still produce one run per seed."""
+    cfg = _exp_cfg({"linear_probe": {"name": "linear_probe", "training": {"lr": 1e-3}}})
+    specs = enumerate_runs(cfg, output_base="runs")
+
+    assert sorted(s.seed for s in specs) == [0, 1, 2, 3, 4]
+    assert all(s.is_learned for s in specs)
+
+
+def test_enumerate_runs_mixed_methods():
+    """A realistic mix: one training-based, one seeded-flag, one neither."""
+    cfg = _exp_cfg({
+        "linear_probe": {"name": "linear_probe", "training": {"lr": 1e-3}},
+        "llmsknow_probe": {"name": "llmsknow_probe", "seeded": True},
+        "token_entropy": {"name": "token_entropy"},
+    })
+    specs = enumerate_runs(cfg, output_base="runs")
+
+    by_method = {}
+    for s in specs:
+        by_method.setdefault(s.method_name, []).append(s)
+
+    assert len(by_method["linear_probe"]) == 5
+    assert len(by_method["llmsknow_probe"]) == 5
+    assert len(by_method["token_entropy"]) == 1
+    assert by_method["token_entropy"][0].seed is None
+
+
+# ---------------------------------------------------------------------------
+# Checked-in config: llmsknow_probe.json must carry the flag.
+# ---------------------------------------------------------------------------
+
+
+def test_llmsknow_probe_config_has_seeded_flag():
+    """The shipped llmsknow_probe.json must declare seeded:true so all
+    historical and future experiments produce per-seed probes (issue #57)."""
+    repo_root = Path(__file__).parent.parent
+    cfg_path = repo_root / "configs" / "methods" / "llmsknow_probe.json"
+    with cfg_path.open() as f:
+        cfg = json.load(f)
+    assert cfg.get("seeded") is True, (
+        "llmsknow_probe.json must set 'seeded: true' — without it the runner "
+        "treats the method as non-learned and runs a single seed=None probe."
+    )


### PR DESCRIPTION
## Summary

Closes #57.

- `llmsknow_probe` was being run once with `seed=None` across all 12 dataset/model combinations because the runner gated seed-iteration on the presence of a `training` block, which this sklearn-based probe doesn't have.
- Introduces `is_seeded_method(method_cfg)` in [scripts/experiment_utils.py](scripts/experiment_utils.py) — a method is seeded if it has a `training` block **or** declares `seeded: true`.
- Sets `seeded: true` in [configs/methods/llmsknow_probe.json](configs/methods/llmsknow_probe.json) so every shipped baseline experiment now produces 5 distinct probes per dataset.
- Wires the helper through [run_experiment.py](scripts/run_experiment.py#L2035) (main loop) and [experiment_status.py](scripts/experiment_status.py#L158) (expected-run count).

This is **Option A** from the issue (preferred): an explicit flag rather than a misleading empty `training: {}` stub.

## Why this matters

The three seed-dependent random sources inside `llmsknow_probe` —
`ActivationParser` train/test split, `StratifiedShuffleSplit` dev/val
subsampling, and `LogisticRegression(random_state=…)` — should produce
five meaningfully different probes. Without this fix the 12
`dataset × model` combinations have no error bars to compare against the
seeded saplma / linear_probe baselines.

## Verification

```text
$ python -c 'from scripts.experiment_utils import load_experiment_config, enumerate_runs; ...'
training_seeds: [0, 1, 2, 3, 4]
  contrastive_logprob_recon: seeds=[0, 1, 2, 3, 4]
  linear_probe:              seeds=[0, 1, 2, 3, 4]
  saplma:                    seeds=[0, 1, 2, 3, 4]
  llmsknow_probe:            seeds=[0, 1, 2, 3, 4]   # was [None] before this PR
  token_entropy:             seeds=[None]
  logprob_baseline:          seeds=[None]
```

## Test plan

- [x] `pytest tests/test_experiment_seeded_flag.py` — 11/11 pass (helper edge cases, mixed-method enumeration, shipped-config guard).
- [x] `pytest tests/test_se_paper_fidelity.py` — 8/8 still pass (regression guard).
- [ ] Re-dispatch `baseline_comparison_*` experiments; verify 5 `seed_{0..4}` directories appear under each `runs/.../llmsknow_probe/`.
- [ ] Aggregate results show error bars for `llmsknow_probe` alongside `saplma` / `linear_probe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)