### PR TITLE
feat(#62): cross-dataset transfer matrix evaluation

### DIFF
--- a/activation_research/transfer_eval.py
+++ b/activation_research/transfer_eval.py
@@ -1,0 +1,310 @@
+"""Transfer evaluation: apply source-trained checkpoints to target datasets."""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+from torch.utils.data import DataLoader
+
+from activation_logging.activation_parser import ActivationParser
+from activation_research.metrics import knn_ood_stats, mahalanobis_ood_stats
+from activation_research.model import (
+    LinearProbe,
+    LogprobReconProgressiveCompressor,
+    SimpleHaluClassifier,
+)
+
+
+_CHECKPOINT_FILE = {
+    "contrastive_logprob_recon": "contrastive_last.pt",
+    "linear_probe": "linear_probe_last.pt",
+    "saplma": "linear_probe_last.pt",
+}
+
+_FALLBACK_CHECKPOINT = "trainer_last.pt"
+
+
+def _build_activation_parser(zarr_path: str, eval_json_path: str) -> ActivationParser:
+    """Construct ActivationParser for a pre-split zarr store (split_strategy='none')."""
+    inference_json_path = os.path.join(os.path.dirname(eval_json_path), "generation.jsonl")
+    return ActivationParser(
+        inference_json=inference_json_path,
+        eval_json=eval_json_path,
+        activations_path=zarr_path,
+        logger_type="zarr",
+        split_strategy="none",
+        verbose=False,
+    )
+
+
+def load_checkpoint_model(
+    method: str,
+    checkpoint_path: str,
+    dataset_cfg: dict,
+) -> torch.nn.Module:
+    """Load model from checkpoint. Returns model in eval mode on CPU."""
+    input_dim = dataset_cfg.get("input_dim", 4096)
+
+    config_path = os.path.join(os.path.dirname(checkpoint_path), "config.json")
+    model_params = {}
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            run_cfg = json.load(f)
+        method_cfg = run_cfg.get("method_cfg", {})
+        model_params = method_cfg.get("model_params", {})
+
+    if method == "contrastive_logprob_recon":
+        params = dict(
+            input_dim=input_dim,
+            final_dim=512,
+            input_dropout=0.3,
+            recon_seq_len=64,
+            recon_hidden_dim=256,
+            recon_lambda=1.0,
+            logprob_var_threshold=1e-4,
+        )
+        params.update(model_params)
+        model = LogprobReconProgressiveCompressor(**params)
+    elif method == "linear_probe":
+        params = dict(input_dim=input_dim, pooling="mean")
+        params.update(model_params)
+        model = LinearProbe(**params)
+    elif method == "saplma":
+        params = dict(input_dim=input_dim, hidden_dims=[2048, 1024, 512], dropout=0.1)
+        params.update(model_params)
+        model = SimpleHaluClassifier(**params)
+    else:
+        raise ValueError(f"Unknown method: {method}")
+
+    ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    model.load_state_dict(ckpt["model_state_dict"])
+    model.eval()
+    return model
+
+
+def get_embeddings_contrastive(
+    model: torch.nn.Module,
+    zarr_path: str,
+    eval_json_path: str,
+    relevant_layers: list,
+    device: str = "cpu",
+    batch_size: int = 128,
+    num_workers: int = 4,
+) -> list:
+    """Run forward pass through contrastive model; return embedding records.
+
+    Returns list of dicts: [{"hashkey": str, "z_views": Tensor(1, D), "halu": int}, ...]
+    """
+    ap = _build_activation_parser(zarr_path, eval_json_path)
+    ds = ap.get_dataset(
+        split="test",
+        relevant_layers=relevant_layers,
+        num_views=1,
+        include_response_logprobs=False,
+        preload=False,
+        check_ram=False,
+    )
+    dl = DataLoader(
+        ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        persistent_workers=False,
+    )
+
+    records = []
+    with torch.no_grad():
+        for batch in dl:
+            x = batch["views_activations"][:, 0, :, :]  # (B, T, H) — first (only) view
+            z = model(x.to(device)).cpu()               # (B, D)
+            for i in range(len(z)):
+                records.append({
+                    "hashkey": batch["hashkey"][i],
+                    "z_views": z[i].unsqueeze(0),  # (1, D) — metrics.py expects (K, D)
+                    "halu": int(batch["halu"][i]),
+                })
+    return records
+
+
+def get_scores_probe(
+    model: torch.nn.Module,
+    zarr_path: str,
+    eval_json_path: str,
+    probe_layer: int,
+    device: str = "cpu",
+    batch_size: int = 256,
+    num_workers: int = 4,
+) -> tuple:
+    """Forward-pass a LinearProbe or SimpleHaluClassifier on a dataset split.
+
+    Returns (scores, labels): float32 arrays of shape (N,).
+    scores are sigmoid probabilities in [0, 1].
+    """
+    ap = _build_activation_parser(zarr_path, eval_json_path)
+    ds = ap.get_dataset(
+        split="test",
+        relevant_layers=[probe_layer],
+        num_views=1,
+        include_response_logprobs=False,
+        preload=False,
+        check_ram=False,
+    )
+    dl = DataLoader(
+        ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        persistent_workers=False,
+    )
+
+    all_scores, all_labels = [], []
+    with torch.no_grad():
+        for batch in dl:
+            x = batch["views_activations"][:, 0, :, :]  # (B, T, H)
+            out = model(x.to(device)).squeeze(-1).cpu()  # (B,)
+            all_scores.append(out.numpy())
+            all_labels.append(batch["halu"].numpy())
+
+    return np.concatenate(all_scores), np.concatenate(all_labels)
+
+
+def evaluate_transfer_cell(
+    source_run_dir: str,
+    source_dataset_cfg: dict,
+    target_test_cfg: dict,
+    method: str,
+    relevant_layers: list,
+    probe_layer: int,
+    device: str = "cpu",
+) -> dict:
+    """Evaluate one transfer matrix cell. Returns metrics dict."""
+    ckpt_file = _CHECKPOINT_FILE[method]
+    checkpoint_path = os.path.join(source_run_dir, ckpt_file)
+
+    if not os.path.exists(checkpoint_path):
+        fallback = os.path.join(source_run_dir, _FALLBACK_CHECKPOINT)
+        if os.path.exists(fallback):
+            checkpoint_path = fallback
+        else:
+            return {"status": "missing_checkpoint"}
+
+    model = load_checkpoint_model(method, checkpoint_path, source_dataset_cfg)
+    model = model.to(device)
+
+    if method == "contrastive_logprob_recon":
+        src_train_records = get_embeddings_contrastive(
+            model,
+            zarr_path=source_dataset_cfg["train"]["activations_path"],
+            eval_json_path=source_dataset_cfg["train"]["eval_json"],
+            relevant_layers=relevant_layers,
+            device=device,
+        )
+        tgt_test_records = get_embeddings_contrastive(
+            model,
+            zarr_path=target_test_cfg["test"]["activations_path"],
+            eval_json_path=target_test_cfg["test"]["eval_json"],
+            relevant_layers=relevant_layers,
+            device=device,
+        )
+        maha_stats = mahalanobis_ood_stats(src_train_records, tgt_test_records, outlier_class=1)
+        knn_stats = knn_ood_stats(
+            src_train_records,
+            tgt_test_records,
+            outlier_class=1,
+            k=50,
+            metric="euclidean",
+            calibrate_k=False,
+        )
+        return {
+            "status": "ok",
+            "auroc": maha_stats["mahalanobis_auroc"],
+            "mahalanobis_auroc": maha_stats["mahalanobis_auroc"],
+            "mahalanobis_mean_id": maha_stats["mahalanobis_mean_id"],
+            "mahalanobis_std_id": maha_stats["mahalanobis_std_id"],
+            "mahalanobis_mean_ood": maha_stats["mahalanobis_mean_ood"],
+            "mahalanobis_std_ood": maha_stats["mahalanobis_std_ood"],
+            "knn_auroc": knn_stats["knn_auroc"],
+            "n_src_train": len(src_train_records),
+            "n_tgt_test": len(tgt_test_records),
+        }
+    else:
+        scores, labels = get_scores_probe(
+            model,
+            zarr_path=target_test_cfg["test"]["activations_path"],
+            eval_json_path=target_test_cfg["test"]["eval_json"],
+            probe_layer=probe_layer,
+            device=device,
+        )
+        if len(np.unique(labels)) < 2:
+            auroc = float("nan")
+        else:
+            auroc = float(roc_auc_score(labels, scores))
+        return {
+            "status": "ok",
+            "auroc": auroc,
+            "n_tgt_test": len(labels),
+        }
+
+
+def discover_runs(runs_root: str, method: str) -> list:
+    """Scan runs_root for completed runs of the given method.
+
+    Returns list of dicts: experiment_name, dataset, method, seed, run_dir, config.
+    Only includes runs where both eval_metrics.json and the checkpoint file exist.
+    """
+    ckpt_file = _CHECKPOINT_FILE[method]
+    results = []
+
+    runs_root_path = Path(runs_root)
+    if not runs_root_path.exists():
+        return results
+
+    # Walk: runs_root/{experiment_name}/{dataset}/{method}/seed_{seed}/
+    for exp_dir in sorted(runs_root_path.iterdir()):
+        if not exp_dir.is_dir():
+            continue
+        experiment_name = exp_dir.name
+        for dataset_dir in sorted(exp_dir.iterdir()):
+            if not dataset_dir.is_dir():
+                continue
+            dataset = dataset_dir.name
+            method_dir = dataset_dir / method
+            if not method_dir.is_dir():
+                continue
+            for seed_dir in sorted(method_dir.iterdir()):
+                if not seed_dir.is_dir() or not seed_dir.name.startswith("seed_"):
+                    continue
+                try:
+                    seed = int(seed_dir.name.split("_", 1)[1])
+                except (ValueError, IndexError):
+                    continue
+
+                eval_metrics = seed_dir / "eval_metrics.json"
+                checkpoint = seed_dir / ckpt_file
+                if not eval_metrics.exists():
+                    continue
+                if not checkpoint.exists():
+                    fallback = seed_dir / _FALLBACK_CHECKPOINT
+                    if not fallback.exists():
+                        continue
+
+                config_path = seed_dir / "config.json"
+                config = {}
+                if config_path.exists():
+                    with open(config_path) as f:
+                        config = json.load(f)
+
+                results.append({
+                    "experiment_name": experiment_name,
+                    "dataset": dataset,
+                    "method": method,
+                    "seed": seed,
+                    "run_dir": str(seed_dir),
+                    "config": config,
+                })
+
+    return results

--- a/scripts/eval_transfer_matrix.py
+++ b/scripts/eval_transfer_matrix.py
@@ -1,0 +1,245 @@
+"""CLI: evaluate cross-dataset transfer matrix for hallucination detectors.
+
+Zero new training; zero new inference. CPU-only.
+
+Usage:
+  # Smoke test (1 cell, diagonal):
+  python scripts/eval_transfer_matrix.py \
+    --source-datasets hotpotqa --target-datasets hotpotqa \
+    --methods linear_probe --model-slugs llama --seeds 0
+
+  # Full run:
+  python scripts/eval_transfer_matrix.py --model-slugs llama --resume
+  python scripts/eval_transfer_matrix.py --model-slugs qwen3 --resume
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Allow running from repo root without installing as a package
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from activation_research.transfer_eval import discover_runs, evaluate_transfer_cell
+
+DATASETS = ["hotpotqa", "mmlu", "nq", "popqa", "sciq", "searchqa"]
+METHODS = ["contrastive_logprob_recon", "linear_probe", "saplma"]
+MODEL_SLUGS = ["llama", "qwen3"]
+
+
+def parse_layer_range(spec: str) -> list:
+    """Parse '14-29' → [14..29] or '22,26' → [22, 26]."""
+    if "-" in spec and "," not in spec:
+        start, end = spec.split("-", 1)
+        return list(range(int(start), int(end) + 1))
+    return [int(x) for x in spec.split(",")]
+
+
+def _dataset_cfg_name(dataset: str, model_slug: str) -> str:
+    return dataset if model_slug == "llama" else f"{dataset}_qwen3"
+
+
+def _slug_from_experiment(experiment_name: str) -> str:
+    if "_qwen3" in experiment_name:
+        return "qwen3"
+    return "llama"
+
+
+def _resolve_probe_layer(run_dir: str, config: dict) -> int:
+    """Determine probe layer: eval_metrics > config.json > default 26."""
+    eval_metrics_path = os.path.join(run_dir, "eval_metrics.json")
+    if os.path.exists(eval_metrics_path):
+        with open(eval_metrics_path) as f:
+            em = json.load(f)
+        if "selected_layer" in em:
+            return int(em["selected_layer"])
+    method_cfg = config.get("method_cfg", {})
+    if "probe_layer" in method_cfg:
+        return int(method_cfg["probe_layer"])
+    return 26
+
+
+def aggregate_results(output_dir: str) -> None:
+    """Read all per-cell JSON files; write transfer_matrix*.csv."""
+    records = []
+    for slug_dir in Path(output_dir).iterdir():
+        if not slug_dir.is_dir():
+            continue
+        for jf in slug_dir.glob("*.json"):
+            try:
+                with open(jf) as f:
+                    records.append(json.load(f))
+            except Exception:
+                pass
+
+    if not records:
+        print("[aggregate] No cell JSON files found.")
+        return
+
+    df = pd.DataFrame(records)
+
+    cols = [
+        "source_dataset", "target_dataset", "method", "model_slug", "seed",
+        "auroc", "status", "mahalanobis_auroc", "knn_auroc",
+        "n_src_train", "n_tgt_test",
+    ]
+    for c in cols:
+        if c not in df.columns:
+            df[c] = np.nan
+    df = df[cols]
+
+    flat_path = os.path.join(output_dir, "transfer_matrix.csv")
+    df.to_csv(flat_path, index=False)
+    print(f"[aggregate] Wrote {flat_path} ({len(df)} rows)")
+
+    group_cols = ["source_dataset", "target_dataset", "method", "model_slug"]
+    ok = df[df["status"] == "ok"].copy()
+    if ok.empty:
+        return
+
+    ok["auroc"] = pd.to_numeric(ok["auroc"], errors="coerce")
+    agg = ok.groupby(group_cols)["auroc"].agg(["mean", "std", "count"]).reset_index()
+    agg.columns = group_cols + ["auroc_mean", "auroc_std", "n_seeds"]
+    agg["auroc_ci95_lo"] = agg["auroc_mean"] - 1.96 * agg["auroc_std"] / np.sqrt(agg["n_seeds"])
+    agg["auroc_ci95_hi"] = agg["auroc_mean"] + 1.96 * agg["auroc_std"] / np.sqrt(agg["n_seeds"])
+
+    mean_path = os.path.join(output_dir, "transfer_matrix_mean.csv")
+    agg.to_csv(mean_path, index=False)
+    print(f"[aggregate] Wrote {mean_path} ({len(agg)} rows)")
+
+    ci_path = os.path.join(output_dir, "transfer_matrix_ci.csv")
+    agg.to_csv(ci_path, index=False)
+    print(f"[aggregate] Wrote {ci_path} ({len(agg)} rows)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate cross-dataset transfer matrix for hallucination detectors"
+    )
+    parser.add_argument("--runs-dir", default="runs",
+                        help="Root of existing training runs (default: runs)")
+    parser.add_argument("--configs-dir", default="configs",
+                        help="Root of configs/ directory (default: configs)")
+    parser.add_argument("--output-dir", default="runs/transfer_matrix",
+                        help="Output directory (default: runs/transfer_matrix)")
+    parser.add_argument("--methods", nargs="+", default=METHODS,
+                        help="Methods to evaluate")
+    parser.add_argument("--model-slugs", nargs="+", default=MODEL_SLUGS,
+                        choices=["llama", "qwen3"],
+                        help="Model families to include")
+    parser.add_argument("--source-datasets", nargs="+", default=DATASETS,
+                        help="Source dataset names")
+    parser.add_argument("--target-datasets", nargs="+", default=DATASETS,
+                        help="Target dataset names")
+    parser.add_argument("--seeds", type=int, nargs="+", default=None,
+                        help="Seeds to include (default: all discovered)")
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--relevant-layers", default="14-29",
+                        help="Layer range for contrastive model (e.g. '14-29')")
+    parser.add_argument("--resume", action="store_true",
+                        help="Skip cells where output JSON already exists")
+    args = parser.parse_args()
+
+    relevant_layers = parse_layer_range(args.relevant_layers)
+
+    # Load target dataset configs
+    target_cfgs = {}
+    for dataset in args.target_datasets:
+        for slug in args.model_slugs:
+            cfg_name = _dataset_cfg_name(dataset, slug)
+            cfg_path = os.path.join(args.configs_dir, "datasets", f"{cfg_name}.json")
+            if not os.path.exists(cfg_path):
+                print(f"[warn] Dataset config not found: {cfg_path} — skipping {dataset}/{slug}")
+                continue
+            with open(cfg_path) as f:
+                target_cfgs[(dataset, slug)] = json.load(f)
+
+    # Discover source runs across all requested methods
+    all_runs = []
+    for method in args.methods:
+        found = discover_runs(args.runs_dir, method)
+        all_runs += found
+    print(f"[info] Discovered {len(all_runs)} runs before filtering")
+
+    all_runs = [r for r in all_runs if r["dataset"] in args.source_datasets]
+    all_runs = [r for r in all_runs if _slug_from_experiment(r["experiment_name"]) in args.model_slugs]
+    if args.seeds is not None:
+        all_runs = [r for r in all_runs if r["seed"] in args.seeds]
+    print(f"[info] {len(all_runs)} runs after filtering (sources={args.source_datasets}, slugs={args.model_slugs})")
+
+    total = 0
+    skipped = 0
+    errors = 0
+
+    for run in all_runs:
+        model_slug = _slug_from_experiment(run["experiment_name"])
+
+        src_cfg_name = _dataset_cfg_name(run["dataset"], model_slug)
+        src_cfg_path = os.path.join(args.configs_dir, "datasets", f"{src_cfg_name}.json")
+        if not os.path.exists(src_cfg_path):
+            print(f"[warn] Source config not found: {src_cfg_path} — skipping run")
+            continue
+        with open(src_cfg_path) as f:
+            src_dataset_cfg = json.load(f)
+
+        probe_layer = _resolve_probe_layer(run["run_dir"], run["config"])
+
+        for target_dataset in args.target_datasets:
+            key = (target_dataset, model_slug)
+            if key not in target_cfgs:
+                continue
+
+            cell_id = f"{run['dataset']}__{target_dataset}__{run['method']}__{run['seed']}"
+            output_path = os.path.join(args.output_dir, model_slug, f"{cell_id}.json")
+
+            if args.resume and os.path.exists(output_path):
+                skipped += 1
+                continue
+
+            total += 1
+            try:
+                result = evaluate_transfer_cell(
+                    source_run_dir=run["run_dir"],
+                    source_dataset_cfg=src_dataset_cfg,
+                    target_test_cfg=target_cfgs[key],
+                    method=run["method"],
+                    relevant_layers=relevant_layers,
+                    probe_layer=probe_layer,
+                    device=args.device,
+                )
+            except Exception as exc:
+                result = {"status": f"error: {exc}"}
+                errors += 1
+
+            result.update({
+                "source_dataset": run["dataset"],
+                "target_dataset": target_dataset,
+                "method": run["method"],
+                "seed": run["seed"],
+                "model_slug": model_slug,
+                "experiment_name": run["experiment_name"],
+            })
+
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            with open(output_path, "w") as f:
+                json.dump(result, f, indent=2)
+
+            auroc = result.get("auroc", "ERR")
+            status = result.get("status", "?")
+            if isinstance(auroc, float) and not np.isnan(auroc):
+                print(f"[{cell_id}] status={status} auroc={auroc:.4f}")
+            else:
+                print(f"[{cell_id}] status={status} auroc={auroc}")
+
+    print(f"\n[done] Evaluated {total} cells, skipped {skipped} (resume), errors {errors}")
+    aggregate_results(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `activation_research/transfer_eval.py` — core transfer evaluation logic with `load_checkpoint_model`, `get_embeddings_contrastive`, `get_scores_probe`, `evaluate_transfer_cell`, and `discover_runs`
- Adds `scripts/eval_transfer_matrix.py` — CLI entry point that iterates over (source_run × target_dataset) cells, writes per-cell JSON, and aggregates into `transfer_matrix{,_mean,_ci}.csv`

## Design notes

- **Zero new training or inference** — loads existing checkpoints and zarr activation stores
- **CPU-only** — Mahalanobis on D=512 embeddings is fast (<1s/cell); no GPU needed
- **Seeds discovered from filesystem** — existing runs use `[0,1,2,3,4]`; issue #62 lists `[0,5,26,42,63]` which does not match actual trained seeds. The script auto-discovers whatever seeds exist.
- **Diagonal sanity check** — diagonal cells (source==target) should match stored `eval_metrics.json` AUROC within floating-point noise; discrepancy >0.02 indicates a pipeline bug
- **`--resume` flag** — skips cells where output JSON already exists; safe to re-run

## Test plan

- [ ] Smoke test (1 diagonal cell, fastest path):
  ```bash
  python scripts/eval_transfer_matrix.py \
    --source-datasets hotpotqa --target-datasets hotpotqa \
    --methods linear_probe --model-slugs llama --seeds 0 --device cpu
  ```
  Verify `runs/transfer_matrix/llama/hotpotqa__hotpotqa__linear_probe__0.json` has `status: ok` and `auroc` close to in-distribution value from `eval_metrics.json`
- [ ] Full Llama run: `python scripts/eval_transfer_matrix.py --model-slugs llama --resume`
- [ ] Full Qwen3 run: `python scripts/eval_transfer_matrix.py --model-slugs qwen3 --resume`
- [ ] Check `runs/transfer_matrix/transfer_matrix_mean.csv` is produced with 6×6 matrix per method

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)