### PR TITLE
feat(#82): coarse + full attention recon targets

### DIFF
--- a/activation_research/memmap_contrastive_dataset.py
+++ b/activation_research/memmap_contrastive_dataset.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 from torch.utils.data import Dataset
 
 from activation_research.icr_dataset import _make_split_indices
@@ -175,11 +176,10 @@ class MemmapContrastiveDataset(Dataset):
         if not capture_dir.exists():
             raise FileNotFoundError(f"capture_dir not found: {capture_dir}")
 
-        if attention_summary != "stats":
-            # K2 ('coarse') and K3 ('full') are reserved API — see spec §5.1.
-            raise NotImplementedError(
-                f"attention_summary={attention_summary!r} is reserved for a "
-                "future PR; only 'stats' is implemented today."
+        if attention_summary not in ("stats", "coarse", "full"):
+            raise ValueError(
+                f"attention_summary must be 'stats', 'coarse', or 'full', "
+                f"got {attention_summary!r}"
             )
 
         # --- Config ---
@@ -240,6 +240,7 @@ class MemmapContrastiveDataset(Dataset):
 
         # --- Attention options ---
         self._include_attn = bool(include_response_attention)
+        self._attn_summary = str(attention_summary)
         self._attn_offset_fwd = (
             int(attention_target_layer_offset_forward)
             if attention_target_layer_offset_forward is not None
@@ -373,6 +374,69 @@ class MemmapContrastiveDataset(Dataset):
         return _compute_attn_stats(np.asarray(attn_block), rlen)
 
     # ------------------------------------------------------------------ #
+    def _attn_coarse_for_all_layers(self, sample_row: int) -> np.ndarray:
+        """Return coarse (8×8) binned attention for all num_layers, one sample.
+
+        Returns
+        -------
+        ndarray (num_layers, 8, 8) float32
+            Each layer's r_eff × r_eff valid block is binned into 8×8 via
+            adaptive average pooling. Cells beyond r_eff are NaN-filled so
+            the loss can exclude them via masking. When r_eff == 0 the entire
+            layer matrix is NaN.
+        """
+        rlen = int(self._resp_len[sample_row])
+        r_eff = min(rlen, self._r_max)
+
+        out = np.full((self._num_layers, 8, 8), np.nan, dtype=np.float32)
+        if r_eff <= 0:
+            return out
+
+        # Read all layers at once — one memmap row.
+        attn_all = np.array(
+            self._resp_attn[sample_row], dtype=np.float32
+        )  # (num_layers, r_max, r_max)
+
+        # Bin via adaptive average pooling (CPU, via torch).
+        # Pool only the valid r_eff × r_eff block; the remainder is padding
+        # zeros from the capture writer and must not pollute the average.
+        valid_block = torch.from_numpy(
+            attn_all[:, :r_eff, :r_eff]
+        )  # (num_layers, r_eff, r_eff)
+        valid_block = valid_block.unsqueeze(0)  # (1, num_layers, r_eff, r_eff) for pool2d
+
+        # F.adaptive_avg_pool2d expects (N, C, H, W); treat layers as channels.
+        pooled = F.adaptive_avg_pool2d(valid_block, (8, 8))  # (1, num_layers, 8, 8)
+        out[:] = pooled.squeeze(0).numpy()
+        return out  # (num_layers, 8, 8) — all cells are valid (no NaN needed)
+
+    # ------------------------------------------------------------------ #
+    def _attn_full_for_all_layers(self, sample_row: int) -> np.ndarray:
+        """Return full (r_max × r_max) attention for all num_layers, one sample.
+
+        Returns
+        -------
+        ndarray (num_layers, r_max, r_max) float32
+            The raw attention block. Cells at positions (i, j) where either
+            i >= r_eff or j >= r_eff are NaN-filled (variable-length masking).
+            When r_eff == 0 the entire output is NaN.
+        """
+        rlen = int(self._resp_len[sample_row])
+        r_eff = min(rlen, self._r_max)
+
+        out = np.full((self._num_layers, self._r_max, self._r_max), np.nan, dtype=np.float32)
+        if r_eff <= 0:
+            return out
+
+        attn_all = np.array(
+            self._resp_attn[sample_row], dtype=np.float32
+        )  # (num_layers, r_max, r_max)
+
+        # Copy the valid r_eff × r_eff block; everything outside stays NaN.
+        out[:, :r_eff, :r_eff] = attn_all[:, :r_eff, :r_eff]
+        return out  # (num_layers, r_max, r_max)
+
+    # ------------------------------------------------------------------ #
     def _get_logprob_fields(self, sample_row: int) -> Dict[str, torch.Tensor]:
         target_len = self._pad_length
         target_top_k = self._target_top_k
@@ -466,24 +530,46 @@ class MemmapContrastiveDataset(Dataset):
 
         # --- Attention summary fields (Mechanism K) ---
         if self._include_attn:
-            if self._attn_offset_fwd is not None:
-                stats_fwd = np.stack(
-                    [
-                        self._attn_stats_for_layer(sample_row, m + self._attn_offset_fwd)
-                        for m in view_model_layers
-                    ],
-                    axis=0,
-                )  # (K, _ATTN_STAT_DIM)
-                sample["attention_forward"] = torch.from_numpy(stats_fwd)
+            if self._attn_summary == "stats":
+                if self._attn_offset_fwd is not None:
+                    stats_fwd = np.stack(
+                        [
+                            self._attn_stats_for_layer(sample_row, m + self._attn_offset_fwd)
+                            for m in view_model_layers
+                        ],
+                        axis=0,
+                    )  # (K, _ATTN_STAT_DIM)
+                    sample["attention_forward"] = torch.from_numpy(stats_fwd)
 
-            if self._attn_offset_bwd is not None:
-                stats_bwd = np.stack(
-                    [
-                        self._attn_stats_for_layer(sample_row, m - self._attn_offset_bwd)
-                        for m in view_model_layers
-                    ],
-                    axis=0,
-                )  # (K, _ATTN_STAT_DIM)
-                sample["attention_backward"] = torch.from_numpy(stats_bwd)
+                if self._attn_offset_bwd is not None:
+                    stats_bwd = np.stack(
+                        [
+                            self._attn_stats_for_layer(sample_row, m - self._attn_offset_bwd)
+                            for m in view_model_layers
+                        ],
+                        axis=0,
+                    )  # (K, _ATTN_STAT_DIM)
+                    sample["attention_backward"] = torch.from_numpy(stats_bwd)
+
+            elif self._attn_summary == "coarse":
+                # Coarse: all num_layers attention layers, binned to 8×8.
+                # Shape per view: (num_layers, 8, 8). Stacked: (K, num_layers, 8, 8).
+                # The offset fields are unused for coarse/full — we emit all layers.
+                coarse = self._attn_coarse_for_all_layers(sample_row)  # (num_layers, 8, 8)
+                stacked = np.stack([coarse] * len(view_model_layers), axis=0)  # (K, num_layers, 8, 8)
+                if self._attn_offset_fwd is not None:
+                    sample["attention_forward"] = torch.from_numpy(stacked)
+                if self._attn_offset_bwd is not None:
+                    sample["attention_backward"] = torch.from_numpy(stacked)
+
+            elif self._attn_summary == "full":
+                # Full: all num_layers attention layers, r_max × r_max each.
+                # Shape per view: (num_layers, r_max, r_max). Stacked: (K, num_layers, r_max, r_max).
+                full = self._attn_full_for_all_layers(sample_row)  # (num_layers, r_max, r_max)
+                stacked = np.stack([full] * len(view_model_layers), axis=0)  # (K, num_layers, r_max, r_max)
+                if self._attn_offset_fwd is not None:
+                    sample["attention_forward"] = torch.from_numpy(stacked)
+                if self._attn_offset_bwd is not None:
+                    sample["attention_backward"] = torch.from_numpy(stacked)
 
         return sample

--- a/activation_research/model.py
+++ b/activation_research/model.py
@@ -276,18 +276,38 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         target layer ``ℓ ± k``. Consumed by the *dataset*, not the model —
         recorded here for config provenance only.
     attn_target : {"stats", "coarse", "full"}
-        Decoder output type. Only ``"stats"`` is implemented in this PR;
-        ``"coarse"`` / ``"full"`` raise ``NotImplementedError``.
+        Decoder output type:
+
+        - ``"stats"`` : 3 scalars per view (entropy, focal_frac, self_mass).
+        - ``"coarse"``: 8×8 binned attention map per LLM layer per view;
+          decoder flat output dim = ``attn_num_layers × 64``.
+        - ``"full"``  : full r_max×r_max attention map per LLM layer per view;
+          decoder flat output dim = ``attn_num_layers × attn_r_max²``.
     attn_num_stat_features : int
         Output dimension of the K decoder per direction when
         ``attn_target="stats"`` (default 3: entropy, focal_frac, self_mass).
+    attn_num_layers : int
+        Number of LLM attention layers whose maps the coarse/full decoders
+        predict. Ignored when ``attn_target="stats"``. Should match the
+        model's ``num_layers`` field in the capture config (e.g. 32 for
+        Llama-3.1-8B). Default 32.
+    attn_r_max : int
+        Maximum response length used in the capture (r_max in config).
+        Determines the full-target output width (r_max × r_max per layer).
+        Ignored for ``"stats"`` and ``"coarse"``. Default 64.
     attn_recon_hidden_dim, attn_recon_lambda, attn_var_threshold
         K head hyperparameters. Lambda > 0 enables the head; set 0 to
         disable while keeping the decoder weights for inspection.
+    attn_loss : {"mse", "kl"}
+        Loss function for the K head. ``"mse"`` (default) is always valid.
+        ``"kl"`` treats each attention row as a categorical distribution and
+        computes KL(target || pred); falls back to MSE when
+        ``attn_target="stats"`` (scalars are not probability distributions).
     """
 
     _VALID_DIRECTIONS = ("forward", "backward", "both", "none")
     _VALID_TARGETS = ("stats", "coarse", "full")
+    _VALID_ATTN_LOSS = ("mse", "kl")
     # Internal ModuleDict keys cannot use "forward" (collides with nn.Module.forward).
     _DIRECTION_TO_KEY = {"forward": "fwd", "backward": "bwd"}
 
@@ -308,9 +328,12 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         attn_offset_k: int = 4,
         attn_target: str = "stats",
         attn_num_stat_features: int = 3,
+        attn_num_layers: int = 32,
+        attn_r_max: int = 64,
         attn_recon_hidden_dim: int = 256,
         attn_recon_lambda: float = 1.0,
         attn_var_threshold: float = 1e-5,
+        attn_loss: str = "mse",
     ):
         super().__init__()
 
@@ -325,11 +348,11 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
                 f"attn_target must be one of {self._VALID_TARGETS}, "
                 f"got {attn_target!r}"
             )
-        if attn_target != "stats":
-            # Reserved API — see spec §1 (out of scope).
-            raise NotImplementedError(
-                f"attn_target={attn_target!r} is reserved for a follow-up PR; "
-                "only 'stats' is implemented today."
+        attn_loss = str(attn_loss).lower()
+        if attn_loss not in self._VALID_ATTN_LOSS:
+            raise ValueError(
+                f"attn_loss must be one of {self._VALID_ATTN_LOSS}, "
+                f"got {attn_loss!r}"
             )
 
         self.recon_seq_len = int(recon_seq_len)
@@ -340,8 +363,11 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         self.attn_offset_k = int(attn_offset_k)
         self.attn_target = attn_target
         self.attn_num_stat_features = int(attn_num_stat_features)
+        self.attn_num_layers = int(attn_num_layers)
+        self.attn_r_max = int(attn_r_max)
         self.attn_recon_lambda = float(attn_recon_lambda)
         self.attn_var_threshold = float(attn_var_threshold)
+        self.attn_loss = attn_loss
 
         self.encoder = ProgressiveCompressor(
             input_dim=int(input_dim),
@@ -370,12 +396,27 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
             active_dirs = (attn_direction,)
         self._active_attn_dirs = active_dirs
 
+        # Flat output dimension of each K decoder, determined by target type.
+        # stats:  one stat-vector per view  → attn_num_stat_features scalars.
+        # coarse: one 8×8 binned map per LLM attention layer per view.
+        # full:   one r_max×r_max map per LLM attention layer per view.
+        # The decoder always outputs a flat (B, out_dim) vector; the caller
+        # reshapes to (B, attn_num_layers, 8, 8) or (B, attn_num_layers, r_max, r_max)
+        # before loss computation.
+        if attn_target == "stats":
+            _attn_out_dim = self.attn_num_stat_features
+        elif attn_target == "coarse":
+            _attn_out_dim = self.attn_num_layers * 8 * 8
+        else:  # "full"
+            _attn_out_dim = self.attn_num_layers * self.attn_r_max * self.attn_r_max
+        self._attn_out_dim = _attn_out_dim
+
         self.attn_decoders = nn.ModuleDict(
             {
                 self._DIRECTION_TO_KEY[d]: nn.Sequential(
                     nn.Linear(int(final_dim), int(attn_recon_hidden_dim)),
                     nn.GELU(),
-                    nn.Linear(int(attn_recon_hidden_dim), self.attn_num_stat_features),
+                    nn.Linear(int(attn_recon_hidden_dim), _attn_out_dim),
                 )
                 for d in active_dirs
             }
@@ -400,8 +441,11 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         lp_pred : (B, recon_seq_len)
         attn_pred_by_direction : dict[str, Tensor]
             Keys are subset of ``{"forward", "backward"}``; empty when
-            ``attn_direction == "none"``. Each value has shape
-            ``(B, attn_num_stat_features)``.
+            ``attn_direction == "none"``. Shape per target type:
+
+            - ``"stats"`` : ``(B, attn_num_stat_features)``
+            - ``"coarse"``: ``(B, attn_num_layers * 64)``  (flat; reshape to ``(B, attn_num_layers, 8, 8)``)
+            - ``"full"``  : ``(B, attn_num_layers * r_max^2)`` (flat; reshape similarly)
         """
         z = self.encoder(x)
         lp_pred = self.lp_decoder(z)
@@ -446,20 +490,39 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         attn_pred: torch.Tensor,
         attn_target: torch.Tensor,
     ):
-        """MSE reconstruction loss for one attention direction.
+        """Reconstruction loss for one attention direction.
 
-        ``attn_pred`` and ``attn_target`` have shape
-        ``(N, attn_num_stat_features)`` (N = batch size, flattened over
-        views by the trainer). NaN rows in ``attn_target`` (out-of-range
-        target layers, or samples with response_len == 0) are excluded
-        from the loss. If batch variance over non-NaN entries falls below
-        ``attn_var_threshold`` the loss is suppressed to zero.
+        Handles all three target types (stats / coarse / full) and both
+        loss modes (MSE / KL), selected by ``self.attn_loss``.
+
+        ``attn_pred`` and ``attn_target`` are both flat ``(N, D)`` tensors
+        where N = batch × views (flattened by the trainer) and D is the
+        total number of scalars per view:
+
+        - ``"stats"`` : D = attn_num_stat_features
+        - ``"coarse"``: D = attn_num_layers × 64  (8×8 per layer, all layers)
+        - ``"full"``  : D = attn_num_layers × r_max² (r_max×r_max per layer)
+
+        NaN cells in ``attn_target`` (out-of-range layers or response positions
+        beyond r_eff) are excluded from the loss — valid_count divides the
+        total, so longer responses do not dominate.
+
+        MSE path: element-wise squared error over valid cells / valid_count.
+
+        KL path (``attn_loss='kl'``, intended for coarse/full only): treats
+        each row of the reshaped ``(..., map_size)`` attention map as a
+        categorical distribution. The decoder output is softmax-normalised
+        per row; the target is re-normalised over valid cells per row.
+        Rows that are fully NaN are skipped. KL is per-row, averaged over
+        valid rows. MSE is used as fallback for ``"stats"`` regardless of
+        ``attn_loss`` because stats scalars are not probability distributions.
         """
         target = attn_target.float()
+        pred = attn_pred.float()
         nan_mask = torch.isnan(target)
 
         if nan_mask.all():
-            zero = torch.zeros(1, device=attn_pred.device).squeeze()
+            zero = torch.zeros(1, device=pred.device).squeeze()
             return zero, {
                 "attn_var": float("nan"),
                 "suppressed": True,
@@ -469,19 +532,71 @@ class LogprobAttnReconProgressiveCompressor(nn.Module):
         valid_target = target[~nan_mask]
         attn_var = float(valid_target.var())
         if attn_var < self.attn_var_threshold:
-            zero = torch.zeros(1, device=attn_pred.device).squeeze()
+            zero = torch.zeros(1, device=pred.device).squeeze()
             return zero, {
                 "attn_var": attn_var,
                 "suppressed": True,
                 "reason": "low-variance",
             }
 
-        # MSE only over non-NaN entries — replace NaNs in target with the
-        # corresponding prediction so the squared diff is zero (and excluded
-        # from gradient flow). This avoids per-row reductions.
-        target_filled = torch.where(nan_mask, attn_pred.detach(), target)
-        # Reduce as sum-of-squared-error over valid entries / count.
-        sq_err = (attn_pred - target_filled).pow(2)
+        use_kl = self.attn_loss == "kl" and self.attn_target in ("coarse", "full")
+
+        if use_kl:
+            # KL path: reshape to (N, num_layers, map_size) then operate row-wise.
+            # For coarse: map_size = 64 (8×8 per layer).
+            # For full:   map_size = r_max² per layer.
+            # The "row" for KL is the map_size axis (keys within one attention layer).
+            N = pred.shape[0]
+            D = pred.shape[1]
+            if self.attn_target == "coarse":
+                map_size = 64  # 8×8
+            else:
+                map_size = self.attn_r_max * self.attn_r_max
+            num_layers = D // map_size
+
+            pred_3d = pred.reshape(N, num_layers, map_size)          # (N, L, S)
+            target_3d = target.reshape(N, num_layers, map_size)      # (N, L, S)
+            nan_3d = nan_mask.reshape(N, num_layers, map_size)       # (N, L, S)
+
+            # Row-valid: a row is usable when it has at least one non-NaN cell.
+            row_valid = ~nan_3d.all(dim=-1)  # (N, L) bool
+
+            if not row_valid.any():
+                zero = torch.zeros(1, device=pred.device).squeeze()
+                return zero, {
+                    "attn_var": attn_var,
+                    "suppressed": True,
+                    "reason": "all-nan-rows",
+                }
+
+            # Softmax-normalise decoder output per row (unconstrained logits → dist).
+            pred_dist = F.softmax(pred_3d, dim=-1)  # (N, L, S)
+
+            # Re-normalise target over valid cells per row; skip NaN cells.
+            target_filled = target_3d.masked_fill(nan_3d, 0.0)
+            row_sums = target_filled.sum(dim=-1, keepdim=True).clamp(min=1e-9)
+            target_dist = target_filled / row_sums  # (N, L, S); NaN cells → 0
+
+            # KL(target || pred) per row, only for row_valid rows.
+            # kl_div expects log-probabilities for pred; use log_softmax for stability.
+            log_pred = F.log_softmax(pred_3d, dim=-1)  # (N, L, S)
+            kl_per_cell = target_dist * (target_dist.clamp(min=1e-9).log() - log_pred)
+            kl_per_cell = kl_per_cell.masked_fill(nan_3d, 0.0)
+            kl_per_row = kl_per_cell.sum(dim=-1)  # (N, L)
+
+            valid_row_count = row_valid.sum().clamp(min=1)
+            loss = kl_per_row[row_valid].sum() / valid_row_count
+            return loss, {
+                "attn_var": attn_var,
+                "suppressed": False,
+                "valid_count": int(valid_row_count.item()),
+            }
+
+        # MSE path (default; also used unconditionally for "stats").
+        # Replace NaNs in target with the corresponding prediction so the
+        # squared diff is zero (no gradient contribution).
+        target_filled = torch.where(nan_mask, pred.detach(), target)
+        sq_err = (pred - target_filled).pow(2)
         valid_count = (~nan_mask).sum().clamp(min=1)
         loss = sq_err.sum() / valid_count
         return loss, {

--- a/configs/methods/contrastive_logprob_attn_recon_l10_a10_coarse.json
+++ b/configs/methods/contrastive_logprob_attn_recon_l10_a10_coarse.json
@@ -1,0 +1,60 @@
+{
+  "name": "contrastive_logprob_attn_recon_l10_a10_coarse",
+  "routine": "contrastive_logprob_attn_recon",
+  "model_class": "logprob_attn_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4,
+    "attn_direction": "both",
+    "attn_offset_k": 4,
+    "attn_target": "coarse",
+    "attn_num_layers": 32,
+    "attn_r_max": 64,
+    "attn_recon_hidden_dim": 256,
+    "attn_recon_lambda": 1.0,
+    "attn_var_threshold": 1e-5,
+    "attn_loss": "mse"
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 512,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "dataset_class": "memmap_contrastive_dataset",
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "include_response_attention": true,
+    "attention_summary": "coarse",
+    "attention_target_layer_offset_backward": 4,
+    "attention_target_layer_offset_forward": 4
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 256
+  }
+}

--- a/configs/methods/contrastive_logprob_attn_recon_l10_a10_full.json
+++ b/configs/methods/contrastive_logprob_attn_recon_l10_a10_full.json
@@ -1,0 +1,60 @@
+{
+  "name": "contrastive_logprob_attn_recon_l10_a10_full",
+  "routine": "contrastive_logprob_attn_recon",
+  "model_class": "logprob_attn_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4,
+    "attn_direction": "both",
+    "attn_offset_k": 4,
+    "attn_target": "full",
+    "attn_num_layers": 32,
+    "attn_r_max": 64,
+    "attn_recon_hidden_dim": 256,
+    "attn_recon_lambda": 1.0,
+    "attn_var_threshold": 1e-5,
+    "attn_loss": "mse"
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 512,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "dataset_class": "memmap_contrastive_dataset",
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "include_response_attention": true,
+    "attention_summary": "full",
+    "attention_target_layer_offset_backward": 4,
+    "attention_target_layer_offset_forward": 4
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 256
+  }
+}

--- a/tests/test_logprob_attn_recon_model.py
+++ b/tests/test_logprob_attn_recon_model.py
@@ -36,14 +36,28 @@ def test_invalid_target_raises():
         )
 
 
-def test_coarse_and_full_targets_not_implemented():
-    with pytest.raises(NotImplementedError):
+def test_coarse_target_constructs():
+    m = LogprobAttnReconProgressiveCompressor(
+        input_dim=128, final_dim=64, attn_target="coarse",
+        attn_num_layers=4, attn_direction="backward",
+    )
+    assert m.attn_target == "coarse"
+    assert m._attn_out_dim == 4 * 8 * 8  # num_layers × 8 × 8
+
+
+def test_full_target_constructs():
+    m = LogprobAttnReconProgressiveCompressor(
+        input_dim=128, final_dim=64, attn_target="full",
+        attn_num_layers=4, attn_r_max=6, attn_direction="backward",
+    )
+    assert m.attn_target == "full"
+    assert m._attn_out_dim == 4 * 6 * 6  # num_layers × r_max × r_max
+
+
+def test_invalid_attn_loss_raises():
+    with pytest.raises(ValueError, match="attn_loss"):
         LogprobAttnReconProgressiveCompressor(
-            input_dim=128, final_dim=64, attn_target="coarse",
-        )
-    with pytest.raises(NotImplementedError):
-        LogprobAttnReconProgressiveCompressor(
-            input_dim=128, final_dim=64, attn_target="full",
+            input_dim=128, final_dim=64, attn_loss="l1",
         )
 
 
@@ -245,3 +259,263 @@ def test_attn_recon_partial_nan_excluded_from_loss():
     # 3 valid entries, sum sq err = 3, mean = 1.0
     assert abs(float(loss) - 1.0) < 1e-5
     assert diag["valid_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Coarse target — decoder shape + loss
+# ---------------------------------------------------------------------------
+
+_NUM_LAYERS = 4
+_R_MAX = 6
+
+
+def _make_coarse_model(**kwargs):
+    return LogprobAttnReconProgressiveCompressor(
+        input_dim=128,
+        final_dim=64,
+        attn_target="coarse",
+        attn_num_layers=_NUM_LAYERS,
+        attn_var_threshold=1e-8,
+        **kwargs,
+    )
+
+
+def _make_full_model(**kwargs):
+    return LogprobAttnReconProgressiveCompressor(
+        input_dim=128,
+        final_dim=64,
+        attn_target="full",
+        attn_num_layers=_NUM_LAYERS,
+        attn_r_max=_R_MAX,
+        attn_var_threshold=1e-8,
+        **kwargs,
+    )
+
+
+def test_coarse_decoder_output_shape_backward():
+    m = _make_coarse_model(attn_direction="backward")
+    x = torch.randn(3, 6, 128)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+    assert z.shape == (3, 64)
+    assert set(attn_pred.keys()) == {"backward"}
+    # Flat output: num_layers × 8 × 8
+    assert attn_pred["backward"].shape == (3, _NUM_LAYERS * 8 * 8)
+
+
+def test_coarse_decoder_output_shape_both_directions():
+    m = _make_coarse_model(attn_direction="both")
+    x = torch.randn(2, 6, 128)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+    assert set(attn_pred.keys()) == {"forward", "backward"}
+    assert attn_pred["forward"].shape == (2, _NUM_LAYERS * 8 * 8)
+    assert attn_pred["backward"].shape == (2, _NUM_LAYERS * 8 * 8)
+
+
+def test_full_decoder_output_shape_backward():
+    m = _make_full_model(attn_direction="backward")
+    x = torch.randn(3, 6, 128)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+    assert set(attn_pred.keys()) == {"backward"}
+    # Flat output: num_layers × r_max × r_max
+    assert attn_pred["backward"].shape == (3, _NUM_LAYERS * _R_MAX * _R_MAX)
+
+
+def test_full_decoder_output_shape_both_directions():
+    m = _make_full_model(attn_direction="both")
+    x = torch.randn(2, 6, 128)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+    assert set(attn_pred.keys()) == {"forward", "backward"}
+    assert attn_pred["forward"].shape == (2, _NUM_LAYERS * _R_MAX * _R_MAX)
+    assert attn_pred["backward"].shape == (2, _NUM_LAYERS * _R_MAX * _R_MAX)
+
+
+def test_coarse_decoder_output_dtype():
+    m = _make_coarse_model(attn_direction="backward")
+    x = torch.randn(2, 6, 128)
+    _, _, attn_pred = m.forward_with_recon(x)
+    assert attn_pred["backward"].dtype == torch.float32
+
+
+def test_full_decoder_output_dtype():
+    m = _make_full_model(attn_direction="backward")
+    x = torch.randn(2, 6, 128)
+    _, _, attn_pred = m.forward_with_recon(x)
+    assert attn_pred["backward"].dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# NaN masking for coarse/full targets
+# ---------------------------------------------------------------------------
+
+def test_coarse_mse_out_of_range_layer_contributes_zero():
+    """A layer slice that is entirely NaN must not contribute to the loss."""
+    m = _make_coarse_model(attn_direction="backward")
+    D = _NUM_LAYERS * 8 * 8
+    pred = torch.randn(2, D)
+    # Layer 0 valid (non-NaN), layer 1..3 entirely NaN.
+    target = torch.full((2, D), float("nan"))
+    target[:, : 8 * 8] = torch.randn(2, 8 * 8)  # fill layer-0 cells
+
+    loss, diag = m.recon_loss_attn(pred, target)
+    assert torch.isfinite(loss)
+    assert diag["suppressed"] is False
+    # Only 2 × 64 = 128 valid cells (layer 0 only).
+    assert diag["valid_count"] == 2 * 8 * 8
+
+
+def test_full_mse_out_of_response_cells_contribute_zero():
+    """Cells beyond r_eff (NaN-filled by dataset) must not contribute."""
+    m = _make_full_model(attn_direction="backward")
+    D = _NUM_LAYERS * _R_MAX * _R_MAX
+    pred = torch.randn(4, D)
+    # All valid.
+    target = torch.randn(4, D)
+    loss_all_valid, _ = m.recon_loss_attn(pred, target)
+
+    # NaN half the cells.
+    target_partial = target.clone()
+    target_partial[:, D // 2:] = float("nan")
+    loss_partial, diag_partial = m.recon_loss_attn(pred, target_partial)
+
+    # With half the cells NaN, the valid_count drops.
+    assert diag_partial["valid_count"] == 4 * (D // 2)
+    # Both losses are finite.
+    assert torch.isfinite(loss_all_valid)
+    assert torch.isfinite(loss_partial)
+
+
+# ---------------------------------------------------------------------------
+# MSE + KL loss paths — finite outputs and finite gradients
+# ---------------------------------------------------------------------------
+
+def test_coarse_mse_loss_no_nan_gradients():
+    m = _make_coarse_model(attn_direction="backward", attn_loss="mse")
+    x = torch.randn(4, 6, 128, requires_grad=False)
+    m.train()
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * 8 * 8
+    # Target with some NaN cells (simulates short responses).
+    target = torch.randn(4, D)
+    target[:, D // 2:] = float("nan")
+
+    loss, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    assert torch.isfinite(loss)
+    loss.backward()
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"
+
+
+def test_full_mse_loss_no_nan_gradients():
+    m = _make_full_model(attn_direction="backward", attn_loss="mse")
+    x = torch.randn(4, 6, 128, requires_grad=False)
+    m.train()
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * _R_MAX * _R_MAX
+    target = torch.randn(4, D)
+    target[:, D // 2:] = float("nan")
+
+    loss, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    assert torch.isfinite(loss)
+    loss.backward()
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"
+
+
+def test_coarse_kl_loss_no_nan_gradients():
+    m = _make_coarse_model(attn_direction="backward", attn_loss="kl")
+    x = torch.randn(4, 6, 128, requires_grad=False)
+    m.train()
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * 8 * 8
+    # Row-normalised target (each 8×8 = 64-cell row sums to 1).
+    target_raw = torch.rand(4, D).abs() + 0.01
+    # Normalise each 64-cell row.
+    target_3d = target_raw.reshape(4, _NUM_LAYERS, 64)
+    target_3d = target_3d / target_3d.sum(dim=-1, keepdim=True)
+    target = target_3d.reshape(4, D)
+    # NaN one full layer row per sample to test skip logic.
+    target[:, : 64] = float("nan")
+
+    loss, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    assert torch.isfinite(loss)
+    loss.backward()
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"
+
+
+def test_full_kl_loss_no_nan_gradients():
+    m = _make_full_model(attn_direction="backward", attn_loss="kl")
+    x = torch.randn(4, 6, 128, requires_grad=False)
+    m.train()
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * _R_MAX * _R_MAX
+    map_size = _R_MAX * _R_MAX
+    target_raw = torch.rand(4, D).abs() + 0.01
+    target_3d = target_raw.reshape(4, _NUM_LAYERS, map_size)
+    target_3d = target_3d / target_3d.sum(dim=-1, keepdim=True)
+    target = target_3d.reshape(4, D)
+    target[:, :map_size] = float("nan")
+
+    loss, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    assert torch.isfinite(loss)
+    loss.backward()
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip smoke: synthetic capture → forward+backward → finite grads
+# ---------------------------------------------------------------------------
+
+def test_coarse_round_trip_forward_backward():
+    """End-to-end: model forward + loss backward produces finite grads."""
+    torch.manual_seed(42)
+    m = _make_coarse_model(attn_direction="both")
+    m.train()
+
+    B, L, D_in = 6, 8, 128
+    x = torch.randn(B, L, D_in)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * 8 * 8
+    target = torch.randn(B, D)
+    target[:, D // 4: D // 2] = float("nan")
+
+    loss_fwd, _ = m.recon_loss_attn(attn_pred["forward"], target)
+    loss_bwd, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    (loss_fwd + loss_bwd).backward()
+
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"
+
+
+def test_full_round_trip_forward_backward():
+    """End-to-end: model forward + loss backward produces finite grads."""
+    torch.manual_seed(42)
+    m = _make_full_model(attn_direction="both")
+    m.train()
+
+    B, L, D_in = 4, 8, 128
+    x = torch.randn(B, L, D_in)
+    z, lp_pred, attn_pred = m.forward_with_recon(x)
+
+    D = _NUM_LAYERS * _R_MAX * _R_MAX
+    target = torch.randn(B, D)
+    target[:, D // 3:] = float("nan")
+
+    loss_fwd, _ = m.recon_loss_attn(attn_pred["forward"], target)
+    loss_bwd, _ = m.recon_loss_attn(attn_pred["backward"], target)
+    (loss_fwd + loss_bwd).backward()
+
+    for name, p in m.named_parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all(), f"NaN grad in {name}"

--- a/tests/test_memmap_contrastive_dataset.py
+++ b/tests/test_memmap_contrastive_dataset.py
@@ -367,18 +367,170 @@ def test_view_determinism_with_fixed_layer(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# NotImplementedError on reserved summary modes
+# ValueError on invalid summary mode
 # ---------------------------------------------------------------------------
 
-def test_coarse_and_full_summary_raise_not_implemented(tmp_path):
+def test_invalid_attention_summary_raises(tmp_path):
     capture = _make_full_capture_dir(tmp_path, n_samples=5)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         MemmapContrastiveDataset(
             capture, split="all", num_views=2,
-            include_response_attention=True, attention_summary="coarse",
+            include_response_attention=True, attention_summary="hexgrid",
         )
-    with pytest.raises(NotImplementedError):
-        MemmapContrastiveDataset(
-            capture, split="all", num_views=2,
-            include_response_attention=True, attention_summary="full",
-        )
+
+
+# ---------------------------------------------------------------------------
+# Coarse attention summary
+# ---------------------------------------------------------------------------
+
+def test_coarse_attention_summary_shape(tmp_path):
+    """Coarse target: (num_views, num_layers, 8, 8) per direction."""
+    capture = _make_full_capture_dir(tmp_path, n_samples=10)
+    nl = _SMALL_CFG["num_layers"]
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=2,
+        relevant_layers=[1, 2, 3, 4],
+        include_response_attention=True,
+        attention_summary="coarse",
+        attention_target_layer_offset_forward=1,
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert "attention_forward" in sample
+    assert "attention_backward" in sample
+    assert sample["attention_forward"].shape == (2, nl, 8, 8)
+    assert sample["attention_backward"].shape == (2, nl, 8, 8)
+    assert sample["attention_forward"].dtype == torch.float32
+
+
+def test_coarse_backward_only_emitted(tmp_path):
+    capture = _make_full_capture_dir(tmp_path, n_samples=10)
+    nl = _SMALL_CFG["num_layers"]
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=2,
+        relevant_layers=[1, 2, 3, 4],
+        include_response_attention=True,
+        attention_summary="coarse",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert "attention_backward" in sample
+    assert "attention_forward" not in sample
+    assert sample["attention_backward"].shape == (2, nl, 8, 8)
+
+
+def test_coarse_no_nan_in_full_response(tmp_path):
+    """When all response tokens fill r_max, no NaN cells should appear in coarse."""
+    n = 6
+    r_max = _SMALL_CFG["r_max"]
+    # Set response_len = r_max so all cells are valid.
+    rls = np.full(n, r_max, dtype=np.int32)
+    capture = _make_full_capture_dir(tmp_path, n_samples=n, response_lengths=rls)
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=2,
+        relevant_layers=[1, 2, 3, 4],
+        include_response_attention=True,
+        attention_summary="coarse",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert torch.isfinite(sample["attention_backward"]).all()
+
+
+def test_coarse_zero_response_yields_nan(tmp_path):
+    """response_len=0 → all NaN output for coarse."""
+    n = 4
+    rls = np.zeros(n, dtype=np.int32)
+    capture = _make_full_capture_dir(tmp_path, n_samples=n, response_lengths=rls)
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=1,
+        relevant_layers=[1],
+        fixed_layer=1,
+        include_response_attention=True,
+        attention_summary="coarse",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert torch.isnan(sample["attention_backward"]).all()
+
+
+# ---------------------------------------------------------------------------
+# Full attention summary
+# ---------------------------------------------------------------------------
+
+def test_full_attention_summary_shape(tmp_path):
+    """Full target: (num_views, num_layers, r_max, r_max) per direction."""
+    capture = _make_full_capture_dir(tmp_path, n_samples=10)
+    nl = _SMALL_CFG["num_layers"]
+    rm = _SMALL_CFG["r_max"]
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=2,
+        relevant_layers=[1, 2, 3, 4],
+        include_response_attention=True,
+        attention_summary="full",
+        attention_target_layer_offset_forward=1,
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert "attention_forward" in sample
+    assert "attention_backward" in sample
+    assert sample["attention_forward"].shape == (2, nl, rm, rm)
+    assert sample["attention_backward"].shape == (2, nl, rm, rm)
+    assert sample["attention_forward"].dtype == torch.float32
+
+
+def test_full_backward_only_emitted(tmp_path):
+    capture = _make_full_capture_dir(tmp_path, n_samples=10)
+    nl = _SMALL_CFG["num_layers"]
+    rm = _SMALL_CFG["r_max"]
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=2,
+        relevant_layers=[1, 2, 3, 4],
+        include_response_attention=True,
+        attention_summary="full",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert "attention_backward" in sample
+    assert "attention_forward" not in sample
+    assert sample["attention_backward"].shape == (2, nl, rm, rm)
+
+
+def test_full_out_of_response_cells_are_nan(tmp_path):
+    """Cells beyond r_eff must be NaN; cells within r_eff must be finite."""
+    n = 6
+    r_eff = 3  # shorter than r_max=6
+    rls = np.full(n, r_eff, dtype=np.int32)
+    capture = _make_full_capture_dir(tmp_path, n_samples=n, response_lengths=rls)
+    rm = _SMALL_CFG["r_max"]
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=1,
+        relevant_layers=[1],
+        fixed_layer=1,
+        include_response_attention=True,
+        attention_summary="full",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    attn = sample["attention_backward"]  # (1, num_layers, r_max, r_max)
+    # All cells within r_eff × r_eff block must be finite.
+    assert torch.isfinite(attn[:, :, :r_eff, :r_eff]).all()
+    # Cells outside the block must be NaN.
+    assert torch.isnan(attn[:, :, r_eff:, :]).all()
+    assert torch.isnan(attn[:, :, :, r_eff:]).all()
+
+
+def test_full_zero_response_yields_nan(tmp_path):
+    n = 4
+    rls = np.zeros(n, dtype=np.int32)
+    capture = _make_full_capture_dir(tmp_path, n_samples=n, response_lengths=rls)
+    ds = MemmapContrastiveDataset(
+        capture, split="all", num_views=1,
+        relevant_layers=[1],
+        fixed_layer=1,
+        include_response_attention=True,
+        attention_summary="full",
+        attention_target_layer_offset_backward=1,
+    )
+    sample = ds[0]
+    assert torch.isnan(sample["attention_backward"]).all()


### PR DESCRIPTION
## Summary

- Implements the two reserved-but-unimplemented `attn_target` variants: `'coarse'` (8×8 binned per LLM attention layer) and `'full'` (r_max×r_max per layer), replacing the `NotImplementedError` gates in both model and dataset.
- Adds `attn_loss='mse'|'kl'` config flag (default `'mse'`) so that KL-divergence row-wise loss can be tested against MSE on 2D map targets.
- All 57 tests pass (CPU-only, no GPU required).

## What changed (file-by-file)

| File | Change |
|---|---|
| `activation_research/model.py` | Replace `NotImplementedError` with coarse/full decoder dispatch; add `attn_num_layers`, `attn_r_max`, `attn_loss` params; extend `recon_loss_attn` with KL path and per-cell NaN division |
| `activation_research/memmap_contrastive_dataset.py` | Replace `NotImplementedError`; add `_attn_coarse_for_all_layers` and `_attn_full_for_all_layers` helpers; dispatch in `__getitem__` |
| `tests/test_logprob_attn_recon_model.py` | Replace old `NotImplementedError` tests with construction/shape/dtype/loss/gradient tests for both targets |
| `tests/test_memmap_contrastive_dataset.py` | Replace `NotImplementedError` test with `ValueError` for unknown mode; add shape, NaN-fill, and masking tests for coarse + full |
| `configs/methods/contrastive_logprob_attn_recon_l10_a10_coarse.json` | New config: coarse target, both directions, λ_lp=1.0, λ_attn=1.0, attn_loss=mse |
| `configs/methods/contrastive_logprob_attn_recon_l10_a10_full.json` | New config: full target, both directions, same λ settings |

## Design choices / spec ambiguities resolved

**Dataset target shape:** The bandwidth table in #82 shows `64 × 32 = 2048` for coarse (64=8×8, 32=num_layers), implying the decoder predicts all `num_layers` attention maps per view. The dataset emits `(num_views, num_layers, 8, 8)` per direction, all layers filled regardless of offset — the offset params are still accepted for forward/backward field naming but unused for coarse/full (all layers are always in range). The trainer's existing `target.reshape(bsz*num_views, -1)` path handles the new shape without modification.

**KL loss:** Targets each 8×8 (or r_max×r_max) row as a categorical distribution. Decoder logits → `log_softmax` per row; target → re-normalised over valid cells per row; fully-NaN rows are skipped. `"stats"` uses MSE unconditionally (scalars are not probability distributions).

**NaN convention:** Coarse pools only the valid `r_eff×r_eff` block → all 64 cells per layer are finite (no NaN). Full fills cells beyond `r_eff` with NaN; `recon_loss_attn` already divides by `valid_count`.

## Test plan

- [x] `pytest tests/test_logprob_attn_recon_model.py` — 31 passed
- [x] `pytest tests/test_memmap_contrastive_dataset.py` — 20 passed
- [x] `pytest tests/test_logprob_attn_recon_trainer.py` — 6 passed
- [x] **Total: 57 passed, 0 failed, 0 skipped** (run on Windows CPU, Python 3.10, torch 2.x)
- [ ] GPU round-trip (train one epoch on real captures) — deferred to experiment run in follow-up

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)