### PR TITLE
feat(#50): P(true) self-evaluation baseline (Kadavath et al. 2022)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,10 @@ reports/sampling_baselines_runs/
 
 # Ephemeral llmsknow_probe re-run outputs (shard logs, fanout TSVs)
 reports/llmsknow_probe_runs/
+
+# Generated experiment-coverage markdown (from scripts/audit_coverage.py)
+reports/experiment_coverage_*.md
+
+# SLURM time-left in nodes.json is auto-refreshed by gpu_dispatch.py
+# sync-jupyter and constantly dirties the working tree.
+configs/nodes.json

--- a/scripts/assemble_baseline_table.py
+++ b/scripts/assemble_baseline_table.py
@@ -1,16 +1,19 @@
-"""Phase 6: Assemble AUROC table and compute-matched figure.
+"""Assemble the compute-matched AUROC figure (and optional P(true) bootstrap CIs).
 
-Reads all score files, aligns by row_idx, computes AUROC vs binary hallu label,
-outputs CSV + PDF figure.
+AUROC numbers come from `output/results_table/results_table.json` — produced
+by `scripts/results_table.py`. This script no longer re-computes AUROC; it
+only renders the matplotlib figure and (optionally) bootstrap CIs from the
+raw P(true) score files.
 
 Usage:
-    python scripts/assemble_baseline_table.py \\
-        --models meta-llama/Llama-3.1-8B-Instruct Qwen/Qwen3-8B \\
-        --output-dir output/baseline_results
+    # Make the figure (reads results_table.json):
+    python scripts/results_table.py
+    python scripts/assemble_baseline_table.py
 
-    # Llama only
+    # Custom output dir + bootstrap CIs for P(true):
     python scripts/assemble_baseline_table.py \\
-        --models meta-llama/Llama-3.1-8B-Instruct
+        --output-dir output/baseline_results \\
+        --with-ci
 """
 import argparse
 import json
@@ -19,10 +22,10 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-import pandas as pd
 from sklearn.metrics import roc_auc_score
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
 
 from tasks.p_true.paths import ptrue_scores_path
 from tasks.sampling_baselines.paths import (
@@ -31,76 +34,131 @@ from tasks.sampling_baselines.paths import (
     SAMPLING_DATASETS,
     eval_results_json,
     model_name,
-    nli_matrix_path,
-    se_labels_path,
-    selfcheck_samples_path,
-    selfcheck_scores_path,
-    sep_results_path,
-    searchqa_test_cap_path,
 )
 
+DEFAULT_RESULTS_JSON = PROJECT_ROOT / "output" / "results_table" / "results_table.json"
+
 
 # ---------------------------------------------------------------------------
-# Score loading helpers
+# Results-table loader: turn long-form cells into a {(dataset, model): {col: auroc}} view
 # ---------------------------------------------------------------------------
 
-def load_jsonl_by_row(path: str) -> dict:
-    """Load jsonl into {row_idx: record} dict."""
-    by_row = {}
-    p = Path(path)
-    if not p.exists():
-        return by_row
-    with open(p) as f:
-        for line in f:
-            try:
-                rec = json.loads(line)
-                by_row[rec["row_idx"]] = rec
-            except Exception:
-                pass
-    return by_row
+# Mapping from results_table method names to the figure's column names.
+_FIGURE_COLUMNS = {
+    ("sampling", "se_length_normalized"):  "se_length_normalized",
+    ("sampling", "selfcheck_nli"):         "selfcheck_nli",
+    ("sep", "sep"):                        "sep_se_auroc",
+}
 
 
-def load_hallu_labels(dataset: str, model_id: str, split: str = "test") -> Optional[np.ndarray]:
-    eval_path = eval_results_json(dataset, model_id, split)
-    if not eval_path.exists():
-        return None
-    with open(eval_path) as f:
-        data = json.load(f)
-    return np.array(data["halu_test_res"], dtype=int)
+def load_figure_table(results_json: Path) -> list[dict]:
+    """Pivot the long-form cells into one row per (dataset, model)."""
+    with open(results_json) as f:
+        payload = json.load(f)
+
+    pivot: dict[tuple[str, str], dict[str, float]] = {}
+    for cell in payload["cells"]:
+        col = _FIGURE_COLUMNS.get((cell["kind"], cell["key"]["method"]))
+        if col is None or cell["status"] != "complete":
+            continue
+        key = (cell["key"]["dataset"], cell["key"]["model"])
+        metric_key = "sep_se_auroc" if cell["kind"] == "sep" else "auroc"
+        v = cell["metrics"].get(metric_key)
+        if v is None:
+            continue
+        pivot.setdefault(key, {})[col] = v
+
+    rows = []
+    for (ds, m), cols in pivot.items():
+        rows.append({"dataset": ds, "model": m, **cols})
+    return rows
 
 
-def load_cap_indices(dataset: str, model_id: str) -> Optional[set]:
-    if dataset != "searchqa":
-        return None
-    cap_path = searchqa_test_cap_path(model_id)
-    if not cap_path.exists():
-        return None
-    with open(cap_path) as f:
-        return set(json.load(f)["question_ids"])
+# ---------------------------------------------------------------------------
+# Figure
+# ---------------------------------------------------------------------------
+
+def make_compute_matched_figure(table: list[dict], output_path: Path) -> None:
+    """One panel per dataset; x=forward-pass count, y=AUROC."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("matplotlib not installed — skipping figure.")
+        return
+
+    all_datasets = [d for d in SAMPLING_DATASETS] + ["mmlu"]
+
+    n_cols = 3
+    n_rows = (len(all_datasets) + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 4 * n_rows), squeeze=False)
+
+    method_style = {
+        "SEP-SE (K=1)":            dict(K=1,  marker="s", color="tab:purple", col="sep_se_auroc"),
+        "SelfCheckGPT-NLI (K=10)": dict(K=10, marker="o", color="tab:blue",   col="selfcheck_nli"),
+        "SE length-norm (K=10)":   dict(K=10, marker="^", color="tab:green",  col="se_length_normalized"),
+    }
+
+    for ax_idx, ds in enumerate(all_datasets):
+        row, col = divmod(ax_idx, n_cols)
+        ax = axes[row][col]
+        ds_rows = [r for r in table if r["dataset"] == ds]
+
+        for label, style in method_style.items():
+            for row_data in ds_rows:
+                val = row_data.get(style["col"])
+                if val is None or not np.isfinite(val):
+                    continue
+                ax.scatter(
+                    style["K"], val,
+                    label=f"{label} ({row_data['model']})",
+                    marker=style["marker"], color=style["color"], s=80, zorder=3,
+                )
+
+        ax.set_title(ds, fontsize=11)
+        ax.set_xlabel("Forward passes at test time")
+        ax.set_ylabel("AUROC")
+        ax.set_xlim(0, 12)
+        ax.set_ylim(0.4, 1.0)
+        ax.axhline(0.5, color="gray", linestyle="--", linewidth=0.8)
+        ax.legend(fontsize=7, loc="lower right")
+
+    # Hide unused panels
+    for ax_idx in range(len(all_datasets), n_rows * n_cols):
+        r, c = divmod(ax_idx, n_cols)
+        axes[r][c].set_visible(False)
+
+    fig.suptitle("Compute-matched AUROC comparison", fontsize=13)
+    fig.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    print(f"Figure saved → {output_path}")
+    plt.close(fig)
 
 
-def safe_auroc(scores: list, labels: list) -> Optional[float]:
-    if len(scores) < 10:
-        return None
-    y = np.array(labels, dtype=int)
-    s = np.array(scores, dtype=float)
+# ---------------------------------------------------------------------------
+# Bootstrap CIs (P(true) only — uses raw scores, not the results table)
+# ---------------------------------------------------------------------------
+
+def _safe_auroc(scores, labels) -> Optional[float]:
+    s, y = np.asarray(scores, dtype=float), np.asarray(labels, dtype=int)
     mask = np.isfinite(s)
-    if mask.sum() < 10 or len(np.unique(y[mask])) < 2:
+    s, y = s[mask], y[mask]
+    if len(s) < 10 or len(np.unique(y)) < 2:
         return None
     try:
-        return float(roc_auc_score(y[mask], s[mask]))
+        return float(roc_auc_score(y, s))
     except Exception:
         return None
 
 
-def bootstrap_auroc(scores: list, labels: list, n: int = 1000, seed: int = 42) -> Optional[tuple]:
+def _bootstrap_auroc(scores, labels, n: int = 1000, seed: int = 42):
     """Return (lo, hi) 95% bootstrap CI on AUROC, or None if not computable."""
-    base = safe_auroc(scores, labels)
+    base = _safe_auroc(scores, labels)
     if base is None:
         return None
     rng = np.random.default_rng(seed)
-    y = np.array(labels, dtype=int)
-    s = np.array(scores, dtype=float)
+    y = np.asarray(labels, dtype=int)
+    s = np.asarray(scores, dtype=float)
     mask = np.isfinite(s)
     y, s = y[mask], s[mask]
     aucs = []
@@ -118,178 +176,7 @@ def bootstrap_auroc(scores: list, labels: list, n: int = 1000, seed: int = 42) -
     return (float(np.percentile(aucs, 2.5)), float(np.percentile(aucs, 97.5)))
 
 
-# ---------------------------------------------------------------------------
-# Per-dataset scorer
-# ---------------------------------------------------------------------------
-
-def compute_dataset_aurocs(dataset: str, model_id: str) -> dict:
-    """Return dict of {method: auroc} for one (dataset, model) cell."""
-    result = {"dataset": dataset, "model": model_name(model_id)}
-
-    labels_all = load_hallu_labels(dataset, model_id, "test")
-    if labels_all is None:
-        return result
-
-    cap_indices = load_cap_indices(dataset, model_id)
-
-    def get_aligned(by_row: dict, score_key: str):
-        """Extract (scores, labels) aligned by row_idx, respecting cap."""
-        scores, lbls = [], []
-        for row_idx, rec in sorted(by_row.items()):
-            if cap_indices is not None and row_idx not in cap_indices:
-                continue
-            if row_idx >= len(labels_all):
-                continue
-            val = rec.get(score_key)
-            if val is None or (isinstance(val, float) and not np.isfinite(val)):
-                continue
-            scores.append(val)
-            lbls.append(labels_all[row_idx])
-        return scores, lbls
-
-    # SE — headline is `semantic_entropy` (rao over logsumexp_by_id, raw sequence_logprob).
-    # length-normalized and discrete kept as auxiliary metrics.
-    if dataset in SAMPLING_DATASETS:
-        se_by_row = load_jsonl_by_row(str(se_labels_path(dataset, model_id, "test")))
-        scores, lbls = get_aligned(se_by_row, "semantic_entropy")
-        result["semantic_entropy"] = safe_auroc(scores, lbls)
-
-        scores, lbls = get_aligned(se_by_row, "length_normalized_se")
-        result["se_length_normalized"] = safe_auroc(scores, lbls)
-
-        scores, lbls = get_aligned(se_by_row, "discrete_se")
-        result["se_discrete"] = safe_auroc(scores, lbls)
-
-        # SelfCheckGPT
-        sc_by_row = load_jsonl_by_row(str(selfcheck_scores_path(dataset, model_id, "test")))
-        for key in ("nli", "bertscore", "ngram"):
-            scores, lbls = get_aligned(sc_by_row, key)
-            result[f"selfcheck_{key}"] = safe_auroc(scores, lbls)
-
-    # SEP
-    sep_path = sep_results_path(dataset, model_id)
-    if sep_path.exists():
-        with open(sep_path) as f:
-            sep_data = json.load(f)
-        result["sep_se_auroc"] = sep_data.get("sep_se_auroc")
-        result["sep_layer"] = sep_data.get("layer")
-        result["sep_se_n_train"] = sep_data.get("train_size_sep_se")
-
-    # P(true) — score direction: 1 - p_true (high p_true ⇒ correct ⇒ low halu score)
-    pt_path = ptrue_scores_path(dataset, model_id, "test")
-    if pt_path.exists():
-        pt_by_row = load_jsonl_by_row(str(pt_path))
-        # P(true) runs on all rows (no cap), so cap_indices is irrelevant here.
-        scores_fwd, lbls_fwd = [], []
-        scores_rev, lbls_rev = [], []
-        for row_idx, rec in sorted(pt_by_row.items()):
-            if row_idx >= len(labels_all):
-                continue
-            lbl = labels_all[row_idx]
-            if (v := rec.get("p_true")) is not None and np.isfinite(v):
-                scores_fwd.append(1.0 - v)
-                lbls_fwd.append(lbl)
-            if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
-                scores_rev.append(1.0 - v)
-                lbls_rev.append(lbl)
-        auroc_fwd = safe_auroc(scores_fwd, lbls_fwd)
-        auroc_rev = safe_auroc(scores_rev, lbls_rev)
-        result["p_true_auroc_fwd"] = auroc_fwd
-        result["p_true_auroc_rev"] = auroc_rev
-        # Headline: max over forward / reversed (token-position-bias correction)
-        if auroc_fwd is not None and auroc_rev is not None:
-            result["p_true"] = max(auroc_fwd, auroc_rev)
-        elif auroc_fwd is not None:
-            result["p_true"] = auroc_fwd
-        else:
-            result["p_true"] = auroc_rev
-
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Figure
-# ---------------------------------------------------------------------------
-
-def make_compute_matched_figure(table: pd.DataFrame, output_path: str) -> None:
-    """One panel per dataset; x=forward-pass count, y=AUROC."""
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        print("matplotlib not installed — skipping figure.")
-        return
-
-    free_form = [d for d in SAMPLING_DATASETS if d != "mmlu"]
-    all_datasets = free_form + ["mmlu"]
-
-    n_cols = 3
-    n_rows = (len(all_datasets) + n_cols - 1) // n_cols
-    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 4 * n_rows), squeeze=False)
-
-    method_style = {
-        "Our contrastive (K=1)": dict(K=1, marker="*", color="tab:red", linestyle="none"),
-        "SEP-SE (K=1)": dict(K=1, marker="s", color="tab:purple", linestyle="none"),
-        "SelfCheckGPT-NLI (K=10)": dict(K=10, marker="o", color="tab:blue", linestyle="none"),
-        "SE length-norm (K=10)": dict(K=10, marker="^", color="tab:green", linestyle="none"),
-    }
-
-    col_map = {
-        "SEP-SE (K=1)": "sep_se_auroc",
-        "SelfCheckGPT-NLI (K=10)": "selfcheck_nli",
-        "SE length-norm (K=10)": "se_length_normalized",
-    }
-
-    for ax_idx, ds in enumerate(all_datasets):
-        row, col = divmod(ax_idx, n_cols)
-        ax = axes[row][col]
-        ds_rows = table[table["dataset"] == ds]
-
-        for label, style in method_style.items():
-            if label == "Our contrastive (K=1)":
-                continue  # placeholder — no data yet in this table
-            col_key = col_map.get(label)
-            if col_key is None or col_key not in ds_rows.columns:
-                continue
-            for _, row_data in ds_rows.iterrows():
-                val = row_data.get(col_key)
-                if val is not None and np.isfinite(val):
-                    ax.scatter(
-                        style["K"],
-                        val,
-                        label=f"{label} ({model_name(row_data['model'])})",
-                        marker=style["marker"],
-                        color=style["color"],
-                        s=80,
-                        zorder=3,
-                    )
-
-        ax.set_title(ds, fontsize=11)
-        ax.set_xlabel("Forward passes at test time")
-        ax.set_ylabel("AUROC")
-        ax.set_xlim(0, 12)
-        ax.set_ylim(0.4, 1.0)
-        ax.axhline(0.5, color="gray", linestyle="--", linewidth=0.8)
-        ax.legend(fontsize=7, loc="lower right")
-
-    # Hide unused panels
-    for ax_idx in range(len(all_datasets), n_rows * n_cols):
-        r, c = divmod(ax_idx, n_cols)
-        axes[r][c].set_visible(False)
-
-    fig.suptitle("Compute-matched AUROC comparison", fontsize=13)
-    fig.tight_layout()
-    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-    fig.savefig(output_path, dpi=150, bbox_inches="tight")
-    print(f"Figure saved → {output_path}")
-    plt.close(fig)
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
 def _write_ptrue_bootstrap_ci(models, datasets, out_dir: Path) -> None:
-    """Compute and save bootstrap 95% CIs for P(true) AUROC across all cells."""
     print("\nComputing P(true) bootstrap CIs (1000 resamples)...")
     ci_results = []
     for mid in models:
@@ -306,87 +193,79 @@ def _write_ptrue_bootstrap_ci(models, datasets, out_dir: Path) -> None:
                     labels_cache[ds] = np.array(json.load(f)["halu_test_res"], dtype=int)
             labels_all = labels_cache[ds]
 
-            pt_by_row = load_jsonl_by_row(str(pt_path))
-            scores_fwd, lbls = [], []
-            scores_rev = []
-            for row_idx, rec in sorted(pt_by_row.items()):
-                if row_idx >= len(labels_all):
-                    continue
-                lbl = labels_all[row_idx]
-                if (v := rec.get("p_true")) is not None and np.isfinite(v):
-                    scores_fwd.append(1.0 - v)
-                    lbls.append(lbl)
-                if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
-                    scores_rev.append(1.0 - v)
+            scores_fwd, lbls, scores_rev = [], [], []
+            with open(pt_path) as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    row_idx = rec.get("row_idx")
+                    if row_idx is None or row_idx >= len(labels_all):
+                        continue
+                    lbl = int(labels_all[row_idx])
+                    if (v := rec.get("p_true")) is not None and np.isfinite(v):
+                        scores_fwd.append(1.0 - v)
+                        lbls.append(lbl)
+                    if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
+                        scores_rev.append(1.0 - v)
 
-            ci_fwd = bootstrap_auroc(scores_fwd, lbls)
-            ci_rev = bootstrap_auroc(scores_rev, lbls)
+            ci_fwd = _bootstrap_auroc(scores_fwd, lbls)
+            ci_rev = _bootstrap_auroc(scores_rev, lbls)
             ci_results.append({
                 "dataset": ds,
                 "model": model_name(mid),
-                "p_true_auroc_fwd": safe_auroc(scores_fwd, lbls),
+                "p_true_auroc_fwd": _safe_auroc(scores_fwd, lbls),
                 "p_true_ci_fwd": ci_fwd,
-                "p_true_auroc_rev": safe_auroc(scores_rev, lbls),
+                "p_true_auroc_rev": _safe_auroc(scores_rev, lbls),
                 "p_true_ci_rev": ci_rev,
                 "n_rows": len(scores_fwd),
             })
-            print(
-                f"  {ds}/{model_name(mid)}: "
-                f"fwd={ci_fwd}, rev={ci_rev}"
-            )
+            print(f"  {ds}/{model_name(mid)}: fwd={ci_fwd}, rev={ci_rev}")
 
+    out_dir.mkdir(parents=True, exist_ok=True)
     ci_path = out_dir / "p_true_bootstrap.json"
     with open(ci_path, "w") as f:
         json.dump(ci_results, f, indent=2)
     print(f"Bootstrap CIs saved → {ci_path}")
 
 
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
 def main():
-    parser = argparse.ArgumentParser(description="Assemble AUROC table and figure.")
-    parser.add_argument("--models", nargs="+", default=MODELS)
-    parser.add_argument("--datasets", nargs="+", default=DATASETS, choices=DATASETS)
-    parser.add_argument("--output-dir", default="output/baseline_results")
-    parser.add_argument("--no-figure", action="store_true")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--with-ci",
-        action="store_true",
-        help="Compute bootstrap 95%% CIs for all methods (slow; 1000 resamples × cells).",
+        "--results-json",
+        type=Path,
+        default=DEFAULT_RESULTS_JSON,
+        help=f"Path to results_table.json (default: {DEFAULT_RESULTS_JSON}).",
     )
+    parser.add_argument("--models", nargs="+", default=MODELS,
+                        help="Models for P(true) bootstrap CI (default: all).")
+    parser.add_argument("--datasets", nargs="+", default=DATASETS, choices=DATASETS,
+                        help="Datasets for P(true) bootstrap CI.")
+    parser.add_argument("--output-dir", type=Path, default=Path("output/baseline_results"))
+    parser.add_argument("--no-figure", action="store_true")
+    parser.add_argument("--with-ci", action="store_true",
+                        help="Compute P(true) bootstrap 95%% CIs (1000 resamples × cells).")
     args = parser.parse_args()
 
-    out_dir = Path(args.output_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    if not args.results_json.exists():
+        sys.exit(
+            f"results_table.json not found at {args.results_json}. "
+            f"Run: python scripts/results_table.py"
+        )
 
-    rows = []
-    for mid in args.models:
-        for ds in args.datasets:
-            print(f"  {ds} / {model_name(mid)}")
-            r = compute_dataset_aurocs(ds, mid)
-            rows.append(r)
-
-    table = pd.DataFrame(rows)
-
-    csv_path = out_dir / "baseline_auroc_table.csv"
-    table.to_csv(csv_path, index=False)
-    print(f"\nTable saved → {csv_path}")
-
-    # Pretty-print main table columns
-    main_cols = [
-        "dataset", "model",
-        "se_length_normalized", "selfcheck_nli",
-        "sep_se_auroc",
-        "p_true",             # headline: max(fwd, rev) — score = 1 - P(true)
-        "p_true_auroc_fwd",
-        "p_true_auroc_rev",
-    ]
-    print_cols = [c for c in main_cols if c in table.columns]
-    print(table[print_cols].to_string(index=False))
-
-    if args.with_ci:
-        _write_ptrue_bootstrap_ci(args.models, args.datasets, out_dir)
+    table = load_figure_table(args.results_json)
+    print(f"Loaded {len(table)} (dataset, model) cells from {args.results_json}")
 
     if not args.no_figure:
-        make_compute_matched_figure(table, str(out_dir / "compute_matched_auroc.pdf"))
+        make_compute_matched_figure(table, args.output_dir / "compute_matched_auroc.pdf")
+
+    if args.with_ci:
+        _write_ptrue_bootstrap_ci(args.models, args.datasets, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/assemble_baseline_table.py
+++ b/scripts/assemble_baseline_table.py
@@ -24,6 +24,7 @@ from sklearn.metrics import roc_auc_score
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from tasks.p_true.paths import ptrue_scores_path
 from tasks.sampling_baselines.paths import (
     DATASETS,
     MODELS,
@@ -92,6 +93,31 @@ def safe_auroc(scores: list, labels: list) -> Optional[float]:
         return None
 
 
+def bootstrap_auroc(scores: list, labels: list, n: int = 1000, seed: int = 42) -> Optional[tuple]:
+    """Return (lo, hi) 95% bootstrap CI on AUROC, or None if not computable."""
+    base = safe_auroc(scores, labels)
+    if base is None:
+        return None
+    rng = np.random.default_rng(seed)
+    y = np.array(labels, dtype=int)
+    s = np.array(scores, dtype=float)
+    mask = np.isfinite(s)
+    y, s = y[mask], s[mask]
+    aucs = []
+    for _ in range(n):
+        idx = rng.integers(0, len(y), size=len(y))
+        if len(np.unique(y[idx])) < 2:
+            continue
+        try:
+            aucs.append(roc_auc_score(y[idx], s[idx]))
+        except Exception:
+            pass
+    if len(aucs) < 50:
+        return None
+    aucs = np.array(aucs)
+    return (float(np.percentile(aucs, 2.5)), float(np.percentile(aucs, 97.5)))
+
+
 # ---------------------------------------------------------------------------
 # Per-dataset scorer
 # ---------------------------------------------------------------------------
@@ -150,6 +176,35 @@ def compute_dataset_aurocs(dataset: str, model_id: str) -> dict:
         result["sep_layer"] = sep_data.get("layer")
         result["sep_binary_n_train"] = sep_data.get("train_size_sep_binary")
         result["sep_se_n_train"] = sep_data.get("train_size_sep_se")
+
+    # P(true) — score direction: 1 - p_true (high p_true ⇒ correct ⇒ low halu score)
+    pt_path = ptrue_scores_path(dataset, model_id, "test")
+    if pt_path.exists():
+        pt_by_row = load_jsonl_by_row(str(pt_path))
+        # P(true) runs on all rows (no cap), so cap_indices is irrelevant here.
+        scores_fwd, lbls_fwd = [], []
+        scores_rev, lbls_rev = [], []
+        for row_idx, rec in sorted(pt_by_row.items()):
+            if row_idx >= len(labels_all):
+                continue
+            lbl = labels_all[row_idx]
+            if (v := rec.get("p_true")) is not None and np.isfinite(v):
+                scores_fwd.append(1.0 - v)
+                lbls_fwd.append(lbl)
+            if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
+                scores_rev.append(1.0 - v)
+                lbls_rev.append(lbl)
+        auroc_fwd = safe_auroc(scores_fwd, lbls_fwd)
+        auroc_rev = safe_auroc(scores_rev, lbls_rev)
+        result["p_true_auroc_fwd"] = auroc_fwd
+        result["p_true_auroc_rev"] = auroc_rev
+        # Headline: max over forward / reversed (token-position-bias correction)
+        if auroc_fwd is not None and auroc_rev is not None:
+            result["p_true"] = max(auroc_fwd, auroc_rev)
+        elif auroc_fwd is not None:
+            result["p_true"] = auroc_fwd
+        else:
+            result["p_true"] = auroc_rev
 
     return result
 
@@ -237,12 +292,70 @@ def make_compute_matched_figure(table: pd.DataFrame, output_path: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+def _write_ptrue_bootstrap_ci(models, datasets, out_dir: Path) -> None:
+    """Compute and save bootstrap 95% CIs for P(true) AUROC across all cells."""
+    print("\nComputing P(true) bootstrap CIs (1000 resamples)...")
+    ci_results = []
+    for mid in models:
+        labels_cache = {}
+        for ds in datasets:
+            pt_path = ptrue_scores_path(ds, mid, "test")
+            if not pt_path.exists():
+                continue
+            if ds not in labels_cache:
+                eval_path = eval_results_json(ds, mid, "test")
+                if not eval_path.exists():
+                    continue
+                with open(eval_path) as f:
+                    labels_cache[ds] = np.array(json.load(f)["halu_test_res"], dtype=int)
+            labels_all = labels_cache[ds]
+
+            pt_by_row = load_jsonl_by_row(str(pt_path))
+            scores_fwd, lbls = [], []
+            scores_rev = []
+            for row_idx, rec in sorted(pt_by_row.items()):
+                if row_idx >= len(labels_all):
+                    continue
+                lbl = labels_all[row_idx]
+                if (v := rec.get("p_true")) is not None and np.isfinite(v):
+                    scores_fwd.append(1.0 - v)
+                    lbls.append(lbl)
+                if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
+                    scores_rev.append(1.0 - v)
+
+            ci_fwd = bootstrap_auroc(scores_fwd, lbls)
+            ci_rev = bootstrap_auroc(scores_rev, lbls)
+            ci_results.append({
+                "dataset": ds,
+                "model": model_name(mid),
+                "p_true_auroc_fwd": safe_auroc(scores_fwd, lbls),
+                "p_true_ci_fwd": ci_fwd,
+                "p_true_auroc_rev": safe_auroc(scores_rev, lbls),
+                "p_true_ci_rev": ci_rev,
+                "n_rows": len(scores_fwd),
+            })
+            print(
+                f"  {ds}/{model_name(mid)}: "
+                f"fwd={ci_fwd}, rev={ci_rev}"
+            )
+
+    ci_path = out_dir / "p_true_bootstrap.json"
+    with open(ci_path, "w") as f:
+        json.dump(ci_results, f, indent=2)
+    print(f"Bootstrap CIs saved → {ci_path}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Assemble AUROC table and figure.")
     parser.add_argument("--models", nargs="+", default=MODELS)
     parser.add_argument("--datasets", nargs="+", default=DATASETS, choices=DATASETS)
     parser.add_argument("--output-dir", default="output/baseline_results")
     parser.add_argument("--no-figure", action="store_true")
+    parser.add_argument(
+        "--with-ci",
+        action="store_true",
+        help="Compute bootstrap 95%% CIs for all methods (slow; 1000 resamples × cells).",
+    )
     args = parser.parse_args()
 
     out_dir = Path(args.output_dir)
@@ -266,9 +379,15 @@ def main():
         "dataset", "model",
         "se_length_normalized", "selfcheck_nli",
         "sep_se_auroc", "sep_binary_auroc",
+        "p_true",             # headline: max(fwd, rev) — score = 1 - P(true)
+        "p_true_auroc_fwd",
+        "p_true_auroc_rev",
     ]
     print_cols = [c for c in main_cols if c in table.columns]
     print(table[print_cols].to_string(index=False))
+
+    if args.with_ci:
+        _write_ptrue_bootstrap_ci(args.models, args.datasets, out_dir)
 
     if not args.no_figure:
         make_compute_matched_figure(table, str(out_dir / "compute_matched_auroc.pdf"))

--- a/scripts/assemble_baseline_table.py
+++ b/scripts/assemble_baseline_table.py
@@ -171,10 +171,8 @@ def compute_dataset_aurocs(dataset: str, model_id: str) -> dict:
     if sep_path.exists():
         with open(sep_path) as f:
             sep_data = json.load(f)
-        result["sep_binary_auroc"] = sep_data.get("sep_binary_auroc")
         result["sep_se_auroc"] = sep_data.get("sep_se_auroc")
         result["sep_layer"] = sep_data.get("layer")
-        result["sep_binary_n_train"] = sep_data.get("train_size_sep_binary")
         result["sep_se_n_train"] = sep_data.get("train_size_sep_se")
 
     # P(true) — score direction: 1 - p_true (high p_true ⇒ correct ⇒ low halu score)
@@ -230,14 +228,12 @@ def make_compute_matched_figure(table: pd.DataFrame, output_path: str) -> None:
 
     method_style = {
         "Our contrastive (K=1)": dict(K=1, marker="*", color="tab:red", linestyle="none"),
-        "SEP-binary (K=1)": dict(K=1, marker="D", color="tab:orange", linestyle="none"),
         "SEP-SE (K=1)": dict(K=1, marker="s", color="tab:purple", linestyle="none"),
         "SelfCheckGPT-NLI (K=10)": dict(K=10, marker="o", color="tab:blue", linestyle="none"),
         "SE length-norm (K=10)": dict(K=10, marker="^", color="tab:green", linestyle="none"),
     }
 
     col_map = {
-        "SEP-binary (K=1)": "sep_binary_auroc",
         "SEP-SE (K=1)": "sep_se_auroc",
         "SelfCheckGPT-NLI (K=10)": "selfcheck_nli",
         "SE length-norm (K=10)": "se_length_normalized",
@@ -378,7 +374,7 @@ def main():
     main_cols = [
         "dataset", "model",
         "se_length_normalized", "selfcheck_nli",
-        "sep_se_auroc", "sep_binary_auroc",
+        "sep_se_auroc",
         "p_true",             # headline: max(fwd, rev) — score = 1 - P(true)
         "p_true_auroc_fwd",
         "p_true_auroc_rev",

--- a/scripts/audit_coverage.py
+++ b/scripts/audit_coverage.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Render a human-readable coverage report from results_table.json.
+
+Coverage and metrics live together in `results_table.json` (produced by
+`scripts/results_table.py`). This script is a thin formatter — it does not
+walk the filesystem. Run `results_table.py` first if the JSON is stale.
+
+Usage:
+    python scripts/results_table.py            # refresh source-of-truth
+    python scripts/audit_coverage.py           # print markdown to stdout
+    python scripts/audit_coverage.py --out reports/coverage.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_JSON = PROJECT_ROOT / "output" / "results_table" / "results_table.json"
+
+
+def _md_training_section(cells: list[dict]) -> str:
+    # Group by experiment config (inferred from cell.paths.config).
+    by_cfg: dict[str, list[dict]] = defaultdict(list)
+    for c in cells:
+        if c["kind"] != "training":
+            continue
+        cfg = c["paths"].get("config", "?")
+        by_cfg[cfg].append(c)
+
+    lines = [
+        "## Training-based baselines (experiment configs)",
+        "",
+        "| Config | Complete / Total | Failed | Running | Pending |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    overall = {"total": 0, "complete": 0, "failed": 0, "running": 0, "pending": 0}
+    for cfg, runs in sorted(by_cfg.items()):
+        total = len(runs)
+        counts = defaultdict(int)
+        for r in runs:
+            counts[r["status"]] += 1
+        exp_name = Path(cfg).stem
+        lines.append(
+            f"| {exp_name} | {counts['complete']} / {total} | "
+            f"{counts['failed']} | {counts['running']} | {counts['pending']} |"
+        )
+        overall["total"] += total
+        for k in ("complete", "failed", "running", "pending"):
+            overall[k] += counts[k]
+    lines += [
+        "",
+        f"**Overall training runs:** {overall['complete']} / {overall['total']} complete, "
+        f"{overall['failed']} failed, {overall['running']} running, {overall['pending']} pending.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _md_sampling_section(cells: list[dict]) -> str:
+    lines = [
+        "## Sampling-baseline artefacts (SE + SelfCheckGPT)",
+        "",
+        "Status is per scoring variant. The pipeline runs on a subset of"
+        " the test split (full for hotpotqa/nq/popqa/sciq; 10K cap for"
+        " searchqa). Expected = subset size; actual = rows in the JSONL.",
+        "",
+        "| Dataset | Model | Method | Expected | Actual | Status |",
+        "|---|---|---|---:|---:|---|",
+    ]
+    for c in cells:
+        if c["kind"] != "sampling":
+            continue
+        k = c["key"]
+        exp = c["expected_rows"] if c["expected_rows"] is not None else "-"
+        act = c["actual_rows"] if c["actual_rows"] is not None else "-"
+        lines.append(
+            f"| {k['dataset']} | {k['model']} | {k['method']} | "
+            f"{exp} | {act} | {c['status']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _md_sep_section(cells: list[dict]) -> str:
+    lines = ["## SEP probe", "", "| Dataset | Model | Status |", "|---|---|---|"]
+    for c in cells:
+        if c["kind"] != "sep":
+            continue
+        k = c["key"]
+        lines.append(f"| {k['dataset']} | {k['model']} | {c['status']} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _md_ptrue_section(cells: list[dict]) -> str:
+    lines = [
+        "## P(true) baseline",
+        "",
+        "| Dataset | Model | Gen rows | P(true) rows | Status |",
+        "|---|---|---:|---:|---|",
+    ]
+    for c in cells:
+        if c["kind"] != "p_true":
+            continue
+        k = c["key"]
+        exp = c["expected_rows"] if c["expected_rows"] is not None else "-"
+        act = c["actual_rows"] if c["actual_rows"] is not None else "-"
+        lines.append(
+            f"| {k['dataset']} | {k['model']} | {exp} | {act} | {c['status']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _md_training_breakdown(cells: list[dict]) -> str:
+    sym = {"running": "~", "failed": "x", "pending": "."}
+
+    # model -> dataset -> method -> {status: [seeds]}
+    by_model: dict[str, dict[str, dict[str, dict[str, list]]]] = {}
+    for c in cells:
+        if c["kind"] != "training" or c["status"] == "complete":
+            continue
+        m = by_model.setdefault(c["key"]["model"], {})
+        d = m.setdefault(c["key"]["dataset"], {})
+        method_bucket = d.setdefault(c["key"]["method"], {})
+        method_bucket.setdefault(c["status"], []).append(c["key"]["seed"])
+
+    lines = [
+        "## Training baselines — missing/incomplete breakdown by model",
+        "",
+        "Each entry lists the (method, seeds) combos that are not yet"
+        " complete. Status: `~` running, `x` failed, `.` pending.",
+        "",
+    ]
+
+    all_models = sorted({c["key"]["model"] for c in cells if c["kind"] == "training"})
+    model_order = ["Llama-3.1-8B-Instruct", "Qwen3-8B", "SmolLM3"]
+    seen = [m for m in model_order if m in all_models] + sorted(
+        m for m in all_models if m not in model_order
+    )
+    if not by_model:
+        lines.append("All training runs complete across every model. ✓")
+        lines.append("")
+        return "\n".join(lines)
+
+    for m in seen:
+        lines.append(f"### {m}")
+        if m not in by_model:
+            lines.append("")
+            lines.append("All complete. ✓")
+            lines.append("")
+            continue
+        for ds in sorted(by_model[m]):
+            lines.append(f"- **{ds}**")
+            for method in sorted(by_model[m][ds]):
+                buckets = by_model[m][ds][method]
+                parts = []
+                for st in ("running", "failed", "pending"):
+                    seeds = sorted(s for s in buckets.get(st, []) if s is not None)
+                    no_seed = [s for s in buckets.get(st, []) if s is None]
+                    if seeds:
+                        parts.append(f"{sym[st]} seeds {{{','.join(map(str, seeds))}}}")
+                    if no_seed:
+                        parts.append(f"{sym[st]} (no-seed)")
+                lines.append(f"    - `{method}`: {'; '.join(parts)}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_report(payload: dict) -> str:
+    cells = payload["cells"]
+    ts = payload.get("generated_at", "unknown")
+    git = payload.get("git", {})
+    header = [
+        f"# Experiment coverage audit",
+        "",
+        f"Generated: {ts}  ·  branch `{git.get('branch', '?')}` "
+        f"@ `{git.get('commit', '?')[:10]}`",
+        "",
+        "Coverage view rendered from `output/results_table/results_table.json`."
+        " A cell is OK when its canonical artefact is present (eval_metrics.json"
+        " for training runs; full-length JSONL for sampling artefacts and P(true);"
+        " sep_results.json for SEP).",
+        "",
+    ]
+    return "\n".join([
+        *header,
+        _md_training_section(cells),
+        _md_sampling_section(cells),
+        _md_sep_section(cells),
+        _md_ptrue_section(cells),
+        _md_training_breakdown(cells),
+    ])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--results-json",
+        type=Path,
+        default=DEFAULT_JSON,
+        help=f"Path to results_table.json (default: {DEFAULT_JSON}).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional markdown output path (default: print to stdout).",
+    )
+    args = parser.parse_args()
+
+    if not args.results_json.exists():
+        sys.exit(
+            f"results_table.json not found at {args.results_json}. "
+            f"Run: python scripts/results_table.py"
+        )
+
+    with open(args.results_json) as f:
+        payload = json.load(f)
+
+    out = build_report(payload)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(out)
+        print(f"Wrote {args.out}")
+    else:
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_p_true.py
+++ b/scripts/audit_p_true.py
@@ -1,0 +1,188 @@
+"""Audit P(true) output completeness and correctness.
+
+Usage:
+    # Check expected vs actual row counts for all 12 cells
+    python scripts/audit_p_true.py --check-counts
+
+    # Spot-check 20 random rows per (dataset, model), save to reports/
+    python scripts/audit_p_true.py --spot-check 20
+
+    # Both
+    python scripts/audit_p_true.py --check-counts --spot-check 20
+"""
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.p_true.paths import DATASETS, MODELS, ptrue_scores_path
+from tasks.sampling_baselines.paths import eval_results_json, generation_jsonl, model_name
+
+
+# Expected test-split row counts per dataset (informational; actual count from
+# generation.jsonl is the authoritative source since SearchQA naming is inverted).
+_EXPECTED_COUNTS = {
+    "hotpotqa": 7405,
+    "nq": 4155,
+    "popqa": 2854,
+    "sciq": 1000,
+    "searchqa": 151140,  # ~151K; varies slightly by model
+    "mmlu": 10225,
+}
+
+
+def count_generation_rows(dataset: str, model_id: str) -> int:
+    p = generation_jsonl(dataset, model_id, "test")
+    if not p.exists():
+        return -1
+    with open(p) as f:
+        return sum(1 for _ in f)
+
+
+def count_ptrue_rows(dataset: str, model_id: str) -> int:
+    p = ptrue_scores_path(dataset, model_id, "test")
+    if not p.exists():
+        return -1
+    with open(p) as f:
+        return sum(1 for _ in f)
+
+
+def check_counts(models, datasets) -> bool:
+    print("=== P(true) count audit ===\n")
+    header = f"{'Dataset':<14} {'Model':<30} {'Gen rows':>10} {'ptrue rows':>12} {'Status':>8}"
+    print(header)
+    print("-" * len(header))
+    all_ok = True
+    for mid in models:
+        for ds in datasets:
+            gen_n = count_generation_rows(ds, mid)
+            pt_n = count_ptrue_rows(ds, mid)
+            if gen_n < 0:
+                status = "NO GEN"
+                all_ok = False
+            elif pt_n < 0:
+                status = "MISSING"
+                all_ok = False
+            elif pt_n < gen_n:
+                status = f"PARTIAL"
+                all_ok = False
+            else:
+                status = "OK"
+            print(
+                f"{ds:<14} {model_name(mid):<30} {gen_n:>10,} {pt_n:>12,} {status:>8}"
+            )
+    print()
+    return all_ok
+
+
+def spot_check(models, datasets, n: int, save_dir: Path) -> None:
+    print(f"=== P(true) spot-check ({n} rows per cell) ===\n")
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    for mid in models:
+        # Load labels once per model
+        label_cache = {}
+
+        for ds in datasets:
+            pt_path = ptrue_scores_path(ds, mid, "test")
+            if not pt_path.exists():
+                print(f"SKIP {ds}/{model_name(mid)}: ptrue.jsonl not found")
+                continue
+
+            eval_path = eval_results_json(ds, mid, "test")
+            if ds not in label_cache and eval_path.exists():
+                with open(eval_path) as f:
+                    label_cache[ds] = json.load(f).get("halu_test_res", [])
+
+            gen_path = generation_jsonl(ds, mid, "test")
+
+            # Load ptrue.jsonl
+            rows = []
+            with open(pt_path) as f:
+                for line in f:
+                    try:
+                        rows.append(json.loads(line))
+                    except Exception:
+                        pass
+
+            if not rows:
+                print(f"SKIP {ds}/{model_name(mid)}: ptrue.jsonl is empty")
+                continue
+
+            sample = random.sample(rows, min(n, len(rows)))
+            sample.sort(key=lambda r: r["row_idx"])
+
+            # Load generation rows for context
+            gen_rows = {}
+            if gen_path.exists():
+                with open(gen_path) as f:
+                    for i, line in enumerate(f):
+                        try:
+                            gen_rows[i] = json.loads(line)
+                        except Exception:
+                            pass
+
+            output_lines = [
+                f"=== Spot-check: {ds} / {model_name(mid)} ({len(sample)} rows) ===\n"
+            ]
+
+            labels = label_cache.get(ds, [])
+            for rec in sample:
+                row_idx = rec["row_idx"]
+                gen_row = gen_rows.get(row_idx, {})
+                question = gen_row.get("question", gen_row.get("prompt", "")[:80])
+                answer = gen_row.get("generation", "")[:120]
+                halu = labels[row_idx] if row_idx < len(labels) else rec.get("halu_label")
+                line = (
+                    f"row={row_idx:6d} | halu={halu} | "
+                    f"p_true={rec['p_true']:.4f} | p_true_rev={rec['p_true_reversed']:.4f}\n"
+                    f"  Q: {question[:100]}\n"
+                    f"  A: {answer[:100]}\n"
+                )
+                output_lines.append(line)
+
+            block = "\n".join(output_lines)
+            print(block)
+
+            out_file = save_dir / f"spotcheck_{ds}_{model_name(mid)}.txt"
+            with open(out_file, "w", encoding="utf-8") as f:
+                f.write(block)
+
+    print(f"Spot-check reports saved → {save_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit P(true) output.")
+    parser.add_argument("--datasets", default=",".join(DATASETS))
+    parser.add_argument("--models", default=",".join(MODELS))
+    parser.add_argument("--check-counts", action="store_true")
+    parser.add_argument("--spot-check", type=int, metavar="N",
+                        help="Print N random rows per (dataset, model).")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--save-dir", default="reports/p_true_spotchecks")
+    args = parser.parse_args()
+
+    if not args.check_counts and args.spot_check is None:
+        parser.error("Specify --check-counts and/or --spot-check N")
+
+    random.seed(args.seed)
+
+    datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+
+    ok = True
+    if args.check_counts:
+        ok = check_counts(models, datasets)
+
+    if args.spot_check is not None:
+        spot_check(models, datasets, args.spot_check, Path(args.save_dir))
+
+    if args.check_counts and not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_sep.py
+++ b/scripts/compute_sep.py
@@ -1,120 +1,140 @@
-"""Phase 5: Fit SEP-SE and SEP-binary probes.
+"""Phase 5: Fit SEP-SE probes (Kossen et al. 2024).
 
-SEP-binary works on all 6 datasets including MMLU (no sampling needed).
-SEP-SE requires se_labels.jsonl (train split) and skips MMLU.
+SEP-SE = Ridge probe predicting length-normalized semantic entropy from a
+single greedy-pass hidden state. AUROC is reported against binary halu labels
+on the test split. MMLU is skipped (no SE labels).
+
+Layer is picked per-dataset from compute_sep_layer_sweep.py output by default
+(matching the Kossen paper's per-task selection); pass --layer to override
+with a single fixed layer across all datasets.
 
 Usage:
-    # All datasets, both models (runs after SE labels are available)
+    # Auto-pick layer per dataset from layer_sweep_{ds}.json (run sweep first)
+    python scripts/compute_sep.py --model Qwen/Qwen3-8B
+
+    # Pin a single layer across all datasets
     python scripts/compute_sep.py \\
         --model meta-llama/Llama-3.1-8B-Instruct \\
         --layer 22
-
-    python scripts/compute_sep.py \\
-        --model Qwen/Qwen3-8B \\
-        --layer 24       # from layer sweep
 
     # Single dataset
     python scripts/compute_sep.py \\
         --dataset hotpotqa \\
-        --model meta-llama/Llama-3.1-8B-Instruct \\
-        --layer 22
-
-    # MMLU SEP-binary (no SE, can run any time after main inference)
-    python scripts/compute_sep.py \\
-        --dataset mmlu \\
-        --model meta-llama/Llama-3.1-8B-Instruct \\
-        --layer 22 \\
-        --no-sep-se
+        --model Qwen/Qwen3-8B
 """
 import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from tasks.sampling_baselines.paths import (
-    DATASETS,
     SAMPLING_DATASETS,
     model_name,
     se_labels_path,
+    searchqa_test_cap_path,
     sep_results_path,
     subset_index_path,
 )
 from tasks.sampling_baselines.sep import run_sep
 
 
-def load_subset_indices(dataset: str, mid: str) -> Optional[list]:
-    idx_path = subset_index_path(dataset, mid)
-    if not idx_path.exists():
-        return None
-    with open(idx_path) as f:
-        return json.load(f)["question_ids"]
-
-
 def main():
-    parser = argparse.ArgumentParser(description="Fit SEP probes.")
+    parser = argparse.ArgumentParser(description="Fit SEP-SE probes.")
     parser.add_argument(
         "--dataset",
         nargs="+",
-        default=DATASETS,
-        choices=DATASETS,
-        help="Datasets to process (default: all)",
+        default=SAMPLING_DATASETS,
+        choices=SAMPLING_DATASETS,
+        help="Datasets to process (default: all sampling datasets; MMLU is excluded)",
     )
     parser.add_argument("--model", required=True, help="HuggingFace model ID")
     parser.add_argument(
-        "--layer", required=True, type=int, help="Layer index for feature extraction"
+        "--layer",
+        type=int,
+        default=None,
+        help="Override layer for all datasets. Default: per-dataset best from layer sweep.",
     )
     parser.add_argument(
-        "--no-sep-se",
+        "--force",
         action="store_true",
-        help="Skip SEP-SE (e.g. for MMLU or when SE labels not yet available)",
+        help="Overwrite existing sep_results.json files",
     )
     args = parser.parse_args()
 
     datasets = args.dataset if isinstance(args.dataset, list) else [args.dataset]
 
-    print(f"SEP probes | {model_name(args.model)} | layer={args.layer}")
+    mode = f"layer={args.layer} (fixed)" if args.layer is not None else "layer=auto (from sweep)"
+    print(f"SEP-SE | {model_name(args.model)} | {mode}")
+
+    sweep_dir = Path("output") / "sampling_baselines" / "sep" / model_name(args.model)
 
     for ds in datasets:
         print(f"\n--- {ds} ---")
         out_path = sep_results_path(ds, args.model)
 
-        if out_path.exists():
-            print(f"  Already exists — skipping. Delete to rerun: {out_path}")
+        if out_path.exists() and not args.force:
+            print(f"  Already exists — skipping. Pass --force to rerun: {out_path}")
             continue
 
-        # SEP-SE: needs train subset + SE labels; skip MMLU and when --no-sep-se
-        run_se = not args.no_sep_se and ds in SAMPLING_DATASETS
-        train_subset = None
-        se_train_path = None
-
-        if run_se:
-            train_subset = load_subset_indices(ds, args.model)
-            se_train = se_labels_path(ds, args.model, "train")
-            if not se_train.exists():
+        # Resolve layer: --layer override, else best_layer from sweep file.
+        if args.layer is not None:
+            layer = args.layer
+            layer_source = "cli"
+        else:
+            sweep_path = sweep_dir / f"layer_sweep_{ds}.json"
+            if not sweep_path.exists():
                 print(
-                    f"  WARNING: SE labels not found ({se_train}) — skipping SEP-SE for {ds}."
+                    f"  SKIP: no --layer and sweep file missing — {sweep_path}\n"
+                    f"        Run compute_sep_layer_sweep.py --dataset {ds} --model {args.model} first."
                 )
-                run_se = False
-            else:
-                se_train_path = str(se_train)
+                continue
+            with open(sweep_path) as f:
+                sweep_data = json.load(f)
+            layer = int(sweep_data["best_layer"])
+            best_auroc = sweep_data["auroc_by_layer"].get(str(layer))
+            print(f"  layer={layer} (val AUROC={best_auroc:.4f}, from {sweep_path.name})")
+            layer_source = str(sweep_path)
 
-        if not run_se:
-            train_subset = None
-            se_train_path = None
+        subset_path = subset_index_path(ds, args.model)
+        if not subset_path.exists():
+            print(f"  SKIP: subset index missing — {subset_path}")
+            continue
+        with open(subset_path) as f:
+            subset = json.load(f)["question_ids"]
+
+        se_train = se_labels_path(ds, args.model, "train")
+        if not se_train.exists():
+            print(f"  SKIP: SE labels missing — {se_train}")
+            continue
+
+        # Apply searchqa test cap to match other baselines' evaluation set.
+        test_subset = None
+        if ds == "searchqa":
+            cap_path = searchqa_test_cap_path(args.model)
+            if cap_path.exists():
+                with open(cap_path) as f:
+                    test_subset = json.load(f)["question_ids"]
+                print(f"  test cap: {len(test_subset)} rows from {cap_path.name}")
+            else:
+                print(f"  WARN: searchqa cap not found ({cap_path}) — using full test split")
 
         try:
-            run_sep(
+            result = run_sep(
                 dataset=ds,
                 model_id=args.model,
-                layer_idx=args.layer,
-                train_subset_indices=train_subset,
-                se_labels_train_path=se_train_path,
+                layer_idx=layer,
+                train_subset_indices=subset,
+                se_labels_train_path=str(se_train),
                 output_path=str(out_path),
+                test_subset_indices=test_subset,
             )
-        except FileNotFoundError as e:
+            # Annotate where the layer choice came from.
+            result["layer_source"] = layer_source
+            with open(out_path, "w") as f:
+                json.dump(result, f, indent=2)
+        except (FileNotFoundError, RuntimeError) as e:
             print(f"  SKIP: {e}")
 
     print("\nSEP done.")

--- a/scripts/compute_sep_layer_sweep.py
+++ b/scripts/compute_sep_layer_sweep.py
@@ -1,8 +1,8 @@
-"""Phase 5a: SEP layer sweep for Qwen3-8B.
+"""Phase 5a: SEP-SE layer sweep.
 
-Fits SEP-binary for each candidate layer on a single dataset's val split.
-Prints an AUROC table; the best layer is used in compute_sep.py.
-Llama uses layer 22 (matching existing linear probe baseline) — no sweep needed.
+Fits SEP-SE per layer on 80% of the train subset and reports val AUROC on the
+held-out 20% (binary halu labels). Pick the best layer for compute_sep.py.
+Llama-3.1-8B uses layer 22 by project convention; sweep Qwen3-8B explicitly.
 
 Usage:
     python scripts/compute_sep_layer_sweep.py \\
@@ -21,63 +21,78 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from tasks.sampling_baselines.paths import (
-    DATASETS,
+    SAMPLING_DATASETS,
     eval_results_json,
     generation_jsonl,
     model_name,
+    se_labels_path,
+    subset_index_path,
     zarr_path,
 )
-from tasks.sampling_baselines.sep import layer_sweep_sep_binary
+from tasks.sampling_baselines.sep import layer_sweep_sep_se
 
 DEFAULT_LAYERS = [16, 18, 20, 22, 24, 26]
 
 
 def main():
-    parser = argparse.ArgumentParser(description="SEP layer sweep.")
-    parser.add_argument("--dataset", required=True, choices=DATASETS)
+    parser = argparse.ArgumentParser(description="SEP-SE layer sweep.")
+    parser.add_argument("--dataset", required=True, choices=SAMPLING_DATASETS)
     parser.add_argument("--model", required=True, help="HuggingFace model ID")
     parser.add_argument(
-        "--layers",
-        nargs="+",
-        type=int,
-        default=DEFAULT_LAYERS,
-        help="Layer indices to sweep",
+        "--layers", nargs="+", type=int, default=DEFAULT_LAYERS, help="Layer indices to sweep"
     )
     parser.add_argument("--val-frac", type=float, default=0.2)
     parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
-    gen = generation_jsonl(args.dataset, args.model, "test")
-    zarr = zarr_path(args.dataset, args.model, "test")
-    eval_j = eval_results_json(args.dataset, args.model, "test")
+    gen_train = generation_jsonl(args.dataset, args.model, "train")
+    zarr_train = zarr_path(args.dataset, args.model, "train")
+    eval_train = eval_results_json(args.dataset, args.model, "train")
+    se_train = se_labels_path(args.dataset, args.model, "train")
+    subset_path = subset_index_path(args.dataset, args.model)
 
-    for p, label in [(gen, "generation.jsonl"), (zarr, "zarr store"), (eval_j, "eval_results_for_training.json")]:
+    for p, label in [
+        (gen_train, "generation.jsonl (train)"),
+        (zarr_train, "zarr store (train)"),
+        (eval_train, "eval_results_for_training.json (train)"),
+        (se_train, "se_labels.jsonl (train)"),
+        (subset_path, "subset index"),
+    ]:
         if not Path(p).exists():
             print(f"ERROR: {label} not found: {p}")
             sys.exit(1)
 
+    with open(subset_path) as f:
+        subset = json.load(f)["question_ids"]
+
     print(
-        f"SEP layer sweep | {args.dataset} | {model_name(args.model)}\n"
-        f"Layers: {args.layers}"
+        f"SEP-SE layer sweep | {args.dataset} | {model_name(args.model)}\n"
+        f"Layers: {args.layers} | subset_size: {len(subset)} | val_frac: {args.val_frac}"
     )
 
-    results = layer_sweep_sep_binary(
-        generation_jsonl=str(gen),
-        zarr_path=str(zarr),
-        eval_json=str(eval_j),
+    results = layer_sweep_sep_se(
+        generation_jsonl_train=str(gen_train),
+        zarr_path_train=str(zarr_train),
+        eval_json_train=str(eval_train),
+        se_labels_train_path=str(se_train),
+        train_subset_indices=subset,
         layers=args.layers,
         val_frac=args.val_frac,
         seed=args.seed,
     )
 
+    if not results:
+        print("ERROR: no layers produced AUROC values.")
+        sys.exit(1)
+
     print("\nLayer sweep results:")
     print(f"{'Layer':>6}  {'Val AUROC':>10}")
     print("-" * 20)
+    best_layer = max(results, key=results.get)
     for layer in sorted(results):
-        marker = " <-- best" if layer == max(results, key=results.get) else ""
+        marker = " <-- best" if layer == best_layer else ""
         print(f"{layer:>6}  {results[layer]:>10.4f}{marker}")
 
-    best_layer = max(results, key=results.get)
     print(f"\nBest layer: {best_layer} (AUROC={results[best_layer]:.4f})")
     print(f"Pass --layer {best_layer} to compute_sep.py for {model_name(args.model)}")
 
@@ -98,6 +113,7 @@ def main():
                 "auroc_by_layer": results,
                 "best_layer": best_layer,
                 "seed": args.seed,
+                "val_frac": args.val_frac,
             },
             f,
             indent=2,

--- a/scripts/fanout_p_true.py
+++ b/scripts/fanout_p_true.py
@@ -1,0 +1,134 @@
+"""Fan out P(true) scoring across available Jupyter GPU nodes.
+
+12 cells: 6 datasets × 2 models, test split only (P(true) is deterministic;
+no seed axis). Cells are grouped by model within each shard so the model is
+loaded once per model per node.
+
+Usage:
+    python scripts/fanout_p_true.py --dry-run
+    python scripts/fanout_p_true.py --nodes alphagpu04-8884
+    python scripts/fanout_p_true.py \\
+        --nodes alphagpu04-8884,alphagpu03-8887,alphagpu01-8888
+    python scripts/fanout_p_true.py \\
+        --nodes alphagpu04-8884 \\
+        --models meta-llama/Llama-3.1-8B-Instruct
+
+Dispatch note: searchqa has ~151K rows (85% of total forward passes).
+For balanced fanout across 3 nodes, assign searchqa to its own node and
+split the remaining 5 datasets across the other nodes.  The default
+round-robin assignment is fine for 1–2 nodes.
+"""
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from tasks.p_true.paths import DATASETS, MODELS
+
+DEFAULT_SPLIT = "test"
+
+
+def build_cells(datasets, models):
+    return [(ds, DEFAULT_SPLIT, model) for ds in datasets for model in models]
+
+
+def assign_round_robin(cells, nodes):
+    bins = {n: [] for n in nodes}
+    for i, c in enumerate(cells):
+        bins[nodes[i % len(nodes)]].append(c)
+    return bins
+
+
+def write_shard_file(path: Path, cells) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("# dataset\tmodel\n")
+        for ds, _split, model in cells:
+            f.write(f"{ds}\t{model}\n")
+
+
+def dispatch_shard(node: str, cells_file: Path, dry_run: bool) -> str:
+    cmd = [
+        "python", "scripts/gpu_dispatch.py", "run",
+        "--jupyter", "--node", node,
+        "--",
+        "env", f"CELLS_FILE={cells_file}",
+        "bash", "scripts/run_p_true_shard.sh",
+    ]
+    if dry_run:
+        print(f"  [dry-run] {' '.join(cmd)}")
+        return ""
+    out = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if out.returncode != 0:
+        print(f"  FAILED ({node}): {out.stderr}", file=sys.stderr)
+        return ""
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("Job ID:"):
+            return line.split(":", 1)[1].strip()
+    print(f"  WARNING ({node}): dispatched but no job id found", file=sys.stderr)
+    return ""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--datasets", default=",".join(DATASETS))
+    parser.add_argument("--models", default=",".join(MODELS))
+    parser.add_argument(
+        "--nodes",
+        required=True,
+        help="Comma-separated Jupyter node names (e.g. alphagpu04-8884,...).",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    datasets = [s.strip() for s in args.datasets.split(",") if s.strip()]
+    models = [s.strip() for s in args.models.split(",") if s.strip()]
+    nodes = [s.strip() for s in args.nodes.split(",") if s.strip()]
+
+    cells = build_cells(datasets, models)
+    bins = assign_round_robin(cells, nodes)
+
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    fanout_dir = Path("reports/p_true_runs") / f"fanout_{stamp}"
+
+    print(f"Cells: {len(cells)} | Nodes: {len(nodes)} | Stamp: {stamp}")
+    for n, ncells in bins.items():
+        print(f"  {n}: {len(ncells)} cells")
+        for ds, split, model in ncells:
+            print(f"    - {ds}/{split}/{model.split('/')[-1]}")
+    print()
+
+    job_ids = []
+    for node, ncells in bins.items():
+        cells_file = fanout_dir / f"cells_{node}.tsv"
+        write_shard_file(cells_file, ncells)
+        jid = dispatch_shard(node, cells_file, dry_run=args.dry_run)
+        if jid:
+            job_ids.append((jid, node, cells_file, len(ncells)))
+
+    if args.dry_run:
+        print(
+            f"\nDRY-RUN. Would have written shard files in {fanout_dir} "
+            f"and dispatched {len(bins)} shard jobs."
+        )
+        return
+
+    if job_ids:
+        manifest = fanout_dir / "dispatch.txt"
+        with open(manifest, "w") as f:
+            f.write(f"# P(true) fanout dispatch {stamp}\n")
+            for jid, node, cf, n in job_ids:
+                f.write(f"{jid}\t{node}\t{n}\t{cf}\n")
+        print(f"\nDispatched {len(job_ids)}/{len(bins)} shards.")
+        for jid, node, _, n in job_ids:
+            print(f"  {jid}  {node}  ({n} cells)")
+        print(f"\nManifest: {manifest}")
+        print("\nMonitor:")
+        print("  python scripts/gpu_dispatch.py jobs")
+        print("  python scripts/audit_p_true.py --check-counts")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/results_table.py
+++ b/scripts/results_table.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Assemble a unified, long-form results table across every baseline.
+
+Walks all of:
+  - Training experiments (configs/experiments/baseline_comparison_*.json)
+  - Sampling baselines  (SE variants + SelfCheckGPT)
+  - SEP probe           (output/sampling_baselines/sep/*)
+  - P(true)             (output/p_true/*)
+
+Emits TWO files in a single run (always both, never just one):
+
+  results_table.json — structured, agent-friendly. One entry per cell:
+    {
+      "schema_version": 1,
+      "generated_at": "...",
+      "git": {"branch": "...", "commit": "..."},
+      "cells": [
+        {
+          "key":    {"dataset": "...", "model": "...", "method": "...", "seed": 0},
+          "kind":   "training" | "sampling" | "sep" | "p_true",
+          "status": "complete" | "missing" | "failed" | "running" | "pending" | "partial",
+          "metrics":  {"knn_auroc": 0.85, ...},
+          "expected_rows": int|null,
+          "actual_rows":   int|null,
+          "paths":    {"name": "relative/path", ...}
+        },
+        ...
+      ]
+    }
+
+  results_table.csv — long form. One row per (cell × metric).
+    Columns: kind, dataset, model, method, seed, status, metric_name,
+             metric_value, expected_rows, actual_rows, path
+
+Cells with status != complete still appear (with empty metric/value) so the
+table doubles as the coverage view — `audit_coverage.py` is now redundant
+modulo presentation.
+
+Usage:
+    python scripts/results_table.py              # writes output/results_table/*
+    python scripts/results_table.py --out-dir DIR
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.experiment_utils import (  # noqa: E402
+    RunStatus,
+    classify_run,
+    enumerate_runs,
+    load_experiment_config,
+)
+from tasks.sampling_baselines.paths import (  # noqa: E402
+    SAMPLING_DATASETS,
+    eval_results_json,
+    generation_jsonl,
+    model_name,
+    nli_matrix_path,
+    se_labels_path,
+    searchqa_test_cap_path,
+    selfcheck_samples_path,
+    selfcheck_scores_path,
+    sep_results_path,
+    subset_index_path,
+)
+from tasks.p_true.paths import (  # noqa: E402
+    DATASETS as PTRUE_DATASETS,
+    MODELS as PTRUE_MODELS,
+    ptrue_scores_path,
+)
+
+SCHEMA_VERSION = 1
+
+SAMPLING_MODELS = [
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "Qwen/Qwen3-8B",
+]
+
+# Optional sklearn (preferred); fall back to numpy Mann–Whitney AUROC.
+try:
+    from sklearn.metrics import roc_auc_score as _sklearn_auroc
+    _HAS_SKLEARN = True
+except ImportError:  # pragma: no cover
+    _HAS_SKLEARN = False
+
+
+# ---------------------------------------------------------------------------
+# Small utils
+# ---------------------------------------------------------------------------
+
+def _rel(p: Path) -> str:
+    try:
+        return str(p.resolve().relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(p)
+
+
+def _count_lines(path: Path) -> int:
+    if not path.exists():
+        return -1
+    with open(path) as f:
+        return sum(1 for _ in f)
+
+
+def _auroc(scores: Iterable[float], labels: Iterable[int]) -> Optional[float]:
+    s = np.asarray(list(scores), dtype=float)
+    y = np.asarray(list(labels), dtype=int)
+    mask = np.isfinite(s)
+    s, y = s[mask], y[mask]
+    if len(s) < 10 or len(np.unique(y)) < 2:
+        return None
+    if _HAS_SKLEARN:
+        try:
+            return float(_sklearn_auroc(y, s))
+        except Exception:
+            return None
+    # Mann–Whitney AUROC with average ranks for ties.
+    order = np.argsort(s, kind="mergesort")
+    s_sorted = s[order]
+    # Average ranks for ties
+    ranks = np.empty(len(s), dtype=float)
+    i = 0
+    while i < len(s):
+        j = i + 1
+        while j < len(s) and s_sorted[j] == s_sorted[i]:
+            j += 1
+        avg = 0.5 * ((i + 1) + j)  # ranks are 1-indexed
+        ranks[order[i:j]] = avg
+        i = j
+    n_pos = int(y.sum())
+    n_neg = len(y) - n_pos
+    if n_pos == 0 or n_neg == 0:
+        return None
+    return float((ranks[y == 1].sum() - n_pos * (n_pos + 1) / 2) / (n_pos * n_neg))
+
+
+def _git_info() -> dict[str, str]:
+    try:
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=PROJECT_ROOT, text=True
+        ).strip()
+    except Exception:
+        branch = "unknown"
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=PROJECT_ROOT, text=True
+        ).strip()
+    except Exception:
+        commit = "unknown"
+    return {"branch": branch, "commit": commit}
+
+
+# ---------------------------------------------------------------------------
+# Cell collectors — each returns a list of cell dicts ready for serialization.
+# ---------------------------------------------------------------------------
+
+# Per-method metric keys to surface from eval_metrics.json. Each method may
+# have its own set; anything not listed here is dropped (keeps the table from
+# accidentally including run_size / hparams / etc.).
+_TRAINING_METRIC_KEYS = {
+    "contrastive_logprob_recon": ("cosine_auroc", "mahalanobis_auroc", "knn_auroc"),
+    "linear_probe":               ("auroc",),
+    "saplma":                     ("auroc",),
+    "llmsknow_probe":             ("auroc", "sweep_best_dev_auroc"),
+    "multi_layer_linear_probe":   ("auroc",),
+    "token_entropy":              ("mean_entropy_auroc", "mean_logprob_auroc",
+                                   "min_logprob_auroc"),
+    "logprob_baseline":           ("mean_logprob_auroc", "perplexity_auroc",
+                                   "seq_logprob_auroc"),
+}
+
+
+def _model_from_config_name(cfg_name: str) -> str:
+    stem = cfg_name.removesuffix(".json")
+    if stem.endswith("_qwen3"):
+        return "Qwen3-8B"
+    if stem.endswith("_smollm3"):
+        return "SmolLM3"
+    return "Llama-3.1-8B-Instruct"
+
+
+def _dataset_from_config_name(cfg_name: str, model_label: str) -> str:
+    stem = cfg_name.removesuffix(".json").removeprefix("baseline_comparison_")
+    if model_label == "Qwen3-8B":
+        stem = stem.removesuffix("_qwen3")
+    elif model_label == "SmolLM3":
+        stem = stem.removesuffix("_smollm3")
+    return stem
+
+
+def collect_training_cells() -> list[dict]:
+    """One cell per (config, dataset, method, seed)."""
+    cells: list[dict] = []
+    cfg_dir = PROJECT_ROOT / "configs" / "experiments"
+    for cfg_path in sorted(cfg_dir.glob("baseline_comparison_*.json")):
+        cfg = load_experiment_config(str(cfg_path), project_root=str(PROJECT_ROOT))
+        model_label = _model_from_config_name(cfg_path.name)
+        dataset_label = _dataset_from_config_name(cfg_path.name, model_label)
+
+        specs = enumerate_runs(
+            cfg,
+            output_base=cfg.get("output_dir", "runs"),
+            project_root=str(PROJECT_ROOT),
+        )
+        for spec in specs:
+            run_dir = Path(spec.run_dir)
+            status = classify_run(str(run_dir))
+            metrics: dict[str, float] = {}
+            if status == RunStatus.COMPLETE:
+                with open(run_dir / "eval_metrics.json") as f:
+                    eval_data = json.load(f)
+                allowed = _TRAINING_METRIC_KEYS.get(spec.method_name, ())
+                for k in allowed:
+                    v = eval_data.get(k)
+                    if isinstance(v, (int, float)) and np.isfinite(v):
+                        metrics[k] = float(v)
+
+            cells.append({
+                "key": {
+                    "dataset": dataset_label,
+                    "model": model_label,
+                    "method": spec.method_name,
+                    "seed": spec.seed,
+                },
+                "kind": "training",
+                "status": status.value,
+                "metrics": metrics,
+                "expected_rows": None,
+                "actual_rows": None,
+                "paths": {
+                    "run_dir":      _rel(run_dir),
+                    "eval_metrics": _rel(run_dir / "eval_metrics.json"),
+                    "config":       _rel(cfg_path),
+                },
+            })
+    return cells
+
+
+def _expected_sampling_rows(ds: str, mid: str, split: str, gen_n: int) -> int:
+    if split == "train":
+        idx_path = subset_index_path(ds, mid)
+        if idx_path.exists():
+            with open(idx_path) as f:
+                return len(json.load(f)["question_ids"])
+        return 5000
+    if ds == "searchqa":
+        cap_path = searchqa_test_cap_path(mid)
+        if cap_path.exists():
+            with open(cap_path) as f:
+                return len(json.load(f)["question_ids"])
+        return 10000
+    return gen_n
+
+
+def _load_jsonl_by_row(path: Path) -> dict[int, dict]:
+    by_row: dict[int, dict] = {}
+    if not path.exists():
+        return by_row
+    with open(path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+                by_row[rec["row_idx"]] = rec
+            except Exception:
+                pass
+    return by_row
+
+
+def _load_hallu_labels(ds: str, mid: str, split: str = "test") -> Optional[np.ndarray]:
+    p = eval_results_json(ds, mid, split)
+    if not p.exists():
+        return None
+    with open(p) as f:
+        return np.array(json.load(f)["halu_test_res"], dtype=int)
+
+
+def _load_cap(ds: str, mid: str) -> Optional[set[int]]:
+    if ds != "searchqa":
+        return None
+    p = searchqa_test_cap_path(mid)
+    if not p.exists():
+        return None
+    with open(p) as f:
+        return set(json.load(f)["question_ids"])
+
+
+def _aligned(by_row: dict, key: str, labels: np.ndarray, cap: Optional[set[int]]):
+    scores, lbls = [], []
+    for row_idx, rec in sorted(by_row.items()):
+        if cap is not None and row_idx not in cap:
+            continue
+        if row_idx >= len(labels):
+            continue
+        v = rec.get(key)
+        if v is None:
+            continue
+        if isinstance(v, float) and not np.isfinite(v):
+            continue
+        scores.append(v)
+        lbls.append(int(labels[row_idx]))
+    return scores, lbls
+
+
+def collect_sampling_cells() -> list[dict]:
+    """SE + SelfCheckGPT.
+
+    Each (dataset, model) generates several "method" rows, one per scoring
+    variant (semantic_entropy, length_normalized_se, discrete_se,
+    selfcheck_nli, selfcheck_ngram, selfcheck_bertscore). The test-split
+    JSONL is what defines completeness; AUROC is computed against
+    halu_test_res from eval_results_for_training.json.
+    """
+    cells: list[dict] = []
+
+    variants = [
+        # (method_key,            file_fn,               score_key)
+        ("se_semantic_entropy",   se_labels_path,        "semantic_entropy"),
+        ("se_length_normalized",  se_labels_path,        "length_normalized_se"),
+        ("se_discrete",           se_labels_path,        "discrete_se"),
+        ("selfcheck_nli",         selfcheck_scores_path, "nli"),
+        ("selfcheck_ngram",       selfcheck_scores_path, "ngram"),
+        ("selfcheck_bertscore",   selfcheck_scores_path, "bertscore"),
+    ]
+
+    for ds in SAMPLING_DATASETS:
+        for mid in SAMPLING_MODELS:
+            gen_n = _count_lines(generation_jsonl(ds, mid, "test"))
+            expected = _expected_sampling_rows(ds, mid, "test", gen_n)
+            labels = _load_hallu_labels(ds, mid, "test")
+            cap = _load_cap(ds, mid)
+
+            for method_key, path_fn, score_key in variants:
+                p = path_fn(ds, mid, "test")
+                actual = _count_lines(p)
+
+                if gen_n < 0:
+                    status = "missing"  # no generation
+                elif actual < 0:
+                    status = "missing"
+                elif actual < expected:
+                    status = "partial"
+                else:
+                    status = "complete"
+
+                metrics: dict[str, float] = {}
+                if status == "complete" and labels is not None:
+                    by_row = _load_jsonl_by_row(p)
+                    # bertscore lives in selfcheck_scores.jsonl but is gated
+                    # by --no-bertscore at generation time, so most rows lack
+                    # the key. We still try; _auroc returns None if too sparse.
+                    scores, lbls = _aligned(by_row, score_key, labels, cap)
+                    auroc = _auroc(scores, lbls)
+                    if auroc is not None:
+                        metrics["auroc"] = auroc
+                        metrics["n_scored"] = float(len(scores))
+
+                cells.append({
+                    "key": {
+                        "dataset": ds,
+                        "model": model_name(mid),
+                        "method": method_key,
+                        "seed": None,
+                    },
+                    "kind": "sampling",
+                    "status": status,
+                    "metrics": metrics,
+                    "expected_rows": expected if gen_n >= 0 else None,
+                    "actual_rows": actual if actual >= 0 else None,
+                    "paths": {
+                        "scores":     _rel(p),
+                        "generation": _rel(generation_jsonl(ds, mid, "test")),
+                        "labels":     _rel(eval_results_json(ds, mid, "test")),
+                    },
+                })
+    return cells
+
+
+def collect_sep_cells() -> list[dict]:
+    cells: list[dict] = []
+    sep_datasets = list(SAMPLING_DATASETS) + ["mmlu"]
+    for ds in sep_datasets:
+        for mid in SAMPLING_MODELS:
+            p = sep_results_path(ds, mid)
+            metrics: dict[str, float] = {}
+            status = "missing"
+            if p.exists():
+                status = "complete"
+                with open(p) as f:
+                    data = json.load(f)
+                for k in ("sep_se_auroc", "sep_binary_auroc"):
+                    v = data.get(k)
+                    if isinstance(v, (int, float)) and np.isfinite(v):
+                        metrics[k] = float(v)
+                for k in ("layer", "train_size_sep_se"):
+                    v = data.get(k)
+                    if isinstance(v, (int, float)):
+                        metrics[k] = float(v)
+            cells.append({
+                "key": {
+                    "dataset": ds,
+                    "model": model_name(mid),
+                    "method": "sep",
+                    "seed": None,
+                },
+                "kind": "sep",
+                "status": status,
+                "metrics": metrics,
+                "expected_rows": None,
+                "actual_rows": None,
+                "paths": {"sep_results": _rel(p)},
+            })
+    return cells
+
+
+def collect_p_true_cells() -> list[dict]:
+    cells: list[dict] = []
+    for mid in PTRUE_MODELS:
+        for ds in PTRUE_DATASETS:
+            p = ptrue_scores_path(ds, mid, "test")
+            gen_n = _count_lines(generation_jsonl(ds, mid, "test"))
+            actual = _count_lines(p)
+
+            if gen_n < 0:
+                status = "missing"
+            elif actual < 0:
+                status = "missing"
+            elif actual < gen_n:
+                status = "partial"
+            else:
+                status = "complete"
+
+            metrics: dict[str, float] = {}
+            if status == "complete":
+                labels = _load_hallu_labels(ds, mid, "test")
+                if labels is not None:
+                    by_row = _load_jsonl_by_row(p)
+                    fwd_scores, fwd_lbls = [], []
+                    rev_scores, rev_lbls = [], []
+                    for row_idx, rec in sorted(by_row.items()):
+                        if row_idx >= len(labels):
+                            continue
+                        lbl = int(labels[row_idx])
+                        if (v := rec.get("p_true")) is not None and np.isfinite(v):
+                            fwd_scores.append(1.0 - v)  # high score = halu
+                            fwd_lbls.append(lbl)
+                        if (v := rec.get("p_true_reversed")) is not None and np.isfinite(v):
+                            rev_scores.append(1.0 - v)
+                            rev_lbls.append(lbl)
+                    a_fwd = _auroc(fwd_scores, fwd_lbls)
+                    a_rev = _auroc(rev_scores, rev_lbls)
+                    if a_fwd is not None:
+                        metrics["p_true_auroc_fwd"] = a_fwd
+                    if a_rev is not None:
+                        metrics["p_true_auroc_rev"] = a_rev
+                    if a_fwd is not None or a_rev is not None:
+                        metrics["p_true_auroc_best"] = max(
+                            v for v in (a_fwd, a_rev) if v is not None
+                        )
+
+            cells.append({
+                "key": {
+                    "dataset": ds,
+                    "model": model_name(mid),
+                    "method": "p_true",
+                    "seed": None,
+                },
+                "kind": "p_true",
+                "status": status,
+                "metrics": metrics,
+                "expected_rows": gen_n if gen_n >= 0 else None,
+                "actual_rows": actual if actual >= 0 else None,
+                "paths": {
+                    "scores":     _rel(p),
+                    "generation": _rel(generation_jsonl(ds, mid, "test")),
+                    "labels":     _rel(eval_results_json(ds, mid, "test")),
+                },
+            })
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+CSV_COLUMNS = [
+    "kind", "dataset", "model", "method", "seed", "status",
+    "metric_name", "metric_value",
+    "expected_rows", "actual_rows", "path",
+]
+
+
+def cells_to_long_rows(cells: list[dict]) -> list[dict]:
+    rows: list[dict] = []
+    for c in cells:
+        key = c["key"]
+        primary_path = next(iter(c["paths"].values()), "")
+        base = {
+            "kind":          c["kind"],
+            "dataset":       key["dataset"],
+            "model":         key["model"],
+            "method":        key["method"],
+            "seed":          key["seed"] if key["seed"] is not None else "",
+            "status":        c["status"],
+            "expected_rows": c["expected_rows"] if c["expected_rows"] is not None else "",
+            "actual_rows":   c["actual_rows"] if c["actual_rows"] is not None else "",
+            "path":          primary_path,
+        }
+        if c["metrics"]:
+            for metric_name, value in c["metrics"].items():
+                rows.append({**base, "metric_name": metric_name, "metric_value": value})
+        else:
+            # Cells with no metrics still emit a single row (preserves coverage view).
+            rows.append({**base, "metric_name": "", "metric_value": ""})
+    return rows
+
+
+def write_outputs(cells: list[dict], out_dir: Path) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "results_table.json"
+    csv_path  = out_dir / "results_table.csv"
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "git": _git_info(),
+        "cells": cells,
+    }
+    with open(json_path, "w") as f:
+        json.dump(payload, f, indent=2, default=str)
+
+    rows = cells_to_long_rows(cells)
+    with open(csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+    return json_path, csv_path
+
+
+def _summary(cells: list[dict]) -> str:
+    by_kind: dict[str, dict[str, int]] = {}
+    for c in cells:
+        d = by_kind.setdefault(c["kind"], {})
+        d[c["status"]] = d.get(c["status"], 0) + 1
+        d["total"] = d.get("total", 0) + 1
+    lines = ["Summary:"]
+    for kind in ("training", "sampling", "sep", "p_true"):
+        d = by_kind.get(kind, {})
+        if not d:
+            continue
+        total = d.get("total", 0)
+        complete = d.get("complete", 0)
+        other = ", ".join(f"{k}={v}" for k, v in sorted(d.items())
+                          if k not in ("total", "complete"))
+        lines.append(f"  {kind:<10} {complete}/{total} complete  ({other})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=PROJECT_ROOT / "output" / "results_table",
+        help="Directory to write results_table.json + results_table.csv "
+             "(default: output/results_table/).",
+    )
+    args = parser.parse_args()
+
+    cells: list[dict] = []
+    cells += collect_training_cells()
+    cells += collect_sampling_cells()
+    cells += collect_sep_cells()
+    cells += collect_p_true_cells()
+
+    json_path, csv_path = write_outputs(cells, args.out_dir)
+    print(f"Wrote {json_path}")
+    print(f"Wrote {csv_path}")
+    print()
+    print(_summary(cells))
+    if not _HAS_SKLEARN:
+        print()
+        print("(note: sklearn not available — AUROC computed with numpy "
+              "Mann–Whitney implementation.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_p_true_for_model.py
+++ b/scripts/run_p_true_for_model.py
@@ -1,0 +1,80 @@
+"""P(true) driver: load model once, score all datasets.
+
+Saves ~30s × 5 model-load overhead compared to launching run_p_true_pass.py
+once per dataset. Preferred for single-node serial execution.
+
+Usage:
+    python scripts/run_p_true_for_model.py \\
+        --model meta-llama/Llama-3.1-8B-Instruct
+
+    python scripts/run_p_true_for_model.py \\
+        --model Qwen/Qwen3-8B \\
+        --datasets hotpotqa,nq,sciq
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.p_true.paths import DATASETS, ptrue_scores_path
+from tasks.p_true.scorer import PTrueScorer
+from tasks.sampling_baselines.paths import eval_results_json, generation_jsonl, model_name
+
+
+def load_labels(dataset: str, model_id: str, split: str) -> list:
+    eval_path = eval_results_json(dataset, model_id, split)
+    if not eval_path.exists():
+        raise FileNotFoundError(f"eval_results not found: {eval_path}")
+    with open(eval_path) as f:
+        data = json.load(f)
+    return data["halu_test_res"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="P(true) — load model once, score all datasets.")
+    parser.add_argument("--model", required=True, help="HuggingFace model ID")
+    parser.add_argument(
+        "--datasets",
+        default=",".join(DATASETS),
+        help="Comma-separated dataset names (default: all 6).",
+    )
+    parser.add_argument("--split", default="test", choices=["train", "test"])
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    datasets = [d.strip() for d in args.datasets.split(",") if d.strip()]
+    invalid = [d for d in datasets if d not in DATASETS]
+    if invalid:
+        print(f"ERROR: unknown datasets: {invalid}")
+        sys.exit(1)
+
+    print(f"Model: {model_name(args.model)}")
+    print(f"Datasets: {datasets}")
+    print(f"Split: {args.split} | batch_size={args.batch_size}\n")
+
+    scorer = PTrueScorer(model_name=args.model, batch_size=args.batch_size)
+
+    for ds in datasets:
+        gen_path = generation_jsonl(ds, args.model, args.split)
+        if not gen_path.exists():
+            print(f"SKIP {ds}: generation.jsonl not found ({gen_path})")
+            continue
+
+        try:
+            labels = load_labels(ds, args.model, args.split)
+        except FileNotFoundError as e:
+            print(f"SKIP {ds}: {e}")
+            continue
+
+        out_path = ptrue_scores_path(ds, args.model, args.split)
+        print(f"=== {ds} ===")
+        scorer.run(str(gen_path), str(out_path), row_indices=None, labels=labels)
+        print()
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_p_true_pass.py
+++ b/scripts/run_p_true_pass.py
@@ -1,0 +1,98 @@
+"""P(true) self-evaluation pass — per (dataset, model) cell.
+
+Scores each row in generation.jsonl with P(true) (Kadavath et al. 2022).
+Writes ptrue.jsonl to output/p_true/{dataset}/{model_name}/.
+Resumable: rows already present in ptrue.jsonl are skipped.
+
+Usage:
+    # Full test split (all rows — no cap, even for searchqa)
+    python scripts/run_p_true_pass.py \\
+        --dataset hotpotqa --model meta-llama/Llama-3.1-8B-Instruct
+
+    # Smoke test (first 50 rows, then validates resumability)
+    python scripts/run_p_true_pass.py \\
+        --dataset sciq --model meta-llama/Llama-3.1-8B-Instruct \\
+        --smoketest
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tasks.p_true.paths import DATASETS, ptrue_scores_path
+from tasks.p_true.scorer import PTrueScorer
+from tasks.sampling_baselines.paths import eval_results_json, generation_jsonl, model_name
+
+SMOKETEST_ROWS = 50
+
+
+def load_labels(dataset: str, model_id: str, split: str) -> list:
+    eval_path = eval_results_json(dataset, model_id, split)
+    if not eval_path.exists():
+        raise FileNotFoundError(f"eval_results not found: {eval_path}")
+    with open(eval_path) as f:
+        data = json.load(f)
+    return data["halu_test_res"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="P(true) scoring pass.")
+    parser.add_argument("--dataset", required=True, choices=DATASETS)
+    parser.add_argument("--split", default="test", choices=["train", "test"])
+    parser.add_argument("--model", required=True, help="HuggingFace model ID")
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument(
+        "--smoketest",
+        action="store_true",
+        help="Process first 50 rows only, then verify resumability.",
+    )
+    args = parser.parse_args()
+
+    gen_path = generation_jsonl(args.dataset, args.model, args.split)
+    if not gen_path.exists():
+        print(f"ERROR: generation.jsonl not found: {gen_path}")
+        sys.exit(1)
+
+    labels = load_labels(args.dataset, args.model, args.split)
+    out_path = ptrue_scores_path(args.dataset, args.model, args.split)
+
+    row_indices = None
+    if args.smoketest:
+        row_indices = list(range(SMOKETEST_ROWS))
+        print(f"SMOKETEST: processing first {SMOKETEST_ROWS} rows only.")
+
+    print(
+        f"Dataset: {args.dataset} | Split: {args.split} | "
+        f"Model: {model_name(args.model)} | batch_size={args.batch_size}"
+    )
+
+    scorer = PTrueScorer(model_name=args.model, batch_size=args.batch_size)
+    scorer.run(str(gen_path), str(out_path), row_indices=row_indices, labels=labels)
+
+    if args.smoketest:
+        # Verify resumability: re-running should be a no-op
+        print("\nSmoketest: verifying resumability (re-run should skip all rows)...")
+        scorer2 = PTrueScorer(model_name=args.model, batch_size=args.batch_size)
+        scorer2._model = scorer._model
+        scorer2._tokenizer = scorer._tokenizer
+        scorer2._tok_a = scorer._tok_a
+        scorer2._tok_b = scorer._tok_b
+        scorer2.run(str(gen_path), str(out_path), row_indices=row_indices, labels=labels)
+
+        # Spot-check 5 rows
+        print("\nSmoketest spot-check (5 rows):")
+        with open(out_path) as f:
+            rows = [json.loads(line) for line in f][:5]
+        for r in rows:
+            print(
+                f"  row_idx={r['row_idx']:5d} | p_true={r['p_true']:.4f} | "
+                f"p_true_reversed={r['p_true_reversed']:.4f} | "
+                f"halu_label={r['halu_label']}"
+            )
+        print(f"\nSmoketest passed. Output: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_p_true_shard.sh
+++ b/scripts/run_p_true_shard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run a shard of P(true) cells defined in a TSV file.
+#
+# TSV format (one header line, then one cell per line):
+#   # dataset\tmodel
+#   hotpotqa\tmeta-llama/Llama-3.1-8B-Instruct
+#   ...
+#
+# Usage:
+#   CELLS_FILE=reports/p_true_runs/fanout_XYZ/cells_nodeA.tsv bash scripts/run_p_true_shard.sh
+#
+# Within a node, cells are grouped by model to avoid reloading the model
+# between datasets with the same model. Uses run_p_true_for_model.py per
+# model group so the model is loaded exactly once per model.
+
+set -euo pipefail
+
+PYTHON="${PYTHON:-/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python}"
+CELLS_FILE="${CELLS_FILE:?CELLS_FILE env var must be set}"
+SPLIT="${SPLIT:-test}"
+BATCH_SIZE="${BATCH_SIZE:-64}"
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -f "$CELLS_FILE" ]]; then
+    echo "ERROR: CELLS_FILE not found: $CELLS_FILE" >&2
+    exit 1
+fi
+
+echo "=== P(true) shard: $CELLS_FILE ==="
+echo "PYTHON=$PYTHON | SPLIT=$SPLIT | BATCH_SIZE=$BATCH_SIZE"
+echo
+
+# Parse TSV into (dataset, model) pairs, skipping comments/header
+declare -A model_datasets  # model -> comma-separated datasets
+
+while IFS=$'\t' read -r dataset model; do
+    [[ "$dataset" =~ ^#.*$ ]] && continue
+    [[ -z "$dataset" || -z "$model" ]] && continue
+    if [[ -v model_datasets["$model"] ]]; then
+        model_datasets["$model"]="${model_datasets[$model]},${dataset}"
+    else
+        model_datasets["$model"]="$dataset"
+    fi
+done < "$CELLS_FILE"
+
+for model in "${!model_datasets[@]}"; do
+    datasets="${model_datasets[$model]}"
+    echo "--- Model: $model | Datasets: $datasets ---"
+    "$PYTHON" scripts/run_p_true_for_model.py \
+        --model "$model" \
+        --datasets "$datasets" \
+        --split "$SPLIT" \
+        --batch-size "$BATCH_SIZE"
+    echo
+done
+
+echo "=== Shard complete ==="

--- a/scripts/smoketest_sep.sh
+++ b/scripts/smoketest_sep.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Smoke-test the SEP-SE pipeline end-to-end on the smallest dataset (sciq, 1000
+# test rows). Sweeps 2 layers for Qwen3, then fits one probe via auto-layer.
+# Verifies outputs exist, contain expected keys, and produce a sane AUROC.
+#
+# Expect wall-clock ~3-5 min on alphacpu.
+set -euo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+MODEL="Qwen/Qwen3-8B"
+DATASET="sciq"
+LAYERS="22 24"   # 2 layers — full default is 6
+MODEL_NAME=$(basename "$MODEL")
+
+LOG_DIR=reports/sampling_baselines_runs/sep_logs
+mkdir -p "$LOG_DIR"
+STAMP=$(date +%Y%m%d_%H%M%S)
+LOG="$LOG_DIR/smoketest_${DATASET}_${MODEL_NAME}_${STAMP}.log"
+
+SWEEP_FILE="output/sampling_baselines/sep/${MODEL_NAME}/layer_sweep_${DATASET}.json"
+RESULT_FILE="output/sampling_baselines/sep/${MODEL_NAME}/${DATASET}_sep_results.json"
+
+echo "============================================" | tee "$LOG"
+echo "SEP-SE smoketest"                              | tee -a "$LOG"
+echo "Model:     $MODEL"                             | tee -a "$LOG"
+echo "Dataset:   $DATASET"                           | tee -a "$LOG"
+echo "Layers:    $LAYERS"                            | tee -a "$LOG"
+echo "Started:   $(date) | Host: $(hostname)"        | tee -a "$LOG"
+echo "Log:       $LOG"                               | tee -a "$LOG"
+echo "============================================" | tee -a "$LOG"
+
+# ---------------------------------------------------------------------------
+# Phase 5a: layer sweep
+# ---------------------------------------------------------------------------
+echo                                                  | tee -a "$LOG"
+echo "--- Phase 5a: layer sweep ---"                  | tee -a "$LOG"
+$PYTHON scripts/compute_sep_layer_sweep.py \
+    --dataset "$DATASET" \
+    --model   "$MODEL" \
+    --layers  $LAYERS \
+    2>&1 | tee -a "$LOG"
+
+if [[ ! -f "$SWEEP_FILE" ]]; then
+    echo "FAIL: sweep file not written → $SWEEP_FILE"  | tee -a "$LOG"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 5: probe fit (auto layer from sweep)
+# ---------------------------------------------------------------------------
+echo                                                  | tee -a "$LOG"
+echo "--- Phase 5: probe fit (auto layer) ---"        | tee -a "$LOG"
+$PYTHON scripts/compute_sep.py \
+    --dataset "$DATASET" \
+    --model   "$MODEL" \
+    --force \
+    2>&1 | tee -a "$LOG"
+
+if [[ ! -f "$RESULT_FILE" ]]; then
+    echo "FAIL: result file not written → $RESULT_FILE" | tee -a "$LOG"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+echo                                                  | tee -a "$LOG"
+echo "--- Verifying outputs ---"                      | tee -a "$LOG"
+$PYTHON - <<PY 2>&1 | tee -a "$LOG"
+import json, sys
+sweep = json.load(open("$SWEEP_FILE"))
+res   = json.load(open("$RESULT_FILE"))
+
+problems = []
+
+# Sweep
+for k in ("dataset", "model", "layers_swept", "auroc_by_layer", "best_layer", "seed", "val_frac"):
+    if k not in sweep:
+        problems.append(f"sweep missing key: {k}")
+if sweep.get("dataset") != "$DATASET":
+    problems.append(f"sweep dataset mismatch: {sweep.get('dataset')}")
+sw_layers = set(int(k) for k in sweep.get("auroc_by_layer", {}).keys())
+exp_layers = set(int(x) for x in "$LAYERS".split())
+if sw_layers != exp_layers:
+    problems.append(f"sweep layers mismatch: got {sw_layers}, expected {exp_layers}")
+for layer, auroc in sweep.get("auroc_by_layer", {}).items():
+    if not (0.0 <= auroc <= 1.0):
+        problems.append(f"sweep AUROC out of range for layer {layer}: {auroc}")
+
+# Result
+for k in ("dataset", "model", "layer", "alpha", "sep_se_auroc",
+          "train_size_sep_se", "test_size", "layer_source"):
+    if k not in res:
+        problems.append(f"result missing key: {k}")
+if res.get("layer") != sweep.get("best_layer"):
+    problems.append(
+        f"result layer={res.get('layer')} != sweep best_layer={sweep.get('best_layer')}"
+    )
+if not (0.0 <= res.get("sep_se_auroc", -1) <= 1.0):
+    problems.append(f"result AUROC out of range: {res.get('sep_se_auroc')}")
+if res.get("test_size", 0) < 100:
+    problems.append(f"result test_size suspiciously small: {res.get('test_size')}")
+
+print()
+print("SWEEP:")
+print(f"  best_layer = {sweep.get('best_layer')}")
+for layer in sorted(sweep.get("auroc_by_layer", {}), key=int):
+    print(f"  layer {layer}: val AUROC = {sweep['auroc_by_layer'][layer]:.4f}")
+print()
+print("RESULT:")
+print(f"  layer = {res.get('layer')}  (source: {res.get('layer_source')})")
+print(f"  test AUROC = {res.get('sep_se_auroc'):.4f}")
+print(f"  n_train = {res.get('train_size_sep_se')}, n_test = {res.get('test_size')}")
+print()
+if problems:
+    print("FAIL — issues found:")
+    for p in problems:
+        print(f"  - {p}")
+    sys.exit(1)
+print("PASS — all checks ok.")
+PY
+
+echo                                                  | tee -a "$LOG"
+echo "DONE: $(date)"                                  | tee -a "$LOG"

--- a/tasks/p_true/paths.py
+++ b/tasks/p_true/paths.py
@@ -1,0 +1,20 @@
+"""Path resolution for P(true) artefacts."""
+from pathlib import Path
+
+from tasks.sampling_baselines.paths import _dir_stem, model_name
+
+DATASETS = ["hotpotqa", "nq", "popqa", "sciq", "searchqa", "mmlu"]
+MODELS = [
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "Qwen/Qwen3-8B",
+]
+
+
+def ptrue_output_dir(dataset: str, model_id: str, split: str = "test") -> Path:
+    stem = _dir_stem(dataset)
+    ds_dir = f"{stem}_train" if split == "train" else stem
+    return Path("output") / "p_true" / ds_dir / model_name(model_id)
+
+
+def ptrue_scores_path(dataset: str, model_id: str, split: str = "test") -> Path:
+    return ptrue_output_dir(dataset, model_id, split) / "ptrue.jsonl"

--- a/tasks/p_true/scorer.py
+++ b/tasks/p_true/scorer.py
@@ -1,0 +1,235 @@
+"""P(true) self-evaluation detector (Kadavath et al. 2022).
+
+One forward pass per example: prefix the question + greedy answer into the
+Kadavath prompt, read logits at the first generated token for tokens " A" and
+" B", compute softmax probability. No chat template (raw string), matching the
+original paper and LLMsKnow exactly.
+
+Score direction: p_true is a *correctness* probability.  For AUROC vs
+halu_label (1=hallucinated), use ``1 - p_true`` as the anomaly score
+(high p_true ⇒ model claims correct ⇒ low hallucination score).
+
+Output per row (ptrue.jsonl):
+    {"row_idx": int, "p_true": float, "p_true_reversed": float,
+     "p_a": float, "p_b": float, "halu_label": 0|1|null}
+
+``p_true_reversed`` is the P(true) score from the variant where (A)=False,
+(B)=True, providing a token-position-bias sanity check.
+"""
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+from tqdm import tqdm
+
+_PROMPT_TEMPLATE = (
+    "Question: {question}\n"
+    "Possible answer: {answer}\n"
+    "Is the possible answer:\n"
+    "(A) True\n"
+    "(B) False\n"
+    "The possible answer is:"
+)
+
+_PROMPT_TEMPLATE_REVERSED = (
+    "Question: {question}\n"
+    "Possible answer: {answer}\n"
+    "Is the possible answer:\n"
+    "(A) False\n"
+    "(B) True\n"
+    "The possible answer is:"
+)
+
+
+def _build_prompt(question: str, answer: str, reversed_: bool = False) -> str:
+    tmpl = _PROMPT_TEMPLATE_REVERSED if reversed_ else _PROMPT_TEMPLATE
+    return tmpl.format(question=question.strip(), answer=answer.strip())
+
+
+def _extract_question(row: dict) -> str:
+    if "question" in row:
+        return row["question"]
+    # Fall back: prompt usually starts with "Question: ..."
+    prompt = row.get("prompt", "")
+    for line in prompt.splitlines():
+        line = line.strip()
+        if line.lower().startswith("question:"):
+            return line[len("question:"):].strip()
+    return prompt
+
+
+class PTrueScorer:
+    """Batched P(true) scorer — loads the model once, runs forward + reversed pass.
+
+    Tokenization invariant: " A" and " B" must each be a single token on the
+    model's tokenizer. Verified in __init__; fails fast with a clear message if not.
+    """
+
+    def __init__(self, model_name: str, batch_size: int = 64):
+        self.model_name = model_name
+        self.batch_size = batch_size
+        self._model = None
+        self._tokenizer = None
+        self._tok_a: Optional[int] = None
+        self._tok_b: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        generation_jsonl: str,
+        output_path: str,
+        row_indices: Optional[List[int]] = None,
+        labels: Optional[List[int]] = None,
+    ) -> None:
+        """Score every row in generation_jsonl with P(true).
+
+        Args:
+            generation_jsonl: Path to existing generation.jsonl.
+            output_path: Destination ptrue.jsonl.
+            row_indices: 0-based row indices to process (None = all rows).
+            labels: Full halu_test_res list so labels[row_idx] gives the
+                    label.  Pass None to omit halu_label from output.
+        """
+        self._ensure_loaded()
+
+        import pandas as pd
+        gendf = pd.read_json(generation_jsonl, lines=True)
+        gendf["row_idx"] = gendf.index
+
+        if row_indices is not None:
+            gendf = gendf[gendf["row_idx"].isin(set(row_indices))].reset_index(drop=True)
+
+        done_rows = _load_done_rows(output_path)
+        remaining = gendf[~gendf["row_idx"].isin(done_rows)].reset_index(drop=True)
+
+        if len(remaining) == 0:
+            print(f"All {len(gendf)} rows already done — skipping.")
+            return
+
+        print(
+            f"P(true) scoring {len(remaining)} rows "
+            f"({len(done_rows)} already done) | batch_size={self.batch_size}"
+        )
+
+        row_idxs = remaining["row_idx"].tolist()
+        questions = [_extract_question(r) for r in remaining.to_dict("records")]
+        answers = remaining["generation"].tolist()
+
+        fwd_prompts = [_build_prompt(q, a, reversed_=False) for q, a in zip(questions, answers)]
+        rev_prompts = [_build_prompt(q, a, reversed_=True) for q, a in zip(questions, answers)]
+
+        print("  Forward pass...")
+        fwd_scores = self._score_batches(fwd_prompts)
+        print("  Reversed pass...")
+        rev_scores = self._score_batches(rev_prompts)
+
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "a", encoding="utf-8") as f:
+            for i, row_idx in enumerate(row_idxs):
+                p_a_fwd, p_b_fwd = fwd_scores[i]
+                p_a_rev, p_b_rev = rev_scores[i]
+                # forward: (A)=True → p_true = p_a_fwd
+                # reversed: (B)=True → p_true_reversed = p_b_rev
+                halu_label = labels[row_idx] if labels is not None and row_idx < len(labels) else None
+                record = {
+                    "row_idx": row_idx,
+                    "p_true": p_a_fwd,
+                    "p_true_reversed": p_b_rev,
+                    "p_a": p_a_fwd,
+                    "p_b": p_b_fwd,
+                    "halu_label": halu_label,
+                }
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        print(f"Written {len(row_idxs)} records → {output_path}")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_loaded(self) -> None:
+        if self._model is not None:
+            return
+        from activation_logging.server import get_model_and_tokenizer
+
+        print(f"Loading model: {self.model_name}")
+        self._model, self._tokenizer = get_model_and_tokenizer(self.model_name, None)
+
+        tok = self._tokenizer
+        tok.padding_side = "left"
+        if tok.pad_token is None:
+            tok.pad_token = tok.eos_token
+
+        # Verify " A" and " B" are single tokens (fail fast)
+        for token_str in [" A", " B"]:
+            ids = tok.encode(token_str, add_special_tokens=False)
+            if len(ids) != 1:
+                raise RuntimeError(
+                    f'Token "{token_str}" encodes to {len(ids)} tokens on '
+                    f"{self.model_name}: {ids}. "
+                    "P(true) requires single-token decode for ' A' and ' B'."
+                )
+        self._tok_a = tok.encode(" A", add_special_tokens=False)[0]
+        self._tok_b = tok.encode(" B", add_special_tokens=False)[0]
+        print(f'Tokenization check passed: " A"={self._tok_a}, " B"={self._tok_b}')
+
+    def _score_batches(self, prompts: List[str]) -> List[tuple]:
+        """Return list of (p_a, p_b) tuples, one per prompt."""
+        results = []
+        for b_start in tqdm(range(0, len(prompts), self.batch_size), leave=False):
+            batch = prompts[b_start : b_start + self.batch_size]
+            results.extend(self._score_batch(batch))
+        return results
+
+    def _score_batch(self, prompts: List[str]) -> List[tuple]:
+        model, tokenizer = self._model, self._tokenizer
+        device = next(model.parameters()).device
+
+        inputs = tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            add_special_tokens=False,
+        ).to(device)
+
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=1,
+                do_sample=False,
+                output_scores=True,
+                return_dict_in_generate=True,
+                pad_token_id=tokenizer.pad_token_id,
+            )
+
+        # scores[0]: logits at the first generated token, shape (batch, vocab)
+        logits = outputs.scores[0]
+        ab_logits = logits[:, [self._tok_a, self._tok_b]]
+        probs = F.softmax(ab_logits.float(), dim=-1).cpu()
+
+        del outputs
+        return [(float(probs[i, 0]), float(probs[i, 1])) for i in range(len(prompts))]
+
+
+# ------------------------------------------------------------------
+# Module-level helpers (shared with scripts)
+# ------------------------------------------------------------------
+
+def _load_done_rows(output_path: str) -> set:
+    done = set()
+    p = Path(output_path)
+    if not p.exists():
+        return done
+    with open(p) as f:
+        for line in f:
+            try:
+                done.add(json.loads(line)["row_idx"])
+            except Exception:
+                pass
+    return done

--- a/tasks/sampling_baselines/sep.py
+++ b/tasks/sampling_baselines/sep.py
@@ -1,4 +1,11 @@
-"""Semantic Entropy Probes (SEP): linear probes on cached greedy activations."""
+"""Semantic Entropy Probes (SEP-SE): Ridge probes on cached greedy activations.
+
+Implements SEP-SE per Kossen et al. 2024: a single-pass linear probe that
+predicts length-normalized semantic entropy from one greedy hidden state, then
+is scored as a hallucination detector via AUROC against binary halu labels on
+the test split. SEP-binary (a logistic probe on halu labels directly) is not
+in the original paper and is intentionally omitted.
+"""
 import hashlib
 import json
 from pathlib import Path
@@ -6,8 +13,9 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
-from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.linear_model import Ridge
 from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
@@ -23,12 +31,6 @@ def extract_last_token_features(
     row_indices: Optional[List[int]] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Extract last-response-token hidden state at layer_idx from greedy zarr store.
-
-    Args:
-        generation_jsonl: Path to generation.jsonl for prompt→hash mapping.
-        zarr_path: Path to zarr activation store.
-        layer_idx: Layer to read.
-        row_indices: Subset of row indices to extract (None = all).
 
     Returns:
         (X, valid_row_indices) where X has shape (n_valid, hidden_dim).
@@ -47,8 +49,8 @@ def extract_last_token_features(
 
     zarr_logger = ZarrActivationsLogger(zarr_path=str(zarr_path), read_only=True, verbose=False)
 
-    features = []
-    valid_indices = []
+    features: List[np.ndarray] = []
+    valid_indices: List[int] = []
 
     for _, row in gendf.iterrows():
         key = row["prompt_hash"]
@@ -60,7 +62,8 @@ def extract_last_token_features(
         features.append(last_tok)
         valid_indices.append(int(row["row_idx"]))
 
-    zarr_logger.close() if hasattr(zarr_logger, "close") else None
+    if hasattr(zarr_logger, "close"):
+        zarr_logger.close()
 
     if not features:
         return np.zeros((0, 0), dtype=np.float32), np.array([], dtype=np.int64)
@@ -69,194 +72,186 @@ def extract_last_token_features(
 
 
 # ---------------------------------------------------------------------------
-# Probe fitting
+# Probe fit / eval
 # ---------------------------------------------------------------------------
 
 def fit_sep_se(X_train: np.ndarray, y_se: np.ndarray, alpha: float = 1.0) -> Pipeline:
-    """Ridge regression probe predicting length-normalized SE."""
+    """Ridge probe predicting length-normalized SE."""
     pipe = Pipeline([("scaler", StandardScaler()), ("ridge", Ridge(alpha=alpha))])
     pipe.fit(X_train, y_se)
     return pipe
 
 
-def fit_sep_binary(X_train: np.ndarray, y_binary: np.ndarray) -> Pipeline:
-    """Logistic regression probe predicting binary hallucination label."""
-    pipe = Pipeline(
-        [
-            ("scaler", StandardScaler()),
-            ("logreg", LogisticRegression(max_iter=1000, C=1.0)),
-        ]
-    )
-    pipe.fit(X_train, y_binary.astype(int))
-    return pipe
-
-
-def eval_auroc(pipe: Pipeline, X_test: np.ndarray, y_binary: np.ndarray, is_regression: bool) -> float:
-    """AUROC of a fitted probe against binary hallucination labels."""
-    if is_regression:
-        scores = pipe.predict(X_test)
-    else:
-        scores = pipe.predict_proba(X_test)[:, 1]
+def eval_auroc(pipe: Pipeline, X: np.ndarray, y_binary: np.ndarray) -> float:
+    """AUROC of the probe's regression score against binary hallucination labels."""
+    scores = pipe.predict(X)
     return float(roc_auc_score(y_binary.astype(int), scores))
 
 
+def _load_se_labels(se_labels_path: str) -> Dict[int, float]:
+    out: Dict[int, float] = {}
+    with open(se_labels_path) as f:
+        for line in f:
+            rec = json.loads(line)
+            out[int(rec["row_idx"])] = float(rec["length_normalized_se"])
+    return out
+
+
 # ---------------------------------------------------------------------------
-# Layer sweep (for Qwen3-8B)
+# Layer sweep (SEP-SE, val AUROC on inner split of train subset)
 # ---------------------------------------------------------------------------
 
-def layer_sweep_sep_binary(
-    generation_jsonl: str,
-    zarr_path: str,
-    eval_json: str,
+def layer_sweep_sep_se(
+    generation_jsonl_train: str,
+    zarr_path_train: str,
+    eval_json_train: str,
+    se_labels_train_path: str,
+    train_subset_indices: List[int],
     layers: List[int],
     val_frac: float = 0.2,
     seed: int = 42,
 ) -> Dict[int, float]:
-    """Fit SEP-binary for each layer; return {layer: val_auroc}."""
-    from sklearn.model_selection import train_test_split
+    """Fit SEP-SE per layer on 80% of the train subset; report val AUROC on 20%.
 
-    with open(eval_json) as f:
-        eval_data = json.load(f)
-    all_labels = np.array(eval_data["halu_test_res"], dtype=bool)
+    Layer is selected by AUROC against binary halu labels on a held-out fold of
+    the train subset (the test split is never touched here).
+    """
+    with open(eval_json_train) as f:
+        train_labels_full = np.array(json.load(f)["halu_test_res"], dtype=bool)
+    se_by_row = _load_se_labels(se_labels_train_path)
 
     results: Dict[int, float] = {}
     for layer in layers:
-        print(f"  Layer {layer}...", end=" ")
-        X, valid_idx = extract_last_token_features(generation_jsonl, zarr_path, layer)
+        print(f"  Layer {layer}...", end=" ", flush=True)
+        X, valid_idx = extract_last_token_features(
+            generation_jsonl_train,
+            zarr_path_train,
+            layer,
+            row_indices=train_subset_indices,
+        )
         if len(X) == 0:
             print("no activations — skipped")
             continue
 
-        y = all_labels[valid_idx]
+        keep = np.array([r in se_by_row for r in valid_idx], dtype=bool)
+        X = X[keep]
+        valid_idx = valid_idx[keep]
+        if len(X) == 0:
+            print("no SE-labelled rows — skipped")
+            continue
+
+        y_se = np.array([se_by_row[int(r)] for r in valid_idx], dtype=np.float32)
+        y_bin = train_labels_full[valid_idx]
 
         try:
-            X_train, X_val, y_train, y_val = train_test_split(
-                X, y, test_size=val_frac, stratify=y, random_state=seed
+            X_tr, X_va, ys_tr, _ys_va, _yb_tr, yb_va = train_test_split(
+                X, y_se, y_bin, test_size=val_frac, stratify=y_bin, random_state=seed
             )
         except ValueError:
-            X_train, X_val, y_train, y_val = train_test_split(
-                X, y, test_size=val_frac, random_state=seed
+            X_tr, X_va, ys_tr, _ys_va, _yb_tr, yb_va = train_test_split(
+                X, y_se, y_bin, test_size=val_frac, random_state=seed
             )
 
-        pipe = fit_sep_binary(X_train, y_train)
-        auroc = eval_auroc(pipe, X_val, y_val, is_regression=False)
+        pipe = fit_sep_se(X_tr, ys_tr)
+        try:
+            auroc = eval_auroc(pipe, X_va, yb_va)
+        except ValueError:
+            auroc = float("nan")
         results[layer] = auroc
-        print(f"AUROC={auroc:.4f}")
+        print(f"val AUROC={auroc:.4f}  (n_train={len(X_tr)}, n_val={len(X_va)})")
 
     return results
 
 
 # ---------------------------------------------------------------------------
-# Full SEP run
+# Full SEP-SE run
 # ---------------------------------------------------------------------------
 
 def run_sep(
     dataset: str,
     model_id: str,
     layer_idx: int,
-    train_subset_indices: Optional[List[int]],
-    se_labels_train_path: Optional[str],
+    train_subset_indices: List[int],
+    se_labels_train_path: str,
     output_path: str,
+    test_subset_indices: Optional[List[int]] = None,
+    alpha: float = 1.0,
 ) -> dict:
-    """Fit SEP-SE and SEP-binary probes; return result dict.
+    """Fit SEP-SE on the 5k train subset; evaluate AUROC on test split.
 
     Args:
-        train_subset_indices: Row indices for SEP-SE training (5k stratified subset).
-            If None, SEP-SE is skipped (e.g. MMLU).
-        se_labels_train_path: Path to se_labels.jsonl for train split.
-            Required when train_subset_indices is not None.
+        test_subset_indices: Restrict test extraction to these row indices
+            (used for the searchqa 10k cap; None = all test rows).
+        alpha: Ridge regularization strength.
     """
     from tasks.sampling_baselines.paths import (
-        generation_jsonl,
         eval_results_json,
+        generation_jsonl,
         zarr_path as get_zarr_path,
     )
 
     gen_train = str(generation_jsonl(dataset, model_id, "train"))
     gen_test = str(generation_jsonl(dataset, model_id, "test"))
-    eval_train = str(eval_results_json(dataset, model_id, "train"))
     eval_test = str(eval_results_json(dataset, model_id, "test"))
     zarr_train = str(get_zarr_path(dataset, model_id, "train"))
     zarr_test = str(get_zarr_path(dataset, model_id, "test"))
 
-    # Load binary labels
-    with open(eval_train) as f:
-        train_eval = json.load(f)
     with open(eval_test) as f:
-        test_eval = json.load(f)
+        test_labels = np.array(json.load(f)["halu_test_res"], dtype=bool)
+    se_by_row = _load_se_labels(se_labels_train_path)
 
-    train_labels_full = np.array(train_eval["halu_test_res"], dtype=bool)
-    test_labels = np.array(test_eval["halu_test_res"], dtype=bool)
+    # --- Train features (SE-labelled subset) ---
+    print(
+        f"Extracting SEP-SE train features "
+        f"({len(train_subset_indices)} rows requested, layer {layer_idx})..."
+    )
+    X_train, train_valid_idx = extract_last_token_features(
+        gen_train, zarr_train, layer_idx, row_indices=train_subset_indices
+    )
+    keep = np.array([int(r) in se_by_row for r in train_valid_idx], dtype=bool)
+    X_train = X_train[keep]
+    train_valid_idx = train_valid_idx[keep]
+    y_se = np.array([se_by_row[int(r)] for r in train_valid_idx], dtype=np.float32)
+
+    if len(X_train) == 0:
+        raise RuntimeError(
+            f"No SE-labelled rows with cached activations for {dataset}/{model_id} train"
+        )
+
+    # --- Test features ---
+    n_test_req = len(test_subset_indices) if test_subset_indices is not None else None
+    print(
+        f"Extracting SEP-SE test features (layer {layer_idx}"
+        + (f", {n_test_req} subset rows" if n_test_req is not None else "")
+        + ")..."
+    )
+    X_test, test_valid_idx = extract_last_token_features(
+        gen_test, zarr_test, layer_idx, row_indices=test_subset_indices
+    )
+    if len(X_test) == 0:
+        raise RuntimeError(
+            f"No cached test activations for {dataset}/{model_id} at layer {layer_idx}"
+        )
+    y_test = test_labels[test_valid_idx]
+
+    pipe = fit_sep_se(X_train, y_se, alpha=alpha)
+    auroc = eval_auroc(pipe, X_test, y_test)
 
     result = {
         "dataset": dataset,
         "model": model_id,
         "layer": layer_idx,
+        "alpha": alpha,
+        "sep_se_auroc": auroc,
+        "train_size_sep_se": int(len(X_train)),
+        "test_size": int(len(X_test)),
+        "test_subset_size": n_test_req,
     }
-
-    # --- SEP-binary (full train split) ---
-    print(f"Extracting test features (layer {layer_idx})...")
-    X_test, test_valid_idx = extract_last_token_features(gen_test, zarr_test, layer_idx)
-    y_test = test_labels[test_valid_idx]
-
-    print(f"Extracting train features for SEP-binary (layer {layer_idx})...")
-    X_train_full, train_valid_idx_full = extract_last_token_features(gen_train, zarr_train, layer_idx)
-    y_train_full = train_labels_full[train_valid_idx_full]
-
-    pipe_binary = fit_sep_binary(X_train_full, y_train_full)
-    auroc_binary = eval_auroc(pipe_binary, X_test, y_test, is_regression=False)
-
-    result["sep_binary_auroc"] = auroc_binary
-    result["train_size_sep_binary"] = len(X_train_full)
-    print(f"SEP-binary AUROC: {auroc_binary:.4f} (n_train={len(X_train_full)})")
-
-    # --- SEP-SE (5k stratified subset) ---
-    if train_subset_indices is not None and se_labels_train_path is not None:
-        se_by_row = _load_se_labels(se_labels_train_path)
-        # Only keep rows present in both SE labels and valid activations
-        subset_set = set(train_subset_indices)
-
-        print(f"Extracting subset features for SEP-SE ({len(subset_set)} rows)...")
-        X_subset, subset_valid_idx = extract_last_token_features(
-            gen_train, zarr_train, layer_idx, row_indices=train_subset_indices
-        )
-
-        # Align SE labels with extracted features
-        y_se = np.array(
-            [se_by_row[r]["length_normalized_se"] for r in subset_valid_idx if r in se_by_row],
-            dtype=np.float32,
-        )
-        X_se = X_subset[[i for i, r in enumerate(subset_valid_idx) if r in se_by_row]]
-        se_test_valid = np.array(
-            [r in se_by_row for r in subset_valid_idx], dtype=bool
-        )
-        kept = se_test_valid.sum()
-
-        if kept > 0:
-            pipe_se = fit_sep_se(X_se, y_se)
-            auroc_se = eval_auroc(pipe_se, X_test, y_test, is_regression=True)
-            result["sep_se_auroc"] = auroc_se
-            result["train_size_sep_se"] = int(kept)
-            print(f"SEP-SE AUROC: {auroc_se:.4f} (n_train={kept})")
-        else:
-            result["sep_se_auroc"] = None
-            result["train_size_sep_se"] = 0
-    else:
-        result["sep_se_auroc"] = None
-        result["train_size_sep_se"] = 0
 
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w") as f:
         json.dump(result, f, indent=2)
+    print(f"SEP-SE AUROC: {auroc:.4f} (n_train={len(X_train)}, n_test={len(X_test)})")
     print(f"SEP results → {output_path}")
 
     return result
-
-
-def _load_se_labels(se_labels_path: str) -> dict:
-    by_row = {}
-    with open(se_labels_path) as f:
-        for line in f:
-            rec = json.loads(line)
-            by_row[rec["row_idx"]] = rec
-    return by_row


### PR DESCRIPTION
Closes #50.

## Summary

- **`tasks/p_true/scorer.py`** — `PTrueScorer`: batched forward + reversed pass using `max_new_tokens=1` + `scores[0]`. Verifies `" A"` / `" B"` are single tokens on init (fail-fast). Resumable via `row_idx` in output. Score direction: `1 - p_true` for AUROC (high p_true ⇒ model claims correct ⇒ low halu score).
- **`tasks/p_true/paths.py`** — `ptrue_scores_path()`, `ptrue_output_dir()`, following `sampling_baselines` layout.
- **`scripts/run_p_true_pass.py`** — per-(dataset, model) CLI driver. No SearchQA cap (P(true) is ~10× cheaper than SE). `--smoketest` runs 50 rows + validates resume.
- **`scripts/run_p_true_for_model.py`** — load model once, iterate all 6 datasets (saves ~5× model-load overhead vs per-cell dispatch).
- **`scripts/run_p_true_shard.sh`** — shard runner; groups cells by model so model loads once per model per node.
- **`scripts/fanout_p_true.py`** — multi-node round-robin fanout over 12 cells (6 datasets × 2 models, test split only).
- **`scripts/audit_p_true.py`** — `--check-counts` (gen rows vs ptrue rows per cell) + `--spot-check N` (prints Q/A/p_true/halu_label, saves to `reports/p_true_spotchecks/`).
- **`scripts/assemble_baseline_table.py`** — adds `p_true` column (headline = `max(AUROC_fwd, AUROC_rev)`), `p_true_auroc_fwd`, `p_true_auroc_rev`; new `--with-ci` flag writes `output/baseline_results/p_true_bootstrap.json` (1000-resample bootstrap 95% CIs).

## Dispatch plan

```bash
# Phase 0: smoketest (one cell, 50 rows)
python scripts/run_p_true_pass.py \
    --dataset sciq --model meta-llama/Llama-3.1-8B-Instruct --smoketest

# Phase 1 (single node, ~2-4h wall)
python scripts/run_p_true_for_model.py --model meta-llama/Llama-3.1-8B-Instruct
python scripts/run_p_true_for_model.py --model Qwen/Qwen3-8B

# Phase 2: table + CIs
python scripts/assemble_baseline_table.py --with-ci
python scripts/audit_p_true.py --check-counts --spot-check 20
```

## Test plan

- [ ] Smoketest passes on `sciq/Llama`: 50-row `ptrue.jsonl`, both `p_true` and `p_true_reversed` ∈ [0, 1], resume is no-op
- [ ] Tokenization assertion logged at startup for both models: `" A"={tok_id}, " B"={tok_id}`
- [ ] `audit_p_true.py --check-counts` shows OK for all 12 cells after full run
- [ ] `audit_p_true.py --spot-check 20` reviewed manually for 12 cells
- [ ] `assemble_baseline_table.py` prints `p_true` column without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)