### PR TITLE
feat(#64): paper build infra — single-source-of-truth CSV → PDF

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,13 @@
 
 ## Paper Writing
 
-The EMNLP 2026 paper draft lives in `paper/`. When drafting, editing, or extending **paper content** (sections, outline, abstract, claims, tables, figures, bibliography), only read from and write to files inside `paper/`. Do not synthesize paper prose from `PAPER_ROADMAP.md`, `THEORETICAL_JUSTIFICATION.md`, `docs/planning/`, `results/`, or any other location unless the user explicitly names a source to pull from.
+The EMNLP 2026 paper draft lives in `paper/`. **When writing the paper, only reference files inside `paper/`, unless the user explicitly names a source outside it.** This applies to drafting, editing, or extending sections, outline, abstract, claims, tables, figures, and bibliography — and covers reading, citing, comparing against, or otherwise consulting external files, not just copying prose from them.
 
-Rationale: the roadmap, theory doc, and SOTA tracker are *planning material* written for collaborators, not reviewers. The user controls when and how content bridges from planning into the paper — auto-importing roadmap prose into the draft loses voice and short-circuits the editorial pass.
+Concretely: do not read `PAPER_ROADMAP.md`, `THEORETICAL_JUSTIFICATION.md`, `docs/planning/`, `results/`, the SOTA tracker, `README.md`, or any other location outside `paper/` when working on paper content. If a fact, number, or framing from outside `paper/` needs to land in the draft, the user will name the source explicitly.
+
+Rationale: the roadmap, theory doc, and SOTA tracker are *planning material* written for collaborators, not reviewers. The user controls when and how content bridges from planning into the paper — auto-importing or even tacitly cross-referencing that material loses voice and short-circuits the editorial pass.
+
+The single source of truth for numbers cited in the paper is `paper/data/*.csv` and `paper/generated/figures/*.numbers.csv`, accessed through the `\result`/`\resdelta`/`\resratio`/`\resultCI`/`\resultPM` macros defined in `paper/macros.tex`. See `paper/README.md` for the build pipeline.
 
 ## Project Overview
 

--- a/paper/.gitignore
+++ b/paper/.gitignore
@@ -1,0 +1,27 @@
+# paper/.gitignore
+#
+# Generated artifacts — never commit, always rebuilt from data/ + figures_src/.
+generated/
+
+# LaTeX byproducts
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.synctex.gz
+*.toc
+*.lof
+*.lot
+
+# Root-level PDF (built by latexmk from main.tex)
+main.pdf
+
+# Working copies of notebooks (per NOTEBOOK_WORKFLOW.md)
+*.ipynb
+
+# Python bytecode caches
+__pycache__/
+*.pyc

--- a/paper/Makefile
+++ b/paper/Makefile
@@ -1,0 +1,60 @@
+# paper/Makefile
+#
+# Targets:
+#   make figures  — render all figures_src/*.py scripts → generated/figures/
+#   make values   — build_numbers.py: CSVs + sidecars → generated/values.tex
+#   make lint     — digit-not-in-citation check on prose .tex files
+#   make paper    — figures + values + lint + latexmk -pdf main.tex
+#   make clean    — remove generated/ and latexmk byproducts
+#
+# Run 'make paper' to build everything from scratch.
+# LaTeX is required for 'make paper'; all other targets work without it.
+
+PYTHON   ?= python3
+PAPER_DIR = $(CURDIR)
+
+# All figure renderer scripts
+FIGURE_SCRIPTS := $(wildcard figures_src/*.py)
+# Sentinel file: figures are up to date when this exists
+FIGURES_STAMP  := generated/.figures_stamp
+
+.PHONY: figures values lint paper clean
+
+# ---------------------------------------------------------------------------
+# figures: run every figures_src/*.py → generated/figures/*.pdf + *.numbers.csv
+# ---------------------------------------------------------------------------
+figures: $(FIGURES_STAMP)
+
+$(FIGURES_STAMP): $(FIGURE_SCRIPTS) $(wildcard data/*.csv)
+	@mkdir -p generated/figures
+	@for script in $(FIGURE_SCRIPTS); do \
+	    echo "  Rendering $$script ..."; \
+	    $(PYTHON) $$script --paper-dir $(PAPER_DIR) || exit 1; \
+	done
+	@touch $(FIGURES_STAMP)
+
+# ---------------------------------------------------------------------------
+# values: build_numbers.py → generated/values.tex + generated/provenance.txt
+# Depends on figures so sidecar CSVs exist before values.tex is built.
+# ---------------------------------------------------------------------------
+values: figures
+	$(PYTHON) build_numbers.py --paper-dir $(PAPER_DIR)
+
+# ---------------------------------------------------------------------------
+# lint: digit-not-in-citation check
+# ---------------------------------------------------------------------------
+lint:
+	$(PYTHON) lint.py --paper-dir $(PAPER_DIR)
+
+# ---------------------------------------------------------------------------
+# paper: end-to-end build (requires latexmk)
+# ---------------------------------------------------------------------------
+paper: figures values lint
+	latexmk -pdf -interaction=nonstopmode main.tex
+
+# ---------------------------------------------------------------------------
+# clean: remove generated/ and latexmk byproducts
+# ---------------------------------------------------------------------------
+clean:
+	rm -rf generated/
+	rm -f main.aux main.bbl main.blg main.fdb_latexmk main.fls main.log main.out main.pdf main.synctex.gz

--- a/paper/README.md
+++ b/paper/README.md
@@ -20,6 +20,44 @@ Python 3.12 + pandas + matplotlib.
 
 ---
 
+## Submission target: EMNLP 2026 (ARR-routed)
+
+Built against the official [ACL style files](https://github.com/acl-org/acl-style-files).
+The `acl.sty` and `acl_natbib.bst` files are committed alongside `main.tex`.
+
+`main.tex` declares `\usepackage[review]{acl}` — the `review` option adds line
+numbers and the "Anonymous ACL submission" placeholder for blind review.
+**Drop the `[review]` option for the camera-ready.**
+
+### Page allowances (long paper)
+
+| Section | Limit | Counted? |
+|---|---|---|
+| Main body | 8 pages (review), 9 pages (camera-ready) | yes |
+| References | unlimited | no |
+| Appendices | unlimited | no |
+| Limitations | unlimited | no — **required, desk-reject if missing** |
+| Ethics Statement | unlimited | no — optional |
+| Acknowledgments | unlimited | no |
+
+The `Limitations` section (`\section*{Limitations}`, unnumbered) is mandatory
+and is scaffolded in `sections/99_limitations.tex`. Replace the placeholder
+before submission.
+
+### LaTeX dependencies
+
+`make paper` requires:
+
+```bash
+sudo apt-get install -y --no-install-recommends \
+    texlive-latex-base texlive-latex-recommended texlive-latex-extra \
+    texlive-fonts-extra texlive-science latexmk
+```
+
+`texlive-fonts-extra` is needed for `inconsolata.sty` (part of the ACL preamble).
+
+---
+
 ## Citation macros
 
 All macros are defined in `paper/macros.tex`. Values resolve at LaTeX build

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,0 +1,214 @@
+# HalluLens Paper Build System
+
+Every number and every figure in the paper traces back to a single CSV cell.
+When an experiment re-runs and its CSV regenerates, `make paper` picks up new
+values automatically. A stale value is a build failure, not a proofreading task.
+
+## Quick start
+
+```bash
+cd paper/
+make paper        # renders figures, builds values.tex, lints, compiles PDF
+make figures      # render figures_src/*.py only
+make values       # build generated/values.tex from data/ + sidecar CSVs
+make lint         # check prose for bare digits outside citation macros
+make clean        # remove generated/ and LaTeX byproducts
+```
+
+LaTeX (`latexmk`) is required for `make paper`. All other targets need only
+Python 3.12 + pandas + matplotlib.
+
+---
+
+## Citation macros
+
+All macros are defined in `paper/macros.tex`. Values resolve at LaTeX build
+time from `paper/generated/values.tex` (produced by `build_numbers.py`).
+
+### Note on macro names
+
+The issue spec lists `\delta` and `\ratio`; we ship `\resdelta` and `\resratio`.
+`\delta` already denotes the Greek letter delta in math mode, so it cannot
+safely be redefined; we keep the `\res*` prefix on `\resratio` for naming
+consistency.
+
+### `\result{csv}{key}[p]`
+
+Look up one cell and render it with `p` decimal places.
+
+```latex
+The probe achieves \result{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}[3] AUROC.
+```
+
+- `csv` is the stem of a file in `paper/data/` (e.g. `baseline_comparison`
+  for `baseline_comparison.csv`) or `fig.<name>` for a figure sidecar.
+- `key` is a colon-joined coordinate per the CSV's `key_schema` plus the
+  column name (e.g. `hotpotqa:icr_probe:auroc:mean`).
+- `[p]` is the number of decimal places (optional; default from CSV header).
+
+### `\resdelta{csv}{key_a}{key_b}[p]`
+
+Compute `key_a - key_b` at build time via `\fpeval` (from `xfp`). Renders
+with explicit sign.
+
+```latex
+a gain of \resdelta{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}{hotpotqa:selfcheck:auroc:mean}[3] pp
+```
+
+### `\resratio{csv}{key_a}{key_b}[p]`
+
+Compute `key_a / key_b` at build time.
+
+```latex
+a speedup of \resratio{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}{hotpotqa:selfcheck:auroc:mean}[2]x
+```
+
+### `\resultCI{csv}{mean,lo,hi}[p]`
+
+Render a confidence interval: `mean [lo, hi]`.
+
+```latex
+(95\% CI \resultCI{baseline_comparison}{hotpotqa:icr_probe:auroc:mean,hotpotqa:icr_probe:auroc_lo:mean,hotpotqa:icr_probe:auroc_hi:mean}[3])
+```
+
+### `\resultPM{csv}{mean,err}[p]`
+
+Render mean with symmetric error: `mean +/- err`.
+
+```latex
+\resultPM{baseline_comparison}{hotpotqa:icr_probe:auroc:mean,hotpotqa:icr_probe:auroc_ci95:mean}[3]
+```
+
+---
+
+## Figure-sidecar contract
+
+Data-derived figures live in `paper/figures_src/` (source) and
+`paper/generated/figures/` (outputs, gitignored). Every figure renderer
+writes two outputs:
+
+```
+paper/generated/figures/<name>.pdf
+paper/generated/figures/<name>.numbers.csv
+```
+
+The sidecar lists every number appearing on the figure:
+
+```
+# generator: paper/figures_src/render_transfer.py
+# source_data: paper/data/baseline_comparison.csv
+label,value,role
+diagonal_mean,0.847,annotation
+off_diag_max,0.811,annotation
+y_axis_max,1.0,axis
+```
+
+Columns: `label` (stable identifier), `value` (raw float), `role` (`annotation`,
+`axis`, or `data`).
+
+### Citing from a sidecar
+
+The sidecar stem is prefixed with `fig.`:
+
+```latex
+\caption{Transfer matrix. Diagonal mean
+\result{fig.transfer_llama_linear}{diagonal_mean}[2],
+off-diagonal max \result{fig.transfer_llama_linear}{off_diag_max}[2].}
+```
+
+This namespace (`fig.<stem>`) is how `build_numbers.py` avoids collisions
+between `data/` CSVs and sidecar CSVs with the same base name.
+
+---
+
+## How to add a CSV
+
+1. Drop `your_experiment.csv` into `paper/data/` with the §3 header block:
+
+   ```
+   # source_commit: <git SHA the aggregator ran at>
+   # generated: 2026-05-18T14:22:31Z
+   # generator: scripts/aggregate_results.py
+   # key_schema: dataset:method:metric
+   # default_precision: 3
+   dataset,method,metric,mean,ci_95,...
+   ```
+
+2. Run `make values` to regenerate `generated/values.tex`.
+
+3. Cite cells with `\result{your_experiment}{...}`.
+
+---
+
+## The lint rule and whitelist
+
+`paper/lint.py` scans `main.tex` and `sections/*.tex`. Any digit appearing
+in prose outside an approved context is a build failure.
+
+**Approved contexts:** inside `\result`, `\resdelta`, `\resratio`, `\resultCI`,
+`\resultPM`, `\ref`, `\cite`, `\citep`, `\citet`, `\eqref`, `\label`.
+
+**Always allowed:** year literals (`\b(19|20)\d{2}\b`), math mode
+(`$...$`, `\[...\]`, equation/align environments).
+
+**Whitelist:** a literal-string list in `paper/lint.py`. Each entry is an
+explicit decision. To add one, append to `WHITELIST` in `lint.py` and document
+why in your PR. Example entries: `"Llama-3.1"`, `"8B parameters"`,
+`"learning rate 1e-4"`.
+
+Do not use regex in the whitelist — keep it to literal strings so the set
+of allowed bare digits is small and auditable.
+
+---
+
+## File layout
+
+```
+paper/
+  Makefile                  # build targets
+  build_numbers.py          # CSVs → generated/values.tex
+  lint.py                   # bare-digit checker
+  macros.tex                # \result, \resdelta, etc. (committed)
+  main.tex                  # minimal article wrapper
+  sections/                 # prose (committed)
+    00_abstract.tex
+    01_intro.tex
+    ...
+  data/                     # committed CSVs (from aggregate scripts)
+    baseline_comparison.csv
+    ...
+  figures/                  # hand-made figures (committed)
+  figures_src/              # figure renderers (committed)
+    render_transfer.py
+    ...
+  templates/                # .tex.template files for generated tables
+  generated/                # GITIGNORED — rebuilt every make paper
+    values.tex
+    provenance.txt
+    figures/
+      *.pdf
+      *.numbers.csv
+  README.md
+  .gitignore
+```
+
+---
+
+## Provenance
+
+After every `make values` (or `make paper`), `paper/generated/provenance.txt`
+lists every `\result`/`\resdelta` call site in prose with its CSV cell and
+resolved value. Use it as a reviewer-letter dump or sanity check.
+
+---
+
+## Aggregator scripts
+
+Aggregator scripts in `scripts/` write CSVs to `paper/data/` with the §3
+header block. They never run automatically at build time — the build consumes
+committed CSVs. To update a CSV after re-running experiments:
+
+```bash
+python scripts/aggregate_results.py --runs-dir runs/baseline_comparison_hotpotqa \
+    --paper-output paper/data/baseline_comparison.csv
+```

--- a/paper/acl.sty
+++ b/paper/acl.sty
@@ -1,0 +1,312 @@
+% This is the LaTex style file for *ACL.
+% The official sources can be found at
+%
+%     https://github.com/acl-org/acl-style-files/
+%
+% This package is activated by adding
+%
+%    \usepackage{acl}
+%
+% to your LaTeX file. When submitting your paper for review, add the "review" option:
+%
+%    \usepackage[review]{acl}
+
+\newif\ifacl@finalcopy
+\newif\ifacl@anonymize
+\newif\ifacl@linenumbers
+\newif\ifacl@pagenumbers
+\DeclareOption{final}{\acl@finalcopytrue\acl@anonymizefalse\acl@linenumbersfalse\acl@pagenumbersfalse}
+\DeclareOption{review}{\acl@finalcopyfalse\acl@anonymizetrue\acl@linenumberstrue\acl@pagenumberstrue}
+\DeclareOption{preprint}{\acl@finalcopytrue\acl@anonymizefalse\acl@linenumbersfalse\acl@pagenumberstrue}
+\ExecuteOptions{final} % final copy is the default
+
+% include hyperref, unless user specifies nohyperref option like this:
+% \usepackage[nohyperref]{acl}
+\newif\ifacl@hyperref
+\DeclareOption{hyperref}{\acl@hyperreftrue}
+\DeclareOption{nohyperref}{\acl@hyperreffalse}
+\ExecuteOptions{hyperref} % default is to use hyperref
+\ProcessOptions\relax
+
+\typeout{Conference Style for ACL}
+
+\usepackage{xcolor}
+
+\ifacl@linenumbers
+  % Add draft line numbering via the lineno package
+  % https://texblog.org/2012/02/08/adding-line-numbers-to-documents/
+  \usepackage[switch,mathlines]{lineno}
+
+  % Line numbers in gray Helvetica 8pt
+  \font\aclhv = phvb at 8pt
+  \renewcommand\linenumberfont{\aclhv\color{lightgray}}
+
+  % Zero-fill line numbers
+  % NUMBER with left flushed zeros  \fillzeros[<WIDTH>]<NUMBER>
+  \newcount\cv@tmpc@ \newcount\cv@tmpc
+  \def\fillzeros[#1]#2{\cv@tmpc@=#2\relax\ifnum\cv@tmpc@<0\cv@tmpc@=-\cv@tmpc@\fi
+    \cv@tmpc=1 %
+    \loop\ifnum\cv@tmpc@<10 \else \divide\cv@tmpc@ by 10 \advance\cv@tmpc by 1 \fi
+      \ifnum\cv@tmpc@=10\relax\cv@tmpc@=11\relax\fi \ifnum\cv@tmpc@>10 \repeat
+    \ifnum#2<0\advance\cv@tmpc1\relax-\fi
+    \loop\ifnum\cv@tmpc<#1\relax0\advance\cv@tmpc1\relax\fi \ifnum\cv@tmpc<#1 \repeat
+    \cv@tmpc@=#2\relax\ifnum\cv@tmpc@<0\cv@tmpc@=-\cv@tmpc@\fi \relax\the\cv@tmpc@}%
+  \renewcommand\thelinenumber{\fillzeros[3]{\arabic{linenumber}}}
+  \AtBeginDocument{\linenumbers}
+
+  \setlength{\linenumbersep}{1.6cm}
+
+  % Bug: An equation with $$ ... $$ isn't numbered, nor is the previous line.
+
+  % Patch amsmath commands so that the previous line and the equation itself
+  % are numbered. Bug: multline has an extra line number.
+  % https://tex.stackexchange.com/questions/461186/how-to-use-lineno-with-amsmath-align
+  \usepackage{etoolbox} %% <- for \pretocmd, \apptocmd and \patchcmd
+
+  \newcommand*\linenomathpatch[1]{%
+    \expandafter\pretocmd\csname #1\endcsname {\linenomath}{}{}%
+    \expandafter\pretocmd\csname #1*\endcsname {\linenomath}{}{}%
+    \expandafter\apptocmd\csname end#1\endcsname {\endlinenomath}{}{}%
+    \expandafter\apptocmd\csname end#1*\endcsname {\endlinenomath}{}{}%
+  }
+  \newcommand*\linenomathpatchAMS[1]{%
+    \expandafter\pretocmd\csname #1\endcsname {\linenomathAMS}{}{}%
+    \expandafter\pretocmd\csname #1*\endcsname {\linenomathAMS}{}{}%
+    \expandafter\apptocmd\csname end#1\endcsname {\endlinenomath}{}{}%
+    \expandafter\apptocmd\csname end#1*\endcsname {\endlinenomath}{}{}%
+  }
+
+  %% Definition of \linenomathAMS depends on whether the mathlines option is provided
+  \expandafter\ifx\linenomath\linenomathWithnumbers
+    \let\linenomathAMS\linenomathWithnumbers
+    %% The following line gets rid of an extra line numbers at the bottom:
+    \patchcmd\linenomathAMS{\advance\postdisplaypenalty\linenopenalty}{}{}{}
+  \else
+    \let\linenomathAMS\linenomathNonumbers
+  \fi
+
+  \AtBeginDocument{%
+    \linenomathpatch{equation}%
+    \linenomathpatchAMS{gather}%
+    \linenomathpatchAMS{multline}%
+    \linenomathpatchAMS{align}%
+    \linenomathpatchAMS{alignat}%
+    \linenomathpatchAMS{flalign}%
+  }
+\else
+  % Hack to ignore these commands, which review mode puts into the .aux file.
+  \newcommand{\@LN@col}[1]{}
+  \newcommand{\@LN}[2]{}
+  \newcommand{\nolinenumbers}{}
+\fi
+
+\PassOptionsToPackage{a4paper,margin=2.5cm,heightrounded=true}{geometry}
+\RequirePackage{geometry}
+
+\setlength\columnsep{0.6cm}
+\newlength\titlebox
+\setlength\titlebox{11\baselineskip}
+% \titlebox should be a multiple of \baselineskip so that
+% column height remaining fits an exact number of lines of text
+
+\flushbottom \twocolumn \sloppy
+
+% We're never going to need a table of contents, so just flush it to
+% save space --- suggested by drstrip@sandia-2
+\def\addcontentsline#1#2#3{}
+
+\ifacl@pagenumbers
+    \pagenumbering{arabic}
+\else
+    \thispagestyle{empty}
+    \pagestyle{empty}
+\fi
+
+%% Title and Authors %%
+
+\let\Thanks\thanks % \Thanks and \thanks used to be different, but keep this for backwards compatibility.
+
+\newcommand\outauthor{%
+    \begin{tabular}[t]{c}
+    \ifacl@anonymize
+        \bfseries Anonymous ACL submission
+    \else
+        \bfseries\@author
+    \fi
+    \end{tabular}}
+
+% Mostly taken from deproc.
+\AtBeginDocument{
+\def\maketitle{\par
+ \begingroup
+   \def\thefootnote{\fnsymbol{footnote}}
+   \twocolumn[\@maketitle]
+   \@thanks
+ \endgroup
+ \setcounter{footnote}{0}
+ \let\maketitle\relax
+ \let\@maketitle\relax
+ \gdef\@thanks{}\gdef\@author{}\gdef\@title{}\let\thanks\relax}
+\def\@maketitle{\vbox to \titlebox{\hsize\textwidth
+ \linewidth\hsize \vskip 0.125in minus 0.125in \centering
+ {\Large\bfseries \@title \par} \vskip 0.2in plus 1fil minus 0.1in
+ {\def\and{\unskip\enspace{\rmfamily and}\enspace}%
+  \def\And{\end{tabular}\hss \egroup \hskip 1in plus 2fil
+           \hbox to 0pt\bgroup\hss \begin{tabular}[t]{c}\bfseries}%
+  \def\AND{\end{tabular}\hss\egroup \hfil\hfil\egroup
+          \vskip 0.25in plus 1fil minus 0.125in
+           \hbox to \linewidth\bgroup\large \hfil\hfil
+             \hbox to 0pt\bgroup\hss \begin{tabular}[t]{c}\bfseries}
+  \hbox to \linewidth\bgroup\large \hfil\hfil
+    \hbox to 0pt\bgroup\hss
+  \outauthor
+   \hss\egroup
+    \hfil\hfil\egroup}
+  \vskip 0.3in plus 2fil minus 0.1in
+}}
+}
+
+% margins and font size for abstract
+\renewenvironment{abstract}%
+  {\begin{center}\large\textbf{\abstractname}\end{center}%
+    \begin{list}{}%
+      {\setlength{\rightmargin}{0.6cm}%
+        \setlength{\leftmargin}{0.6cm}}%
+      \item[]\ignorespaces%
+      \@setsize\normalsize{12pt}\xpt\@xpt
+  }%
+  {\unskip\end{list}}
+
+% Resizing figure and table captions - SL
+% Support for interacting with the caption, subfigure, and subcaption packages - SL
+\RequirePackage{caption}
+\DeclareCaptionFont{10pt}{\fontsize{10pt}{12pt}\selectfont}
+\captionsetup{font=10pt}
+
+\RequirePackage{natbib}
+% for citation commands in the .tex, authors can use:
+% \citep, \citet, and \citeyearpar for compatibility with natbib, or
+% \cite, \newcite, and \shortcite for compatibility with older ACL .sty files
+\renewcommand\cite{\citep}  % to get "(Author Year)" with natbib
+\newcommand\shortcite{\citeyearpar}% to get "(Year)" with natbib
+\newcommand\newcite{\citet} % to get "Author (Year)" with natbib
+\newcommand{\citeposs}[1]{\citeauthor{#1}'s (\citeyear{#1})} % to get "Author's (Year)"
+
+\bibliographystyle{acl_natbib}
+
+% Bibliography
+
+% Don't put a label in the bibliography at all.  Just use the unlabeled format
+% instead.
+\def\thebibliography#1{\vskip\parskip%
+\vskip\baselineskip%
+\def\baselinestretch{1}%
+\ifx\@currsize\normalsize\@normalsize\else\@currsize\fi%
+\vskip-\parskip%
+\vskip-\baselineskip%
+\section*{References\@mkboth
+ {References}{References}}\list
+ {}{\setlength{\labelwidth}{0pt}\setlength{\leftmargin}{\parindent}
+ \setlength{\itemindent}{-\parindent}}
+ \def\newblock{\hskip .11em plus .33em minus -.07em}
+ \sloppy\clubpenalty4000\widowpenalty4000
+ \sfcode`\.=1000\relax}
+\let\endthebibliography=\endlist
+
+
+% Allow for a bibliography of sources of attested examples
+\def\thesourcebibliography#1{\vskip\parskip%
+\vskip\baselineskip%
+\def\baselinestretch{1}%
+\ifx\@currsize\normalsize\@normalsize\else\@currsize\fi%
+\vskip-\parskip%
+\vskip-\baselineskip%
+\section*{Sources of Attested Examples\@mkboth
+ {Sources of Attested Examples}{Sources of Attested Examples}}\list
+ {}{\setlength{\labelwidth}{0pt}\setlength{\leftmargin}{\parindent}
+ \setlength{\itemindent}{-\parindent}}
+ \def\newblock{\hskip .11em plus .33em minus -.07em}
+ \sloppy\clubpenalty4000\widowpenalty4000
+ \sfcode`\.=1000\relax}
+\let\endthesourcebibliography=\endlist
+
+% sections with less space
+\def\section{\@startsection {section}{1}{\z@}{-2.0ex plus
+    -0.5ex minus -.2ex}{1.5ex plus 0.3ex minus .2ex}{\large\bfseries\raggedright}}
+\def\subsection{\@startsection{subsection}{2}{\z@}{-1.8ex plus
+    -0.5ex minus -.2ex}{0.8ex plus .2ex}{\normalsize\bfseries\raggedright}}
+%% changed by KO to - values to get the initial parindent right
+\def\subsubsection{\@startsection{subsubsection}{3}{\z@}{-1.5ex plus
+   -0.5ex minus -.2ex}{0.5ex plus .2ex}{\normalsize\bfseries\raggedright}}
+\def\paragraph{\@startsection{paragraph}{4}{\z@}{1.5ex plus
+   0.5ex minus .2ex}{-1em}{\normalsize\bfseries}}
+\def\subparagraph{\@startsection{subparagraph}{5}{\parindent}{1.5ex plus
+   0.5ex minus .2ex}{-1em}{\normalsize\bfseries}}
+
+% Footnotes
+\footnotesep 6.65pt %
+\skip\footins 9pt plus 4pt minus 2pt
+\def\footnoterule{\kern-3pt \hrule width 5pc \kern 2.6pt }
+\setcounter{footnote}{0}
+
+% Lists and paragraphs
+\parindent 1em
+\topsep 4pt plus 1pt minus 2pt
+\partopsep 1pt plus 0.5pt minus 0.5pt
+\itemsep 2pt plus 1pt minus 0.5pt
+\parsep 2pt plus 1pt minus 0.5pt
+
+\leftmargin 2em \leftmargini\leftmargin \leftmarginii 2em
+\leftmarginiii 1.5em \leftmarginiv 1.0em \leftmarginv .5em \leftmarginvi .5em
+\labelwidth\leftmargini\advance\labelwidth-\labelsep \labelsep 5pt
+
+\def\@listi{\leftmargin\leftmargini}
+\def\@listii{\leftmargin\leftmarginii
+   \labelwidth\leftmarginii\advance\labelwidth-\labelsep
+   \topsep 2pt plus 1pt minus 0.5pt
+   \parsep 1pt plus 0.5pt minus 0.5pt
+   \itemsep \parsep}
+\def\@listiii{\leftmargin\leftmarginiii
+    \labelwidth\leftmarginiii\advance\labelwidth-\labelsep
+    \topsep 1pt plus 0.5pt minus 0.5pt
+    \parsep \z@ \partopsep 0.5pt plus 0pt minus 0.5pt
+    \itemsep \topsep}
+\def\@listiv{\leftmargin\leftmarginiv
+     \labelwidth\leftmarginiv\advance\labelwidth-\labelsep}
+\def\@listv{\leftmargin\leftmarginv
+     \labelwidth\leftmarginv\advance\labelwidth-\labelsep}
+\def\@listvi{\leftmargin\leftmarginvi
+     \labelwidth\leftmarginvi\advance\labelwidth-\labelsep}
+
+\abovedisplayskip 7pt plus2pt minus5pt%
+\belowdisplayskip \abovedisplayskip
+\abovedisplayshortskip  0pt plus3pt%
+\belowdisplayshortskip  4pt plus3pt minus3pt%
+
+% Less leading in most fonts (due to the narrow columns)
+% The choices were between 1-pt and 1.5-pt leading
+\def\@normalsize{\@setsize\normalsize{11pt}\xpt\@xpt}
+\def\small{\@setsize\small{10pt}\ixpt\@ixpt}
+\def\footnotesize{\@setsize\footnotesize{10pt}\ixpt\@ixpt}
+\def\scriptsize{\@setsize\scriptsize{8pt}\viipt\@viipt}
+\def\tiny{\@setsize\tiny{7pt}\vipt\@vipt}
+\def\large{\@setsize\large{14pt}\xiipt\@xiipt}
+\def\Large{\@setsize\Large{16pt}\xivpt\@xivpt}
+\def\LARGE{\@setsize\LARGE{20pt}\xviipt\@xviipt}
+\def\huge{\@setsize\huge{23pt}\xxpt\@xxpt}
+\def\Huge{\@setsize\Huge{28pt}\xxvpt\@xxvpt}
+
+% The hyperref manual (section 9) says hyperref should be loaded after natbib
+\ifacl@hyperref
+  \PassOptionsToPackage{breaklinks}{hyperref}
+  \RequirePackage{hyperref}
+  % make links dark blue
+  \definecolor{darkblue}{rgb}{0, 0, 0.5}
+  \hypersetup{colorlinks=true, citecolor=darkblue, linkcolor=darkblue, urlcolor=darkblue}
+\else
+  % This definition is used if the hyperref package is not loaded.
+  % It provides a backup, no-op definiton of \href.
+  % This is necessary because \href command is used in the acl_natbib.bst file.
+  \def\href#1#2{{#2}}
+  \usepackage{url}
+\fi

--- a/paper/acl_natbib.bst
+++ b/paper/acl_natbib.bst
@@ -1,0 +1,1940 @@
+%%% Modification of BibTeX style file acl_natbib_nourl.bst
+%%% ... by urlbst, version 0.9.1 (marked with "% urlbst")
+%%% See <https://purl.org/nxg/dist/urlbst> and repository <https://heptapod.host/nxg/urlbst>
+%%% Modifications Copyright 2002–23, Norman Gray,
+%%% and distributed under the terms of the LPPL; see README for discussion.
+%%%
+%%% Added webpage entry type, and url and lastchecked fields.
+%%% Added eprint support.
+%%% Added DOI support.
+%%% Added PUBMED support.
+%%% Added hyperref support.
+%%% Original headers follow...
+
+%%
+%% This is file `acl_natbib_basic.bst',
+%% generated with the docstrip utility.
+%%
+%% The original source files were:
+%%
+%% merlin.mbs  (with options: `ay,nat,pres,ed-au,keyxyr,blkyear,dt-beg,yr-per,note-yr,num-xser,pre-edn,xedn,nfss')
+%% ----------------------------------------
+%% *** Intended for ACL conferences ***
+%% 
+%% Copyright 1994-2011 Patrick W Daly
+ % ===============================================================
+ % IMPORTANT NOTICE:
+ % This bibliographic style (bst) file has been generated from one or
+ % more master bibliographic style (mbs) files, listed above.
+ %
+ % This generated file can be redistributed and/or modified under the terms
+ % of the LaTeX Project Public License Distributed from CTAN
+ % archives in directory macros/latex/base/lppl.txt; either
+ % version 1 of the License, or any later version.
+ % ===============================================================
+ % Name and version information of the main mbs file:
+ % \ProvidesFile{merlin.mbs}[2011/11/18 4.33 (PWD, AO, DPC)]
+ %   For use with BibTeX version 0.99a or later
+ %-------------------------------------------------------------------
+ % This bibliography style file is intended for texts in ENGLISH
+ % This is an author-year citation style bibliography. As such, it is
+ % non-standard LaTeX, and requires a special package file to function properly.
+ % Such a package is    natbib.sty   by Patrick W. Daly
+ % The form of the \bibitem entries is
+ %   \bibitem[Jones et al.(1990)]{key}...
+ %   \bibitem[Jones et al.(1990)Jones, Baker, and Smith]{key}...
+ % The essential feature is that the label (the part in brackets) consists
+ % of the author names, as they should appear in the citation, with the year
+ % in parentheses following. There must be no space before the opening
+ % parenthesis!
+ % With natbib v5.3, a full list of authors may also follow the year.
+ % In natbib.sty, it is possible to define the type of enclosures that is
+ % really wanted (brackets or parentheses), but in either case, there must
+ % be parentheses in the label.
+ % The \cite command functions as follows:
+ %   \citet{key} ==>>                Jones et al. (1990)
+ %   \citet*{key} ==>>               Jones, Baker, and Smith (1990)
+ %   \citep{key} ==>>                (Jones et al., 1990)
+ %   \citep*{key} ==>>               (Jones, Baker, and Smith, 1990)
+ %   \citep[chap. 2]{key} ==>>       (Jones et al., 1990, chap. 2)
+ %   \citep[e.g.][]{key} ==>>        (e.g. Jones et al., 1990)
+ %   \citep[e.g.][p. 32]{key} ==>>   (e.g. Jones et al., 1990, p. 32)
+ %   \citeauthor{key} ==>>           Jones et al.
+ %   \citeauthor*{key} ==>>          Jones, Baker, and Smith
+ %   \citeyear{key} ==>>             1990
+ %---------------------------------------------------------------------
+
+%% 2025 modified to truncate author lists of more than 20 authors
+
+ENTRY
+  { address
+    archivePrefix
+    author
+    booktitle
+    chapter
+    edition
+    editor
+    eid
+    eprint
+    eprinttype % = archivePrefix
+    howpublished
+    institution
+    journal
+    key
+    month
+    note
+    number
+    organization
+    pages
+    publisher
+    school
+    series
+    title
+    type
+    volume
+    year
+    doi % urlbst
+    pubmed % urlbst
+    url % urlbst
+    lastchecked % urlbst
+  }
+  {}
+  { label extra.label sort.label short.list }
+INTEGERS { output.state before.all mid.sentence after.sentence after.block }
+% urlbst...
+% urlbst constants and state variables
+STRINGS { urlintro
+  eprinturl eprintprefix doiprefix doiurl pubmedprefix pubmedurl
+  citedstring onlinestring linktextstring
+  openinlinelink closeinlinelink }
+INTEGERS { hrefform doiform inlinelinks makeinlinelink
+  addeprints adddoi addpubmed }
+FUNCTION {init.urlbst.variables}
+{
+  % The following constants may be adjusted by hand, if desired
+
+  % The first set allow you to enable or disable certain functionality.
+  #1 'addeprints :=	% 0=no eprints; 1=include eprints
+  #2 'hrefform :=	% 0=no crossrefs; 1=hypertex hrefs; 2=hyperref hrefs
+  #1 'inlinelinks :=	% 0=URLs explicit; 1=URLs attached to titles
+  #1 'adddoi :=	% 0=no DOI resolver; 1=include it
+  #1 'addpubmed :=	% 0=no PUBMED resolver; 1=include it
+  #0 'doiform :=	% 0=with href; 1=with \doi{}
+
+  % String constants, which you _might_ want to tweak.
+  "online" 'onlinestring :=	% label that a resource is online
+  "[link]" 'linktextstring :=	% anonymous link text
+  "http://www.ncbi.nlm.nih.gov/pubmed/" 'pubmedurl :=	% prefix to make URL from PUBMED
+  "https://doi.org/" 'doiurl :=	% prefix to make URL from DOI
+  "doi:" 'doiprefix :=	% printed text to introduce DOI
+  "https://arxiv.org/abs/" 'eprinturl :=	% prefix to make URL from eprint ref
+  "cited " 'citedstring :=	% label in "lastchecked" remark
+  "arXiv:" 'eprintprefix :=	% text prefix printed before eprint ref
+  "PMID:" 'pubmedprefix :=	% text prefix printed before PUBMED ref
+  "URL: " 'urlintro :=	% text prefix before URL
+
+  % The following are internal state variables, not configuration constants,
+  % so they shouldn't be fiddled with.
+  #0 'makeinlinelink :=     % state variable managed by possibly.setup.inlinelink
+  "" 'openinlinelink :=     % ditto
+  "" 'closeinlinelink :=    % ditto
+}
+INTEGERS {
+  bracket.state
+  outside.brackets
+  open.brackets
+  within.brackets
+  close.brackets
+}
+% ...urlbst to here
+FUNCTION {init.state.consts}
+{ #0 'outside.brackets := % urlbst...
+  #1 'open.brackets :=
+  #2 'within.brackets :=
+  #3 'close.brackets := % ...urlbst to here
+
+  #0 'before.all :=
+  #1 'mid.sentence :=
+  #2 'after.sentence :=
+  #3 'after.block :=
+}
+STRINGS { s t}
+% urlbst
+FUNCTION {output.nonnull.original}
+{ 's :=
+  output.state mid.sentence =
+    { ", " * write$ }
+    { output.state after.block =
+        { add.period$ write$
+          newline$
+          "\newblock " write$
+        }
+        { output.state before.all =
+            'write$
+            { add.period$ " " * write$ }
+          if$
+        }
+      if$
+      mid.sentence 'output.state :=
+    }
+  if$
+  s
+}
+
+% urlbst...
+% Minimal DOI parsing.
+% Given a DOI on the stack, check whether it starts with 'doiurl' or not.
+% In either case, leave on the stack first a DOI with, and then a DOI without, the URL prefix.
+FUNCTION {parse.doi}
+{
+  #1 doiurl text.length$ substring$
+  doiurl =
+    { doi
+      doi doiurl text.length$ #1 + #999 substring$ }
+    { doiurl doi *
+      doi }
+  if$
+}
+% The following three functions are for handling inlinelink.  They wrap
+% a block of text which is potentially output with write$ by multiple
+% other functions, so we don't know the content a priori.
+% They communicate between each other using the variables makeinlinelink
+% (which is true if a link should be made), and closeinlinelink (which holds
+% the string which should close any current link.  They can be called
+% at any time, but start.inlinelink will be a no-op unless something has
+% previously set makeinlinelink true, and the two ...end.inlinelink functions
+% will only do their stuff if start.inlinelink has previously set
+% closeinlinelink to be non-empty.
+% (thanks to 'ijvm' for suggested code here)
+FUNCTION {uand}
+{ 'skip$ { pop$ #0 } if$ } % 'and' (which isn't defined at this point in the file)
+FUNCTION {possibly.setup.inlinelink}
+{ makeinlinelink hrefform #0 > uand
+    { doi empty$ adddoi uand
+        { pubmed empty$ addpubmed uand
+            { eprint empty$ addeprints uand
+                { url empty$
+                    { "" }
+                    { url }
+                  if$ }
+                { eprinturl eprint * }
+              if$ }
+            { pubmedurl pubmed * }
+          if$ }
+%        { doiurl doi * }
+        { doi empty$
+            { "XXX" }
+            { doi parse.doi pop$ }
+          if$
+        }
+      if$
+      % an appropriately-formatted URL is now on the stack
+      hrefform #1 = % hypertex
+        { "\special {html:<a href=" quote$ * swap$ * quote$ * "> }{" * 'openinlinelink :=
+          "\special {html:</a>}" 'closeinlinelink := }
+        { "\href {" swap$ * "} {" * 'openinlinelink := % hrefform=#2 -- hyperref
+          % the space between "} {" matters: a URL of just the right length can cause "\% newline em"
+          "}" 'closeinlinelink := }
+      if$
+      #0 'makeinlinelink :=
+      }
+    'skip$
+  if$ % makeinlinelink
+}
+FUNCTION {add.inlinelink}
+{ openinlinelink empty$
+    'skip$
+    { openinlinelink swap$ * closeinlinelink *
+      "" 'openinlinelink :=
+      }
+  if$
+}
+FUNCTION {output.nonnull}
+{ % Save the thing we've been asked to output
+  's :=
+  % If the bracket-state is close.brackets, then add a close-bracket to
+  % what is currently at the top of the stack, and set bracket.state
+  % to outside.brackets
+  bracket.state close.brackets =
+    { "]" *
+      outside.brackets 'bracket.state :=
+    }
+    'skip$
+  if$
+  bracket.state outside.brackets =
+    { % We're outside all brackets -- this is the normal situation.
+      % Write out what's currently at the top of the stack, using the
+      % original output.nonnull function.
+      s
+      add.inlinelink
+      output.nonnull.original % invoke the original output.nonnull
+    }
+    { % Still in brackets.  Add open-bracket or (continuation) comma, add the
+      % new text (in s) to the top of the stack, and move to the close-brackets
+      % state, ready for next time (unless inbrackets resets it).  If we come
+      % into this branch, then output.state is carefully undisturbed.
+      bracket.state open.brackets =
+        { " [" * }
+        { ", " * } % bracket.state will be within.brackets
+      if$
+      s *
+      close.brackets 'bracket.state :=
+    }
+  if$
+}
+
+% Call this function just before adding something which should be presented in
+% brackets.  bracket.state is handled specially within output.nonnull.
+FUNCTION {inbrackets}
+{ bracket.state close.brackets =
+    { within.brackets 'bracket.state := } % reset the state: not open nor closed
+    { open.brackets 'bracket.state := }
+  if$
+}
+
+FUNCTION {format.lastchecked}
+{ lastchecked empty$
+    { "" }
+    { inbrackets citedstring lastchecked * }
+  if$
+}
+% ...urlbst to here
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+FUNCTION {output.check}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+FUNCTION {fin.entry.original} % urlbst (renamed from fin.entry, so it can be wrapped below)
+{ add.period$
+  write$
+  newline$
+}
+
+FUNCTION {new.block}
+{ output.state before.all =
+    'skip$
+    { after.block 'output.state := }
+  if$
+}
+FUNCTION {new.sentence}
+{ output.state after.block =
+    'skip$
+    { output.state before.all =
+        'skip$
+        { after.sentence 'output.state := }
+      if$
+    }
+  if$
+}
+FUNCTION {add.blank}
+{  " " * before.all 'output.state :=
+}
+
+FUNCTION {date.block}
+{
+  new.block
+}
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+FUNCTION {and}
+{   'skip$
+    { pop$ #0 }
+  if$
+}
+FUNCTION {or}
+{   { pop$ #1 }
+    'skip$
+  if$
+}
+FUNCTION {new.block.checkb}
+{ empty$
+  swap$ empty$
+  and
+    'skip$
+    'new.block
+  if$
+}
+FUNCTION {field.or.null}
+{ duplicate$ empty$
+    { pop$ "" }
+    'skip$
+  if$
+}
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+FUNCTION {tie.or.space.prefix} % puts ~ before the preceding part if it is of length <3
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$
+}
+
+FUNCTION {capitalize}
+{ "u" change.case$ "t" change.case$ }
+
+FUNCTION {space.word}
+{ " " swap$ * " " * }
+ % Here are the language-specific definitions for explicit words.
+ % Each function has a name bbl.xxx where xxx is the English word.
+ % The language selected here is ENGLISH
+FUNCTION {bbl.and}
+{ "and"}
+
+FUNCTION {bbl.etal}
+{ "et~al." }
+
+FUNCTION {bbl.editors}
+{ "editors" }
+
+FUNCTION {bbl.editor}
+{ "editor" }
+
+FUNCTION {bbl.edby}
+{ "edited by" }
+
+FUNCTION {bbl.edition}
+{ "edition" }
+
+FUNCTION {bbl.volume}
+{ "volume" }
+
+FUNCTION {bbl.of}
+{ "of" }
+
+FUNCTION {bbl.number}
+{ "number" }
+
+FUNCTION {bbl.nr}
+{ "no." }
+
+FUNCTION {bbl.in}
+{ "in" }
+
+FUNCTION {bbl.pages}
+{ "pages" }
+
+FUNCTION {bbl.page}
+{ "page" }
+
+FUNCTION {bbl.chapter}
+{ "chapter" }
+
+FUNCTION {bbl.techrep}
+{ "Technical Report" }
+
+FUNCTION {bbl.mthesis}
+{ "Master's thesis" }
+
+FUNCTION {bbl.phdthesis}
+{ "Ph.D. thesis" }
+
+MACRO {jan} {"January"}
+
+MACRO {feb} {"February"}
+
+MACRO {mar} {"March"}
+
+MACRO {apr} {"April"}
+
+MACRO {may} {"May"}
+
+MACRO {jun} {"June"}
+
+MACRO {jul} {"July"}
+
+MACRO {aug} {"August"}
+
+MACRO {sep} {"September"}
+
+MACRO {oct} {"October"}
+
+MACRO {nov} {"November"}
+
+MACRO {dec} {"December"}
+
+MACRO {acmcs} {"ACM Computing Surveys"}
+
+MACRO {acta} {"Acta Informatica"}
+
+MACRO {cacm} {"Communications of the ACM"}
+
+MACRO {ibmjrd} {"IBM Journal of Research and Development"}
+
+MACRO {ibmsj} {"IBM Systems Journal"}
+
+MACRO {ieeese} {"IEEE Transactions on Software Engineering"}
+
+MACRO {ieeetc} {"IEEE Transactions on Computers"}
+
+MACRO {ieeetcad}
+ {"IEEE Transactions on Computer-Aided Design of Integrated Circuits"}
+
+MACRO {ipl} {"Information Processing Letters"}
+
+MACRO {jacm} {"Journal of the ACM"}
+
+MACRO {jcss} {"Journal of Computer and System Sciences"}
+
+MACRO {scp} {"Science of Computer Programming"}
+
+MACRO {sicomp} {"SIAM Journal on Computing"}
+
+MACRO {tocs} {"ACM Transactions on Computer Systems"}
+
+MACRO {tods} {"ACM Transactions on Database Systems"}
+
+MACRO {tog} {"ACM Transactions on Graphics"}
+
+MACRO {toms} {"ACM Transactions on Mathematical Software"}
+
+MACRO {toois} {"ACM Transactions on Office Information Systems"}
+
+MACRO {toplas} {"ACM Transactions on Programming Languages and Systems"}
+
+MACRO {tcs} {"Theoretical Computer Science"}
+
+% bibinfo.check avoids acting on missing fields while bibinfo.warn will
+% issue a warning message if a missing field is detected. Prior to calling
+% the bibinfo functions, the user should push the field value and then its
+% name string, in that order.
+FUNCTION {bibinfo.check}
+{ swap$
+  duplicate$ missing$
+    {
+      pop$ pop$
+      ""
+    }
+    { duplicate$ empty$
+        {
+          swap$ pop$
+        }
+        { swap$
+          pop$
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {bibinfo.warn}
+{ swap$
+  duplicate$ missing$
+    {
+      swap$ "missing " swap$ * " in " * cite$ * warning$ pop$
+      ""
+    }
+    { duplicate$ empty$
+        {
+          swap$ "empty " swap$ * " in " * cite$ * warning$
+        }
+        { swap$
+          pop$
+        }
+      if$
+    }
+  if$
+}
+INTEGERS { nameptr namesleft numnames }
+
+
+STRINGS  { bibinfo}
+
+FUNCTION {format.names}
+{ 'bibinfo :=
+  duplicate$ empty$ 'skip$ {
+  's :=
+  "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{ff~}{vv~}{ll}{, jj}" % first name first for all authors
+      format.name$
+      bibinfo bibinfo.check
+      't :=
+      nameptr #1 >
+        {
+          nameptr #19	% truncate after 19 names
+          #1 + =
+          numnames #20	% if there are more than 20 names
+          > and
+            { "others" 't :=
+              #1 'namesleft := }
+            'skip$
+          if$		% end truncation of long list of names
+          namesleft #1 >
+            { ", " * t * }
+            {
+              s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              t "others" =
+                {
+		  %%                 " " * bbl.etal *
+		  % compute the number of remaining authors
+		  " and " * numnames nameptr - #1 + int.to.str$ * " others" *
+                }
+                {
+                  bbl.and
+                  space.word * t *
+                }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+  } if$
+}
+FUNCTION {format.names.ed}
+{
+  format.names
+}
+FUNCTION {format.key}
+{ empty$
+    { key field.or.null }
+    { "" }
+  if$
+}
+
+FUNCTION {format.authors}
+{ author "author" format.names
+}
+FUNCTION {get.bbl.editor}
+{ editor num.names$ #1 > 'bbl.editors 'bbl.editor if$ }
+
+FUNCTION {format.editors}
+{ editor "editor" format.names duplicate$ empty$ 'skip$
+    {
+      "," *
+      " " *
+      get.bbl.editor
+      *
+    }
+  if$
+}
+FUNCTION {format.note}
+{
+ note empty$
+    { "" }
+    { note #1 #1 substring$
+      duplicate$ "{" =
+        'skip$
+        { output.state mid.sentence =
+          { "l" }
+          { "u" }
+        if$
+        change.case$
+        }
+      if$
+      note #2 global.max$ substring$ * "note" bibinfo.check
+    }
+  if$
+}
+
+FUNCTION {format.title}
+{ title
+  duplicate$ empty$ 'skip$
+    { "t" change.case$ }
+  if$
+  "title" bibinfo.check
+}
+FUNCTION {format.full.names}
+{'s :=
+ "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{vv~}{ll}" format.name$
+      't :=
+      nameptr #1 >
+        {
+          namesleft #1 >
+            { ", " * t * }
+            {
+              s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              t "others" =
+                {
+                  " " * bbl.etal *
+                }
+                {
+                  numnames #2 >
+                    { "," * }
+                    'skip$
+                  if$
+                  bbl.and
+                  space.word * t *
+                }
+              if$
+            }
+          if$
+        }
+        't
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {author.editor.key.full}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { cite$ #1 #3 substring$ }
+            'key
+          if$
+        }
+        { editor format.full.names }
+      if$
+    }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {author.key.full}
+{ author empty$
+    { key empty$
+         { cite$ #1 #3 substring$ }
+          'key
+      if$
+    }
+    { author format.full.names }
+  if$
+}
+
+FUNCTION {editor.key.full}
+{ editor empty$
+    { key empty$
+         { cite$ #1 #3 substring$ }
+          'key
+      if$
+    }
+    { editor format.full.names }
+  if$
+}
+
+FUNCTION {make.full.names}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.key.full
+    { type$ "proceedings" =
+        'editor.key.full
+        'author.key.full
+      if$
+    }
+  if$
+}
+
+FUNCTION {output.bibitem.original} % urlbst (renamed from output.bibitem, so it can be wrapped below)
+{ newline$
+  "\bibitem[{" write$
+  label write$
+  ")" make.full.names duplicate$ short.list =
+     { pop$ }
+     { * }
+   if$
+  "}]{" * write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  before.all 'output.state :=
+}
+
+FUNCTION {n.dashify}
+{
+  't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+FUNCTION {word.in}
+{ bbl.in capitalize
+  " " * }
+
+FUNCTION {format.date}
+{ year "year" bibinfo.check duplicate$ empty$
+    {
+    }
+    'skip$
+  if$
+  extra.label *
+  before.all 'output.state :=
+  after.sentence 'output.state :=
+}
+FUNCTION {format.btitle}
+{ title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    {
+      emphasize
+    }
+  if$
+}
+FUNCTION {either.or.check}
+{ empty$
+    'pop$
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+FUNCTION {format.bvolume}
+{ volume empty$
+    { "" }
+    { bbl.volume volume tie.or.space.prefix
+      "volume" bibinfo.check * *
+      series "series" bibinfo.check
+      duplicate$ empty$ 'pop$
+        { swap$ bbl.of space.word * swap$
+          emphasize * }
+      if$
+      "volume and number" number either.or.check
+    }
+  if$
+}
+FUNCTION {format.number.series}
+{ volume empty$
+    { number empty$
+        { series field.or.null }
+        { series empty$
+            { number "number" bibinfo.check }
+            { output.state mid.sentence =
+                { bbl.number }
+                { bbl.number capitalize }
+              if$
+              number tie.or.space.prefix "number" bibinfo.check * *
+              bbl.in space.word *
+              series "series" bibinfo.check *
+            }
+          if$
+        }
+      if$
+    }
+    { "" }
+  if$
+}
+
+FUNCTION {format.edition}
+{ edition duplicate$ empty$ 'skip$
+    {
+      output.state mid.sentence =
+        { "l" }
+        { "t" }
+      if$ change.case$
+      "edition" bibinfo.check
+      " " * bbl.edition *
+    }
+  if$
+}
+INTEGERS { multiresult }
+FUNCTION {multi.page.check}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+  multiresult
+}
+FUNCTION {format.pages}
+{ pages duplicate$ empty$ 'skip$
+    { duplicate$ multi.page.check
+        {
+          bbl.pages swap$
+          n.dashify
+        }
+        {
+          bbl.page swap$
+        }
+      if$
+      tie.or.space.prefix
+      "pages" bibinfo.check
+      * *
+    }
+  if$
+}
+FUNCTION {format.journal.pages}
+{ pages duplicate$ empty$ 'pop$
+    { swap$ duplicate$ empty$
+        { pop$ pop$ format.pages }
+        {
+          ":" *
+          swap$
+          n.dashify
+          "pages" bibinfo.check
+          *
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {format.journal.eid}
+{ eid "eid" bibinfo.check
+  duplicate$ empty$ 'pop$
+    { swap$ duplicate$ empty$ 'skip$
+      {
+          ":" *
+      }
+      if$
+      swap$ *
+    }
+  if$
+}
+FUNCTION {format.vol.num.pages}
+{ volume field.or.null
+  duplicate$ empty$ 'skip$
+    {
+      "volume" bibinfo.check
+    }
+  if$
+  number "number" bibinfo.check duplicate$ empty$ 'skip$
+    {
+      swap$ duplicate$ empty$
+        { "there's a number but no volume in " cite$ * warning$ }
+        'skip$
+      if$
+      swap$
+      "(" swap$ * ")" *
+    }
+  if$ *
+  eid empty$
+    { format.journal.pages }
+    { format.journal.eid }
+  if$
+}
+
+FUNCTION {format.chapter}
+{ chapter empty$
+    'format.pages
+    { type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+    }
+  if$
+}
+
+FUNCTION {format.chapter.pages}
+{ chapter empty$
+    'format.pages
+    { type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+      pages empty$
+        'skip$
+        { ", " * format.pages * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.booktitle}
+{
+  booktitle "booktitle" bibinfo.check
+  emphasize
+}
+FUNCTION {format.in.booktitle}
+{ format.booktitle duplicate$ empty$ 'skip$
+    {
+      word.in swap$ *
+    }
+  if$
+}
+FUNCTION {format.in.ed.booktitle}
+{ format.booktitle duplicate$ empty$ 'skip$
+    {
+      editor "editor" format.names.ed duplicate$ empty$ 'pop$
+        {
+          "," *
+          " " *
+          get.bbl.editor
+          ", " *
+          * swap$
+          * }
+      if$
+      word.in swap$ *
+    }
+  if$
+}
+FUNCTION {format.thesis.type}
+{ type duplicate$ empty$
+    'pop$
+    { swap$ pop$
+      "t" change.case$ "type" bibinfo.check
+    }
+  if$
+}
+FUNCTION {format.tr.number}
+{ number "number" bibinfo.check
+  type duplicate$ empty$
+    { pop$ bbl.techrep }
+    'skip$
+  if$
+  "type" bibinfo.check
+  swap$ duplicate$ empty$
+    { pop$ "t" change.case$ }
+    { tie.or.space.prefix * * }
+  if$
+}
+FUNCTION {format.article.crossref}
+{
+  word.in
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.book.crossref}
+{ volume duplicate$ empty$
+    { "empty volume in " cite$ * "'s crossref of " * crossref * warning$
+      pop$ word.in
+    }
+    { bbl.volume
+      capitalize
+      swap$ tie.or.space.prefix "volume" bibinfo.check * * bbl.of space.word *
+    }
+  if$
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.incoll.inproc.crossref}
+{
+  word.in
+  " \cite{" * crossref * "}" *
+}
+FUNCTION {format.org.or.pub}
+{ 't :=
+  ""
+  address empty$ t empty$ and
+    'skip$
+    {
+      t empty$
+        { address "address" bibinfo.check *
+        }
+        { t *
+          address empty$
+            'skip$
+            { ", " * address "address" bibinfo.check * }
+          if$
+        }
+      if$
+    }
+  if$
+}
+FUNCTION {format.publisher.address}
+{ publisher "publisher" bibinfo.warn format.org.or.pub
+}
+
+FUNCTION {format.organization.address}
+{ organization "organization" bibinfo.check format.org.or.pub
+}
+
+FUNCTION {archiveprefix.or.eprinttype} % holder for eprinttype with archiveprefix precedence
+{
+  archiveprefix empty$
+  {
+    eprinttype empty$
+      { "" } % not using 'skip$ to reduce errors like "nothing to pop from stack"
+      { eprinttype }
+    if$
+  }
+  { archiveprefix }
+  if$
+}
+
+FUNCTION {output.eprint} % this is only used with the @misc record type (common for arXiv and other preprint server bibtex records)
+{
+  eprint empty$
+    {% if eprint field is empty
+      publisher field.or.null "arXiv" = % field.or.null here helps when no publisher field in the record
+        { publisher " preprint" * } % add " preprint" to publisher with the idea that publisher is the name of the preprint server
+        { "" } % if publisher != "arXiv" then empty output
+      if$
+      emphasize % no output function after emphasize because nothing goes after this
+    }
+    {% if eprint field is not empty
+      archiveprefix.or.eprinttype empty$
+        { "" } % not using 'skip$ to reduce errors like "nothing to pop from stack"
+        {% if archiveprefix or eprinttype fields are not empty
+          journal empty$
+            { "Preprint" } % if journal field is empty: output just "Preprint" emphasized like a journal name
+            { journal } % if journal field is not empty, output it (takes precedence)
+          if$
+          emphasize output % emphasize what we formed before, setting output as a border to the subblock that follows with the comma delimiter
+          archiveprefix.or.eprinttype ":" * eprint * % subblock with eprinttype and eprint number
+        }
+      if$
+    }
+  if$
+}
+
+% urlbst...
+% Functions for making hypertext links.
+% In all cases, the stack has (link-text href-url)
+%
+% make 'null' specials
+FUNCTION {make.href.null}
+{
+  pop$
+}
+% make hypertex specials
+FUNCTION {make.href.hypertex}
+{
+  "\special {html:<a href=" quote$ *
+  swap$ * quote$ * "> }" * swap$ *
+  "\special {html:</a>}" *
+}
+% make hyperref specials
+FUNCTION {make.href.hyperref}
+{
+  "\href {" swap$ * "} {\path{" * swap$ * "}}" *
+}
+FUNCTION {make.href}
+{ hrefform #2 =
+    'make.href.hyperref      % hrefform = 2
+    { hrefform #1 =
+        'make.href.hypertex  % hrefform = 1
+        'make.href.null      % hrefform = 0 (or anything else)
+      if$
+    }
+  if$
+}
+
+% If inlinelinks is true, then format.url should be a no-op, since it's
+% (a) redundant, and (b) could end up as a link-within-a-link.
+FUNCTION {format.url}
+{ inlinelinks #1 = url empty$ or
+   { "" }
+   { hrefform #1 =
+       { % special case -- add HyperTeX specials
+         urlintro "\url{" url * "}" * url make.href.hypertex * }
+       { urlintro "\url{" * url * "}" * }
+     if$
+   }
+  if$
+}
+FUNCTION {format.eprint}
+{ eprint empty$
+    { "" }
+    { eprintprefix eprint * eprinturl eprint * make.href }
+  if$
+}
+
+FUNCTION {format.doi}
+{ doi empty$
+    { "" }
+    { doi parse.doi % leaves "https://doi.org/DOI" DOI on the stack
+      's := 't :=
+      doiform #1 =
+        { "\doi{" s * "}" * }
+        { doiprefix s * t make.href }
+      if$
+    }
+  if$
+}
+
+FUNCTION {format.pubmed}
+{ pubmed empty$
+    { "" }
+    { pubmedprefix pubmed * pubmedurl pubmed * make.href }
+  if$
+}
+
+% Output a URL.  We can't use the more normal idiom (something like
+% `format.url output'), because the `inbrackets' within
+% format.lastchecked applies to everything between calls to `output',
+% so that `format.url format.lastchecked * output' ends up with both
+% the URL and the lastchecked in brackets.
+FUNCTION {output.url}
+{ url empty$
+    'skip$
+    { new.block
+      format.url output
+      format.lastchecked output
+    }
+  if$
+}
+
+FUNCTION {output.web.refs}
+{
+  new.block
+  inlinelinks
+    'skip$ % links were inline -- don't repeat them
+    { % If the generated DOI will be the same as the URL,
+      % then don't print the URL (thanks to Joseph Wright
+      % for (the original version of) this code,
+      % at http://tex.stackexchange.com/questions/5660)
+      adddoi
+          doi empty$ { "X" } { doi parse.doi pop$ } if$ % DOI URL to be generated
+          url empty$ { "Y" } { url } if$          % the URL, or "Y" if empty
+          =                                       % are the strings equal?
+          and
+        'skip$
+        { output.url }
+      if$
+      addeprints eprint empty$ not and
+        { format.eprint output.nonnull }
+        'skip$
+      if$
+      adddoi doi empty$ not and
+        { format.doi output.nonnull }
+        'skip$
+      if$
+      addpubmed pubmed empty$ not and
+        { format.pubmed output.nonnull }
+        'skip$
+      if$
+    }
+  if$
+}
+
+% Wrapper for output.bibitem.original.
+% If the URL field is not empty, set makeinlinelink to be true,
+% so that an inline link will be started at the next opportunity
+FUNCTION {output.bibitem}
+{ outside.brackets 'bracket.state :=
+  output.bibitem.original
+  inlinelinks url empty$ not doi empty$ not or pubmed empty$ not or eprint empty$ not or and
+    { #1 'makeinlinelink := }
+    { #0 'makeinlinelink := }
+  if$
+}
+
+% Wrapper for fin.entry.original
+FUNCTION {fin.entry}
+{ output.web.refs  % urlbst
+  makeinlinelink       % ooops, it appears we didn't have a title for inlinelink
+    { possibly.setup.inlinelink % add some artificial link text here, as a fallback
+      linktextstring output.nonnull }
+    'skip$
+  if$
+  bracket.state close.brackets = % urlbst
+    { "]" * }
+    'skip$
+  if$
+  fin.entry.original
+}
+
+% Webpage entry type.
+% Title and url fields required;
+% author, note, year, month, and lastchecked fields optional
+% See references
+%   ISO 690-2 http://www.nlc-bnc.ca/iso/tc46sc9/standard/690-2e.htm
+%   http://www.classroom.net/classroom/CitingNetResources.html
+%   http://neal.ctstateu.edu/history/cite.html
+%   http://www.cas.usf.edu/english/walker/mla.html
+% for citation formats for web pages.
+FUNCTION {webpage}
+{ output.bibitem
+  author empty$
+    { editor empty$
+        'skip$  % author and editor both optional
+        { format.editors output.nonnull }
+      if$
+    }
+    { editor empty$
+        { format.authors output.nonnull }
+        { "can't use both author and editor fields in " cite$ * warning$ }
+      if$
+    }
+  if$
+  new.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$
+  format.title "title" output.check
+  inbrackets onlinestring output
+  new.block
+  year empty$
+    'skip$
+    { format.date "year" output.check }
+  if$
+  % We don't need to output the URL details ('lastchecked' and 'url'),
+  % because fin.entry does that for us, using output.web.refs.  The only
+  % reason we would want to put them here is if we were to decide that
+  % they should go in front of the rather miscellaneous information in 'note'.
+  new.block
+  note output
+  fin.entry
+}
+% ...urlbst to here
+
+
+FUNCTION {article}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    {
+      journal
+      "journal" bibinfo.check
+      emphasize
+      "journal" output.check
+      possibly.setup.inlinelink format.vol.num.pages output% urlbst
+    }
+    { format.article.crossref output.nonnull
+      format.pages output
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {book}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+      editor format.key output
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.btitle "title" output.check
+  format.edition output
+  crossref missing$
+    { format.bvolume output
+      new.block
+      format.number.series output
+      new.sentence
+      format.publisher.address output
+    }
+    {
+      new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {booklet}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title "title" output.check
+  new.block
+  howpublished "howpublished" bibinfo.check output
+  address "address" bibinfo.check output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {inbook}
+{ output.bibitem
+  author empty$
+    { format.editors "author and editor" output.check
+      editor format.key output
+    }
+    { format.authors output.nonnull
+      crossref missing$
+        { "author and editor" editor either.or.check }
+        'skip$
+      if$
+    }
+  if$
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.btitle "title" output.check
+  crossref missing$
+    {
+      format.edition output
+      format.bvolume output
+      format.chapter "chapter" output.check
+      new.block
+      format.number.series output
+      new.sentence
+      format.publisher.address output
+    }
+    {
+      format.chapter "chapter" output.check
+      new.block
+      format.book.crossref output.nonnull
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {incollection}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.ed.booktitle "booktitle" output.check
+      format.edition output
+      format.bvolume output
+      format.number.series output
+      format.chapter.pages output
+      new.sentence
+      format.publisher.address output
+    }
+    { format.incoll.inproc.crossref output.nonnull
+      format.chapter.pages output
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {inproceedings}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title "title" output.check
+  new.block
+  crossref missing$
+    { format.in.booktitle "booktitle" output.check
+      format.bvolume output
+      format.number.series output
+      format.pages output
+      address "address" bibinfo.check output
+      new.sentence
+      organization "organization" bibinfo.check output
+      publisher "publisher" bibinfo.check output
+    }
+    { format.incoll.inproc.crossref output.nonnull
+      format.pages output
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {conference} { inproceedings }
+FUNCTION {manual}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.btitle "title" output.check
+  format.edition output
+  organization address new.block.checkb
+  organization "organization" bibinfo.check output
+  address "address" bibinfo.check output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {mastersthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title
+  "title" output.check
+  new.block
+  bbl.mthesis format.thesis.type output.nonnull
+  school "school" bibinfo.warn output
+  address "address" bibinfo.check output
+  month "month" bibinfo.check output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {misc}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title output
+  new.block
+  howpublished "howpublished" bibinfo.check output
+  new.block
+  output.eprint output
+  new.block
+  format.note output
+  fin.entry
+}
+FUNCTION {phdthesis}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.btitle
+  "title" output.check
+  new.block
+  bbl.phdthesis format.thesis.type output.nonnull
+  school "school" bibinfo.warn output
+  address "address" bibinfo.check output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {presentation}
+{ output.bibitem
+  format.authors output
+  author format.key output
+  new.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title output
+  new.block
+  format.organization.address "organization and address" output.check
+  month "month" output.check
+  year "year" output.check
+  new.block
+  format.note output
+  new.sentence
+  type missing$ 'skip$
+  {"(" type capitalize * ")" * output}
+    if$
+  fin.entry
+}
+
+FUNCTION {proceedings}
+{ output.bibitem
+  format.editors output
+  editor format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.btitle "title" output.check
+  format.bvolume output
+  format.number.series output
+  new.sentence
+  publisher empty$
+    { format.organization.address output }
+    { organization "organization" bibinfo.check output
+      new.sentence
+      format.publisher.address output
+    }
+  if$
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {techreport}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title
+  "title" output.check
+  new.block
+  format.tr.number output.nonnull
+  institution "institution" bibinfo.warn output
+  address "address" bibinfo.check output
+  new.block
+  format.note output
+  fin.entry
+}
+
+FUNCTION {unpublished}
+{ output.bibitem
+  format.authors "author" output.check
+  author format.key output
+  format.date "year" output.check
+  date.block
+  title empty$ 'skip$ 'possibly.setup.inlinelink if$ % urlbst
+  format.title "title" output.check
+  new.block
+  format.note "note" output.check
+  fin.entry
+}
+
+FUNCTION {default.type} { misc }
+READ
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+INTEGERS { len }
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    's
+  if$
+}
+FUNCTION {format.lab.names}
+{ 's :=
+  "" 't :=
+  s #1 "{vv~}{ll}" format.name$
+  s num.names$ duplicate$
+  #2 >
+    { pop$
+      " " * bbl.etal *
+    }
+    { #2 <
+        'skip$
+        { s #2 "{ff }{vv }{ll}{ jj}" format.name$ "others" =
+            {
+              " " * bbl.etal *
+            }
+            { bbl.and space.word * s #2 "{vv~}{ll}" format.name$
+              * }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+FUNCTION {author.key.label}
+{ author empty$
+    { key empty$
+        { cite$ #1 #3 substring$ }
+        'key
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {author.editor.key.label}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { cite$ #1 #3 substring$ }
+            'key
+          if$
+        }
+        { editor format.lab.names }
+      if$
+    }
+    { author format.lab.names }
+  if$
+}
+
+FUNCTION {editor.key.label}
+{ editor empty$
+    { key empty$
+        { cite$ #1 #3 substring$ }
+        'key
+      if$
+    }
+    { editor format.lab.names }
+  if$
+}
+
+FUNCTION {calc.short.authors}
+{ type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.key.label
+    { type$ "proceedings" =
+        'editor.key.label
+        'author.key.label
+      if$
+    }
+  if$
+  'short.list :=
+}
+
+FUNCTION {calc.label}
+{ calc.short.authors
+  short.list
+  "("
+  *
+  year duplicate$ empty$
+  short.list key field.or.null = or
+     { pop$ "" }
+     'skip$
+  if$
+  *
+  'label :=
+}
+
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      "{vv{ } }{ll{ }}{  ff{ }}{  jj{ }}"
+      format.name$ 't :=
+      nameptr #1 >
+        {
+          "   "  *
+          namesleft #1 = t "others" = and
+            { "zzzzz" 't := }
+            'skip$
+          if$
+          t sortify *
+        }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+FUNCTION {author.sort}
+{ author empty$
+    { key empty$
+        { "to sort, need author or key in " cite$ * warning$
+          ""
+        }
+        { key sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+FUNCTION {author.editor.sort}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { "to sort, need author, editor, or key in " cite$ * warning$
+              ""
+            }
+            { key sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+FUNCTION {editor.sort}
+{ editor empty$
+    { key empty$
+        { "to sort, need editor or key in " cite$ * warning$
+          ""
+        }
+        { key sortify }
+      if$
+    }
+    { editor sort.format.names }
+  if$
+}
+FUNCTION {presort}
+{ calc.label
+  label sortify
+  "    "
+  *
+  type$ "book" =
+  type$ "inbook" =
+  or
+    'author.editor.sort
+    { type$ "proceedings" =
+        'editor.sort
+        'author.sort
+      if$
+    }
+  if$
+  #1 entry.max$ substring$
+  'sort.label :=
+  sort.label
+  *
+  "    "
+  *
+  title field.or.null
+  sort.format.title
+  *
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+
+ITERATE {presort}
+SORT
+STRINGS { last.label next.extra }
+INTEGERS { last.extra.num last.extra.num.extended last.extra.num.blank number.label }
+FUNCTION {initialize.extra.label.stuff}
+{ #0 int.to.chr$ 'last.label :=
+  "" 'next.extra :=
+  #0 'last.extra.num :=
+  "a" chr.to.int$ #1 - 'last.extra.num.blank :=
+  last.extra.num.blank 'last.extra.num.extended :=
+  #0 'number.label :=
+}
+FUNCTION {forward.pass}
+{ last.label label =
+    { last.extra.num #1 + 'last.extra.num :=
+      last.extra.num "z" chr.to.int$ >
+       { "a" chr.to.int$ 'last.extra.num :=
+         last.extra.num.extended #1 + 'last.extra.num.extended :=
+       }
+       'skip$
+      if$
+      last.extra.num.extended last.extra.num.blank >
+        { last.extra.num.extended int.to.chr$
+          last.extra.num int.to.chr$
+          * 'extra.label := }
+        { last.extra.num int.to.chr$ 'extra.label := }
+      if$
+    }
+    { "a" chr.to.int$ 'last.extra.num :=
+      "" 'extra.label :=
+      label 'last.label :=
+    }
+  if$
+  number.label #1 + 'number.label :=
+}
+FUNCTION {reverse.pass}
+{ next.extra "b" =
+    { "a" 'extra.label := }
+    'skip$
+  if$
+  extra.label 'next.extra :=
+  extra.label
+  duplicate$ empty$
+    'skip$
+    { year field.or.null #-1 #1 substring$ chr.to.int$ #65 < 
+      { "{\natexlab{" swap$ * "}}" * }
+      { "{(\natexlab{" swap$ * "})}" * }
+    if$ }
+  if$
+  'extra.label :=
+  label extra.label * 'label :=
+}
+EXECUTE {initialize.extra.label.stuff}
+ITERATE {forward.pass}
+REVERSE {reverse.pass}
+FUNCTION {bib.sort.order}
+{ sort.label
+  "    "
+  *
+  year field.or.null sortify
+  *
+  "    "
+  *
+  title field.or.null
+  sort.format.title
+  *
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+ITERATE {bib.sort.order}
+SORT
+FUNCTION {begin.bib}
+{ preamble$ empty$
+    'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{" number.label int.to.str$ * "}" *
+  write$ newline$
+  "\providecommand{\natexlab}[1]{#1}"
+  write$ newline$
+}
+EXECUTE {begin.bib}
+EXECUTE {init.urlbst.variables} % urlbst
+EXECUTE {init.state.consts}
+ITERATE {call.type$}
+FUNCTION {end.bib}
+{ newline$
+  "\end{thebibliography}" write$ newline$
+}
+EXECUTE {end.bib}
+%% End of customized bst file
+%%
+%% End of file `acl_natbib_basic.bst'.

--- a/paper/build_numbers.py
+++ b/paper/build_numbers.py
@@ -1,0 +1,444 @@
+"""paper/build_numbers.py
+
+Reads every CSV in paper/data/ and every *.numbers.csv sidecar in
+paper/generated/figures/, then emits:
+
+  paper/generated/values.tex   -- one csname definition per (stem, key) pair
+  paper/generated/provenance.txt -- call sites in prose .tex -> CSV cell -> value
+
+Run:
+    python paper/build_numbers.py [--paper-dir <path>]
+
+The script is deliberately free of GPU/cluster dependencies: pandas + stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NamedTuple
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+CellMap = dict[tuple[str, str], str]  # (stem, key) -> raw value string
+
+# ---------------------------------------------------------------------------
+# §3 header parsing for paper/data/ CSVs
+# ---------------------------------------------------------------------------
+REQUIRED_HEADER_FIELDS = {"source_commit", "generated", "generator", "key_schema"}
+OPTIONAL_HEADER_FIELDS = {"default_precision"}
+
+
+class DataCSVHeader(NamedTuple):
+    source_commit: str
+    generated: str
+    generator: str
+    key_schema: list[str]  # ordered list of column names forming the row key
+    default_precision: int
+
+
+def parse_data_csv_header(path: Path) -> DataCSVHeader:
+    """Parse the §3 comment block from a paper/data/ CSV.
+
+    Raises ValueError if required fields are missing.
+    """
+    fields: dict[str, str] = {}
+    with open(path) as fh:
+        for line in fh:
+            if not line.startswith("#"):
+                break
+            m = re.match(r"#\s*(\w+):\s*(.+)", line)
+            if m:
+                fields[m.group(1).strip()] = m.group(2).strip()
+
+    missing = REQUIRED_HEADER_FIELDS - set(fields)
+    if missing:
+        raise ValueError(
+            f"{path}: missing required header fields: {', '.join(sorted(missing))}. "
+            "Every CSV in paper/data/ must start with the §3 header block."
+        )
+
+    key_schema = [col.strip() for col in fields["key_schema"].split(":")]
+    default_precision = int(fields.get("default_precision", "3"))
+
+    return DataCSVHeader(
+        source_commit=fields["source_commit"],
+        generated=fields["generated"],
+        generator=fields["generator"],
+        key_schema=key_schema,
+        default_precision=default_precision,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sidecar header parsing for paper/generated/figures/*.numbers.csv
+# ---------------------------------------------------------------------------
+class SidecarCSVHeader(NamedTuple):
+    generator: str
+    source_data: str
+
+
+def parse_sidecar_header(path: Path) -> SidecarCSVHeader:
+    """Parse the simpler header from a *.numbers.csv sidecar."""
+    fields: dict[str, str] = {}
+    with open(path) as fh:
+        for line in fh:
+            if not line.startswith("#"):
+                break
+            m = re.match(r"#\s*([\w_]+):\s*(.+)", line)
+            if m:
+                fields[m.group(1).strip()] = m.group(2).strip()
+    return SidecarCSVHeader(
+        generator=fields.get("generator", "unknown"),
+        source_data=fields.get("source_data", "unknown"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Git ancestry check
+# ---------------------------------------------------------------------------
+def is_ancestor_of_head(commit: str, repo_root: Path) -> bool:
+    """Return True if *commit* is an ancestor of HEAD (or is HEAD)."""
+    if commit in ("placeholder", "unknown", ""):
+        return True  # synthetic / hand-built CSVs skip the check
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", commit, "HEAD"],
+            capture_output=True,
+            cwd=repo_root,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return True  # git not available — skip silently
+
+
+# ---------------------------------------------------------------------------
+# Flatten paper/data/ CSV into (stem, key) -> value
+# ---------------------------------------------------------------------------
+def load_data_csv(path: Path) -> tuple[CellMap, DataCSVHeader]:
+    """Load one paper/data/ CSV and return its cell map + header."""
+    header = parse_data_csv_header(path)
+    stem = path.stem  # e.g. "baseline_comparison"
+
+    # Skip comment lines when reading with pandas
+    df = pd.read_csv(path, comment="#")
+
+    # Verify key_schema columns exist
+    for col in header.key_schema:
+        if col not in df.columns:
+            raise ValueError(
+                f"{path}: key_schema column '{col}' not found in data. "
+                f"Available columns: {list(df.columns)}"
+            )
+
+    # Identify value columns (everything not in key_schema)
+    value_cols = [c for c in df.columns if c not in header.key_schema]
+
+    cells: CellMap = {}
+
+    # Store default_precision as a special key
+    cells[(stem, "__default_precision__")] = str(header.default_precision)
+
+    for _, row in df.iterrows():
+        # Build the row key from key_schema columns
+        row_key_parts = [str(row[col]) for col in header.key_schema]
+        row_key_prefix = ":".join(row_key_parts)
+
+        for vcol in value_cols:
+            val = row[vcol]
+            if pd.isna(val):
+                continue
+            # Full key: row_key_prefix:column_name
+            full_key = f"{row_key_prefix}:{vcol}"
+            cells[(stem, full_key)] = str(val)
+
+    return cells, header
+
+
+# ---------------------------------------------------------------------------
+# Flatten sidecar CSV into (fig.<stem>, key) -> value
+# ---------------------------------------------------------------------------
+def load_sidecar_csv(path: Path) -> tuple[CellMap, SidecarCSVHeader]:
+    """Load one *.numbers.csv sidecar; stem is prefixed with 'fig.'."""
+    header = parse_sidecar_header(path)
+    # Strip .numbers from stem: "transfer_llama_linear.numbers" -> "fig.transfer_llama_linear"
+    raw_stem = path.stem  # e.g. "transfer_llama_linear.numbers"
+    if raw_stem.endswith(".numbers"):
+        base = raw_stem[: -len(".numbers")]
+    else:
+        base = raw_stem
+    stem = f"fig.{base}"
+
+    df = pd.read_csv(path, comment="#")
+
+    required_cols = {"label", "value"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"{path}: sidecar CSV missing required columns: {missing}. "
+            "Expected columns: label, value, role"
+        )
+
+    cells: CellMap = {}
+    cells[(stem, "__default_precision__")] = "3"
+
+    for _, row in df.iterrows():
+        label = str(row["label"])
+        value = str(row["value"])
+        cells[(stem, label)] = value
+
+    return cells, header
+
+
+# ---------------------------------------------------------------------------
+# Tex-identifier escaping
+# ---------------------------------------------------------------------------
+def tex_escape_csname(s: str) -> str:
+    """Escape characters that are illegal in \\csname...\\endcsname.
+
+    \\csname allows almost any character except \\endcsname itself. The key
+    string is used verbatim — colons, dots, underscores are all legal.
+    """
+    # The only truly forbidden sequence is \endcsname; we don't expect that.
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Emit values.tex
+# ---------------------------------------------------------------------------
+def emit_values_tex(cells: CellMap, out_path: Path) -> None:
+    """Write paper/generated/values.tex from the combined cell map."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    with open(out_path, "w") as fh:
+        fh.write(f"% paper/generated/values.tex\n")
+        fh.write(f"% Auto-generated by build_numbers.py on {now}.\n")
+        fh.write(f"% DO NOT EDIT. Regenerate with: make values\n")
+        fh.write(f"% Total cells: {len(cells)}\n\n")
+
+        # Group by stem for readability
+        by_stem: dict[str, list[tuple[str, str]]] = {}
+        for (stem, key), value in sorted(cells.items()):
+            by_stem.setdefault(stem, []).append((key, value))
+
+        for stem, pairs in sorted(by_stem.items()):
+            fh.write(f"% --- {stem} ---\n")
+            for key, value in sorted(pairs):
+                csname = f"hl@{stem}@{key}"
+                safe_key = tex_escape_csname(csname)
+                fh.write(
+                    f"\\expandafter\\def\\csname {safe_key}\\endcsname{{{value}}}\n"
+                )
+            fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Regex for citation macros in prose .tex files
+# ---------------------------------------------------------------------------
+# Matches: \result{csv}{key}[p] or \delta{...}{...}{...}[p] etc.
+_MACRO_NAMES = r"(?:result|resdelta|resratio|resultCI|resultPM)"
+_RESULT_RE = re.compile(
+    r"\\(?P<macro>" + _MACRO_NAMES + r")"
+    r"\{(?P<csv>[^}]+)\}"
+    r"\{(?P<args>[^}]+)\}"
+    r"(?:\{(?P<args2>[^}]+)\})?"  # optional third brace (for \resdelta/\resratio)
+    r"(?:\[(?P<prec>[0-9]+)\])?"
+)
+
+
+def extract_citations(tex_path: Path) -> list[dict]:
+    """Extract all citation macro calls from a .tex file.
+
+    Returns a list of dicts with keys: file, line, macro, csv, args, prec.
+    """
+    citations = []
+    text = tex_path.read_text(errors="replace")
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for m in _RESULT_RE.finditer(line):
+            citations.append(
+                {
+                    "file": str(tex_path),
+                    "line": lineno,
+                    "macro": m.group("macro"),
+                    "csv": m.group("csv"),
+                    "args": m.group("args"),
+                    "args2": m.group("args2"),
+                    "prec": m.group("prec"),
+                    "raw": m.group(0),
+                }
+            )
+    return citations
+
+
+def resolve_citation(cite: dict, cells: CellMap) -> str:
+    """Attempt to resolve a citation to its value(s), returning a string."""
+    csv_stem = cite["csv"]
+    args = cite["args"]
+    macro = cite["macro"]
+
+    if macro == "result":
+        key = args
+        return cells.get((csv_stem, key), "<UNRESOLVED>")
+    elif macro in ("resdelta", "resratio"):
+        key_a = args
+        key_b = cite.get("args2") or ""
+        va = cells.get((csv_stem, key_a), "<UNRESOLVED>")
+        vb = cells.get((csv_stem, key_b), "<UNRESOLVED>")
+        op = "-" if macro == "resdelta" else "/"
+        if "<UNRESOLVED>" not in (va, vb):
+            try:
+                result_val = (float(va) - float(vb)) if op == "-" else (float(va) / float(vb))
+                return f"{result_val:.6g}"
+            except (ValueError, ZeroDivisionError):
+                return f"{va} {op} {vb} = <ERROR>"
+        return f"{va} {op} {vb}"
+    elif macro in ("resultCI", "resultPM"):
+        keys = [k.strip() for k in args.split(",")]
+        values = [cells.get((csv_stem, k), "<UNRESOLVED>") for k in keys]
+        sep = ", " if macro == "resultCI" else " +/- "
+        return sep.join(values)
+    return "<UNRESOLVED>"
+
+
+# ---------------------------------------------------------------------------
+# Emit provenance.txt
+# ---------------------------------------------------------------------------
+def emit_provenance(
+    cells: CellMap,
+    prose_paths: list[Path],
+    out_path: Path,
+) -> None:
+    """Scan all prose .tex files for citation macros and write provenance."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    all_citations = []
+    for p in prose_paths:
+        all_citations.extend(extract_citations(p))
+
+    with open(out_path, "w") as fh:
+        fh.write(f"# paper/generated/provenance.txt\n")
+        fh.write(f"# Generated by build_numbers.py on {now}\n")
+        fh.write(f"# Total citations: {len(all_citations)}\n\n")
+        fh.write(f"{'FILE':40s} {'LINE':5s} {'MACRO':12s} {'CSV':20s} {'KEY':40s} {'VALUE'}\n")
+        fh.write("-" * 140 + "\n")
+
+        unresolved = []
+        for cite in all_citations:
+            value = resolve_citation(cite, cells)
+            csv_stem = cite["csv"]
+            key = cite["args"]
+            fh.write(
+                f"{cite['file'][:40]:40s} {cite['line']:5d} "
+                f"{cite['macro']:12s} {csv_stem:20s} {key:40s} {value}\n"
+            )
+            if "<UNRESOLVED>" in value:
+                unresolved.append(cite)
+
+        if unresolved:
+            fh.write(f"\n# UNRESOLVED ({len(unresolved)}):\n")
+            for cite in unresolved:
+                fh.write(f"#   {cite['file']}:{cite['line']} — {cite['raw']}\n")
+
+    return unresolved
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build paper/generated/values.tex from CSVs")
+    parser.add_argument(
+        "--paper-dir",
+        default="paper",
+        help="Path to the paper/ directory (default: paper/)",
+    )
+    args = parser.parse_args(argv)
+
+    paper_dir = Path(args.paper_dir)
+    repo_root = paper_dir.parent
+
+    data_dir = paper_dir / "data"
+    sidecar_dir = paper_dir / "generated" / "figures"
+    out_values = paper_dir / "generated" / "values.tex"
+    out_provenance = paper_dir / "generated" / "provenance.txt"
+
+    all_cells: CellMap = {}
+    warnings_list: list[str] = []
+
+    # --- Load paper/data/ CSVs ---
+    data_csvs = sorted(data_dir.glob("*.csv"))
+    if not data_csvs:
+        print(f"WARNING: No CSVs found in {data_dir}", file=sys.stderr)
+
+    for csv_path in data_csvs:
+        try:
+            cells, header = load_data_csv(csv_path)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+
+        # Git ancestry check
+        if not is_ancestor_of_head(header.source_commit, repo_root):
+            warnings_list.append(
+                f"WARNING: {csv_path.name}: source_commit {header.source_commit!r} "
+                "is not an ancestor of HEAD. CSV may be stale."
+            )
+
+        all_cells.update(cells)
+        print(f"  Loaded data CSV: {csv_path.name} ({len(cells)} cells)")
+
+    # --- Load sidecar CSVs from generated/figures/ ---
+    if sidecar_dir.exists():
+        for sidecar_path in sorted(sidecar_dir.glob("*.numbers.csv")):
+            try:
+                cells, sidecar_header = load_sidecar_csv(sidecar_path)
+            except ValueError as e:
+                print(f"ERROR: {e}", file=sys.stderr)
+                return 1
+            all_cells.update(cells)
+            print(f"  Loaded sidecar: {sidecar_path.name} ({len(cells)} cells)")
+
+    print(f"  Total cells: {len(all_cells)}")
+
+    # --- Emit values.tex ---
+    emit_values_tex(all_cells, out_values)
+    print(f"  Written: {out_values}")
+
+    # --- Scan prose .tex files and emit provenance.txt ---
+    prose_paths: list[Path] = []
+    main_tex = paper_dir / "main.tex"
+    if main_tex.exists():
+        prose_paths.append(main_tex)
+    sections_dir = paper_dir / "sections"
+    if sections_dir.exists():
+        prose_paths.extend(sorted(sections_dir.glob("*.tex")))
+
+    unresolved = emit_provenance(all_cells, prose_paths, out_provenance)
+    print(f"  Written: {out_provenance}")
+
+    # --- Print warnings ---
+    for w in warnings_list:
+        print(w, file=sys.stderr)
+
+    if unresolved:
+        print(
+            f"\nWARNING: {len(unresolved)} unresolved citation(s). "
+            "Check paper/generated/provenance.txt.",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/paper/data/baseline_comparison.csv
+++ b/paper/data/baseline_comparison.csv
@@ -1,0 +1,24 @@
+# source_commit: placeholder
+# generated: 2026-05-18T00:00:00Z
+# generator: scripts/aggregate_results.py
+# key_schema: dataset:method:metric
+# default_precision: 3
+dataset,method,metric,mean,ci_95,n_seeds
+hotpotqa,icr_probe,auroc,0.847,0.012,5
+hotpotqa,selfcheck,auroc,0.721,0.018,5
+mmlu,icr_probe,auroc,0.831,0.009,5
+mmlu,selfcheck,auroc,0.694,0.022,5
+natural_questions,icr_probe,auroc,0.819,0.014,5
+natural_questions,selfcheck,auroc,0.703,0.016,5
+popqa,icr_probe,auroc,0.862,0.011,5
+popqa,selfcheck,auroc,0.739,0.019,5
+sciq,icr_probe,auroc,0.883,0.008,5
+sciq,selfcheck,auroc,0.751,0.021,5
+searchqa,icr_probe,auroc,0.841,0.013,5
+searchqa,selfcheck,auroc,0.718,0.017,5
+hotpotqa,icr_probe,auprc,0.823,0.015,5
+hotpotqa,selfcheck,auprc,0.698,0.021,5
+mmlu,icr_probe,auprc,0.809,0.011,5
+mmlu,selfcheck,auprc,0.671,0.025,5
+hotpotqa,icr_probe,auroc_lo,0.835,0.0,5
+hotpotqa,icr_probe,auroc_hi,0.859,0.0,5

--- a/paper/figures_src/render_transfer.py
+++ b/paper/figures_src/render_transfer.py
@@ -1,0 +1,209 @@
+"""paper/figures_src/render_transfer.py
+
+Reads paper/data/baseline_comparison.csv and renders a bar chart comparing
+ICR-probe vs SelfCheck AUROC across datasets.
+
+Outputs:
+  paper/generated/figures/transfer_llama_linear.pdf
+  paper/generated/figures/transfer_llama_linear.numbers.csv
+
+The sidecar lists every number that appears on the figure (bar heights,
+annotations, axis limits). Figure captions in prose cite from the sidecar:
+
+    \\result{fig.transfer_llama_linear}{diagonal_mean}[2]
+
+Pure pandas + matplotlib; no dependency on runs/ or zarr stores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("pdf")  # Non-interactive PDF backend — no display required
+import matplotlib.pyplot as plt
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+FIGURE_NAME = "transfer_llama_linear"
+SOURCE_CSV = "baseline_comparison.csv"
+
+# Datasets to show in the figure (display order)
+DATASETS_ORDER = [
+    "hotpotqa",
+    "mmlu",
+    "natural_questions",
+    "popqa",
+    "sciq",
+    "searchqa",
+]
+DATASET_LABELS = {
+    "hotpotqa": "HotpotQA",
+    "mmlu": "MMLU",
+    "natural_questions": "NatQ",
+    "popqa": "PopQA",
+    "sciq": "SciQ",
+    "searchqa": "SearchQA",
+}
+
+
+def write_sidecar_header(fh, generator: str, source_data: str) -> None:
+    """Write the sidecar comment header."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fh.write(f"# generator: {generator}\n")
+    fh.write(f"# source_data: {source_data}\n")
+    fh.write(f"# generated: {now}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Render baseline comparison figure")
+    parser.add_argument(
+        "--paper-dir",
+        default="paper",
+        help="Path to the paper/ directory (default: paper/)",
+    )
+    args = parser.parse_args(argv)
+
+    paper_dir = Path(args.paper_dir)
+    data_csv = paper_dir / "data" / SOURCE_CSV
+    out_dir = paper_dir / "generated" / "figures"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    out_pdf = out_dir / f"{FIGURE_NAME}.pdf"
+    out_sidecar = out_dir / f"{FIGURE_NAME}.numbers.csv"
+
+    if not data_csv.exists():
+        print(f"ERROR: {data_csv} not found.", file=sys.stderr)
+        return 1
+
+    # --- Load data ---
+    df = pd.read_csv(data_csv, comment="#")
+
+    # Filter to AUROC rows only
+    auroc_df = df[df["metric"] == "auroc"].copy()
+
+    # Filter to datasets we want to show
+    auroc_df = auroc_df[auroc_df["dataset"].isin(DATASETS_ORDER)].copy()
+
+    # Pivot: rows = dataset, columns = method
+    pivot = auroc_df.pivot_table(
+        index="dataset", columns="method", values="mean", aggfunc="mean"
+    )
+
+    # Reindex to our display order (only datasets present in data)
+    datasets_present = [d for d in DATASETS_ORDER if d in pivot.index]
+    pivot = pivot.reindex(datasets_present)
+
+    methods = list(pivot.columns)
+
+    # --- Compute summary numbers for sidecar ---
+    icr_col = "icr_probe" if "icr_probe" in methods else methods[0]
+    ref_col = "selfcheck" if "selfcheck" in methods else (methods[1] if len(methods) > 1 else None)
+
+    icr_values = pivot[icr_col].dropna().values
+    diagonal_mean = float(icr_values.mean()) if len(icr_values) > 0 else 0.0
+    icr_max = float(icr_values.max()) if len(icr_values) > 0 else 0.0
+    icr_min = float(icr_values.min()) if len(icr_values) > 0 else 0.0
+
+    ref_values = pivot[ref_col].dropna().values if ref_col else []
+    off_diag_max = float(max(ref_values)) if len(ref_values) > 0 else 0.0
+
+    # --- Build the figure ---
+    n_datasets = len(datasets_present)
+    n_methods = len(methods)
+    bar_width = 0.35
+    x = list(range(n_datasets))
+
+    fig, ax = plt.subplots(figsize=(6.5, 3.5))
+
+    colors = ["#2166ac", "#d6604d"]
+    method_labels = {"icr_probe": "ICR-Probe", "selfcheck": "SelfCheck"}
+
+    bar_handles = []
+    for i, method in enumerate(methods):
+        offsets = [xi + i * bar_width - bar_width * (n_methods - 1) / 2 for xi in x]
+        vals = [pivot[method].get(d, float("nan")) for d in datasets_present]
+        color = colors[i % len(colors)]
+        bars = ax.bar(
+            offsets,
+            vals,
+            bar_width * 0.9,
+            label=method_labels.get(method, method),
+            color=color,
+            alpha=0.85,
+        )
+        bar_handles.append(bars)
+
+    # Annotation: diagonal_mean line
+    ax.axhline(diagonal_mean, color="#2166ac", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax.text(
+        n_datasets - 0.05,
+        diagonal_mean + 0.005,
+        f"{diagonal_mean:.2f}",
+        ha="right",
+        va="bottom",
+        fontsize=7,
+        color="#2166ac",
+    )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(
+        [DATASET_LABELS.get(d, d) for d in datasets_present], fontsize=8
+    )
+    ax.set_ylabel("AUROC", fontsize=9)
+    ax.set_title("Baseline comparison: AUROC across datasets", fontsize=9)
+    ax.legend(fontsize=8)
+    ax.set_ylim(0.5, 1.0)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    fig.tight_layout()
+    fig.savefig(out_pdf)
+    plt.close(fig)
+    print(f"  Written figure: {out_pdf}")
+
+    # --- Write sidecar ---
+    y_axis_min = 0.5
+    y_axis_max = 1.0
+
+    sidecar_rows = [
+        ("diagonal_mean", diagonal_mean, "annotation"),
+        ("icr_auroc_max", icr_max, "annotation"),
+        ("icr_auroc_min", icr_min, "annotation"),
+        ("off_diag_max", off_diag_max, "annotation"),
+        ("y_axis_min", y_axis_min, "axis"),
+        ("y_axis_max", y_axis_max, "axis"),
+    ]
+    # Per-dataset values
+    for d in datasets_present:
+        safe_d = d.replace("_", "")
+        if icr_col in pivot.columns and d in pivot.index:
+            sidecar_rows.append(
+                (f"{safe_d}_icr_auroc", float(pivot.loc[d, icr_col]), "data")
+            )
+        if ref_col and ref_col in pivot.columns and d in pivot.index:
+            sidecar_rows.append(
+                (f"{safe_d}_ref_auroc", float(pivot.loc[d, ref_col]), "data")
+            )
+
+    with open(out_sidecar, "w") as fh:
+        write_sidecar_header(
+            fh,
+            generator="paper/figures_src/render_transfer.py",
+            source_data=str(data_csv),
+        )
+        fh.write("label,value,role\n")
+        for label, value, role in sidecar_rows:
+            fh.write(f"{label},{value:.6g},{role}\n")
+
+    print(f"  Written sidecar: {out_sidecar}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/paper/lint.py
+++ b/paper/lint.py
@@ -1,0 +1,279 @@
+"""paper/lint.py
+
+Lint rule: every digit in prose must be inside an approved citation macro,
+or covered by the whitelist.
+
+Approved contexts (digits inside these are allowed):
+  result, resdelta, resratio, resultCI, resultPM macros
+  ref, cite, citep, citet, eqref, label arguments
+
+Math mode ($ $, display math, equation/align environments) is stripped before
+scanning -- digits in math are allowed unconditionally.
+
+Year literals matching the pattern (19|20)XX are allowed everywhere.
+
+Whitelist entries are literal strings (not regexes). A digit is OK if the
+surrounding text contains a whitelist string that overlaps the digit position.
+
+Usage:
+    python paper/lint.py [--paper-dir <path>]
+
+Exit code 0 = clean. Non-zero = violations found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Approved macro patterns — digits inside these are safe.
+# A match means "this span is an approved context; skip digit scanning inside."
+# ---------------------------------------------------------------------------
+_CITATION_MACROS = r"(?:result|resdelta|resratio|resultCI|resultPM|ref|cite|citep|citet|eqref|label)"
+
+# Match \macroname{...} possibly with additional brace groups and optional [p]
+_APPROVED_RE = re.compile(
+    r"\\"
+    + _CITATION_MACROS
+    + r"(?:\{[^}]*\}){1,3}"   # 1 to 3 brace groups
+    + r"(?:\[[^\]]*\])?"       # optional [precision]
+)
+
+# ---------------------------------------------------------------------------
+# LaTeX structural commands — not prose, digits inside are ignored.
+# These appear in the preamble and document skeleton, not in paper prose.
+# ---------------------------------------------------------------------------
+_STRUCTURAL_CMDS = r"(?:documentclass|usepackage|geometry|input|include|inputenc|fontenc|bibliographystyle|bibliography|includegraphics|setlength|setcounter|vspace|hspace|textwidth|columnwidth|linewidth)"
+
+_STRUCTURAL_RE = re.compile(
+    r"\\"
+    + _STRUCTURAL_CMDS
+    + r"(?:\[[^\]]*\])?"       # optional [options]
+    + r"(?:\{[^}]*\}){1,2}"   # 1 to 2 brace groups
+)
+
+# ---------------------------------------------------------------------------
+# Math mode patterns — stripped before digit scanning.
+# ---------------------------------------------------------------------------
+# Inline math: $...$
+_INLINE_MATH_RE = re.compile(r"\$[^$]*\$")
+# Display math: \[...\] (non-greedy, single-line approximation)
+_DISPLAY_MATH_RE = re.compile(r"\\\[.*?\\\]", re.DOTALL)
+# equation/align/align* environments (multi-line)
+_ENV_MATH_RE = re.compile(
+    r"\\begin\{(?:equation|align|align\*|gather|gather\*|multline)\}.*?\\end\{(?:equation|align|align\*|gather|gather\*|multline)\}",
+    re.DOTALL,
+)
+
+# ---------------------------------------------------------------------------
+# Year pattern — allowed everywhere.
+# ---------------------------------------------------------------------------
+_YEAR_RE = re.compile(r"\b(?:19|20)\d{2}\b")
+
+# ---------------------------------------------------------------------------
+# Digit detector
+# ---------------------------------------------------------------------------
+_DIGIT_RE = re.compile(r"\d")
+
+# ---------------------------------------------------------------------------
+# Whitelist — literal strings; a digit is OK if its context contains one.
+# To add an entry, append a string here and document it in README.md.
+# ---------------------------------------------------------------------------
+WHITELIST: list[str] = [
+    # Model names and sizes
+    "8B parameters",
+    "Llama-3.1",
+    "Llama-3.1-8B",
+    "Llama-3.1-8B-Instruct",
+    "Qwen3-8B",
+    "Qwen3",
+    "GPT-4",
+    "GPT-3.5",
+    # Training hyperparameters (explicit, not experimental results)
+    "layers 14",
+    "layers 14-29",
+    "layers 22,26",
+    "seeds [0, 1, 2, 3, 4]",
+    "learning rate 1e-4",
+    "150 epochs",
+    "32 samples",
+    "batch size 32",
+    "top-k",
+    "top-p",
+    "2e-4",
+    "1e-3",
+    "1e-4",
+    "1e-5",
+    # Hardware
+    "H200",
+    "A100",
+    "V100",
+    "T4",
+    # Cross-reference macros (the argument digits are already masked by _APPROVED_RE,
+    # but these catch "Figure~\ref", "Table~\ref" prose patterns where ~ is nearby)
+    "Figure~\\ref",
+    "Table~\\ref",
+    "Section~\\ref",
+    "Appendix~\\ref",
+    # Confidence interval prose: "95\% CI" is a standard statistical phrase
+    "95\\% CI",
+    "95\\%",
+    "95\\,\\% CI",
+    # Enumerated contributions in intro/conclusion (prose lists)
+    "(1) ",
+    "(2) ",
+    "(3) ",
+    "(4) ",
+    "(5) ",
+    # Footnote/endnote markers
+    "\\footnote{",
+]
+
+
+def _mask_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    """Replace all character positions covered by *spans* with spaces."""
+    text_list = list(text)
+    for start, end in spans:
+        for i in range(start, end):
+            if i < len(text_list):
+                text_list[i] = " "
+    return "".join(text_list)
+
+
+def strip_math_and_approved(text: str) -> tuple[str, list[tuple[int, int]]]:
+    """Return text with math mode and approved macros replaced by spaces.
+
+    Also returns the list of (start, end) spans that were masked, so callers
+    can check whether a digit position was masked.
+    """
+    masked_spans: list[tuple[int, int]] = []
+
+    # Strip multi-line math environments first
+    for m in _ENV_MATH_RE.finditer(text):
+        masked_spans.append((m.start(), m.end()))
+
+    # Strip display math \[...\]
+    for m in _DISPLAY_MATH_RE.finditer(text):
+        masked_spans.append((m.start(), m.end()))
+
+    # Strip inline math $...$
+    for m in _INLINE_MATH_RE.finditer(text):
+        masked_spans.append((m.start(), m.end()))
+
+    # Strip approved citation macros
+    for m in _APPROVED_RE.finditer(text):
+        masked_spans.append((m.start(), m.end()))
+
+    # Strip structural LaTeX commands (preamble/skeleton, not prose)
+    for m in _STRUCTURAL_RE.finditer(text):
+        masked_spans.append((m.start(), m.end()))
+
+    stripped = _mask_spans(text, masked_spans)
+    return stripped, masked_spans
+
+
+def _context_window(text: str, pos: int, width: int = 40) -> str:
+    """Return a short context string around *pos* in *text*."""
+    start = max(0, pos - width)
+    end = min(len(text), pos + width + 1)
+    snippet = text[start:end].replace("\n", " ")
+    return snippet
+
+
+def lint_file(path: Path) -> list[str]:
+    """Lint one .tex file; return list of violation strings (empty = clean)."""
+    text = path.read_text(errors="replace")
+    violations: list[str] = []
+
+    # Strip TeX comment lines (% ...) — they should not be linted
+    # Remove LaTeX comments (% to end-of-line), but not \%
+    text_no_comments = re.sub(r"(?<!\\)%.*", "", text)
+
+    # Work line by line so we can report line numbers
+    lines_original = text_no_comments.splitlines()
+
+    for lineno, line in enumerate(lines_original, 1):
+        # Strip math mode and approved macros from this line
+        stripped, _ = strip_math_and_approved(line)
+
+        # Check each digit in the stripped line
+        for digit_match in _DIGIT_RE.finditer(stripped):
+            pos = digit_match.start()
+
+            # Year check: is this digit part of a year pattern in the ORIGINAL line?
+            # Re-check in original line at same position
+            if _YEAR_RE.search(line[max(0, pos - 4) : pos + 4]):
+                continue
+
+            # Whitelist check: does the context around the digit contain any entry?
+            context_start = max(0, pos - 60)
+            context_end = min(len(line), pos + 60)
+            context = line[context_start:context_end]
+            if any(entry in context for entry in WHITELIST):
+                continue
+
+            # Violation
+            snippet = _context_window(stripped, pos, width=30)
+            violations.append(
+                f"{path}:{lineno}: bare digit '{digit_match.group()}' "
+                f"outside approved context — «{snippet.strip()}»"
+            )
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Lint .tex prose for bare digits")
+    parser.add_argument(
+        "--paper-dir",
+        default="paper",
+        help="Path to the paper/ directory (default: paper/)",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        help="Specific .tex files to lint (overrides default scan)",
+    )
+    args = parser.parse_args(argv)
+
+    paper_dir = Path(args.paper_dir)
+
+    if args.files:
+        tex_files = [Path(f) for f in args.files]
+    else:
+        tex_files = []
+        main_tex = paper_dir / "main.tex"
+        if main_tex.exists():
+            tex_files.append(main_tex)
+        sections_dir = paper_dir / "sections"
+        if sections_dir.exists():
+            tex_files.extend(sorted(sections_dir.glob("*.tex")))
+
+    if not tex_files:
+        print(f"No .tex files found under {paper_dir}", file=sys.stderr)
+        return 0
+
+    all_violations: list[str] = []
+    for tex_path in tex_files:
+        violations = lint_file(tex_path)
+        all_violations.extend(violations)
+
+    if all_violations:
+        for v in all_violations:
+            print(v, file=sys.stderr)
+        print(
+            f"\nlint: {len(all_violations)} violation(s) found. "
+            "Add to WHITELIST in paper/lint.py or use \\result{{...}} macros.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"lint: OK — {len(tex_files)} file(s) scanned, no bare digits found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/paper/macros.tex
+++ b/paper/macros.tex
@@ -137,14 +137,14 @@
 % Utility: split comma-delimited pairs and triples into named macros.
 % --------------------------------------------------------------------------
 \def\hl@splittwo#1#2#3{%
-  \hl@splittwoaux#1,\@nil{#2}{#3}%
+  \hl@splittwoaux#1\@nil{#2}{#3}%
 }
 \def\hl@splittwoaux#1,#2\@nil#3#4{%
   \def#3{#1}\def#4{#2}%
 }
 
 \def\hl@splitthree#1#2#3#4{%
-  \hl@splitthreeaux#1,\@nil{#2}{#3}{#4}%
+  \hl@splitthreeaux#1\@nil{#2}{#3}{#4}%
 }
 \def\hl@splitthreeaux#1,#2,#3\@nil#4#5#6{%
   \def#4{#1}\def#5{#2}\def#6{#3}%

--- a/paper/macros.tex
+++ b/paper/macros.tex
@@ -1,0 +1,153 @@
+% paper/macros.tex
+% Late-binding citation macros for HalluLens paper.
+%
+% Every number in prose resolves at build time through these macros.
+% Values are defined in paper/generated/values.tex via \csname lookup;
+% build_numbers.py produces that file from paper/data/*.csv and
+% paper/generated/figures/*.numbers.csv.
+%
+% Usage:
+%   \result{csv_stem}{key}[precision]
+%   \resdelta{csv_stem}{key_a}{key_b}[precision]
+%   \resratio{csv_stem}{key_a}{key_b}[precision]
+%   \resultCI{csv_stem}{mean_key,lo_key,hi_key}[precision]
+%   \resultPM{csv_stem}{mean_key,err_key}[precision]
+%
+% Where:
+%   csv_stem  - stem of the CSV file (e.g. "baseline" for baseline.csv,
+%               "fig.transfer_llama_linear" for the sidecar of that figure)
+%   key       - colon-joined coordinate per the CSV's key_schema
+%   precision - number of decimal places for siunitx rounding (optional;
+%               default is the CSV's default_precision, embedded as
+%               hl@<stem>@__default_precision__ in values.tex)
+
+\usepackage{siunitx}
+\usepackage{xfp}
+\usepackage{etoolbox}
+
+% --------------------------------------------------------------------------
+% All definitions below use @ in macro names (\@ifundefined, \hl@..., \@nil).
+% Outside a .sty file, @ has catcode 12 (other), so we must temporarily make
+% it a letter via \makeatletter / \makeatother for the definitions to parse.
+% --------------------------------------------------------------------------
+\makeatletter
+
+% --------------------------------------------------------------------------
+% Internal helper: look up \csname hl@<stem>@<key>\endcsname
+% Raises \PackageError if undefined.
+% --------------------------------------------------------------------------
+\newcommand{\hlget}[2]{%
+  \@ifundefined{hl@#1@#2}{%
+    \PackageError{hallulens-macros}%
+      {Undefined result key '#2' in CSV stem '#1'.
+       Check paper/data/#1.csv and re-run 'make values'.}%
+      {The key '#2' was not found in the values generated from '#1'.
+       Valid keys are listed in paper/generated/values.tex.}%
+    \textbf{??}%
+  }{%
+    \csname hl@#1@#2\endcsname%
+  }%
+}
+
+% --------------------------------------------------------------------------
+% Helper: get default precision for a CSV stem (falls back to 3)
+% --------------------------------------------------------------------------
+\newcommand{\hlgetdefprec}[1]{%
+  \@ifundefined{hl@#1@__default_precision__}{3}{\csname hl@#1@__default_precision__\endcsname}%
+}
+
+% --------------------------------------------------------------------------
+% \result{csv}{key}[precision]
+% --------------------------------------------------------------------------
+\DeclareRobustCommand{\result}[2]{%
+  \@ifnextchar[%]
+    {\hl@result@prec{#1}{#2}}%
+    {\hl@result@prec{#1}{#2}[\hlgetdefprec{#1}]}%
+}
+\def\hl@result@prec#1#2[#3]{%
+  \num[round-mode=places,round-precision=#3]{\hlget{#1}{#2}}%
+}
+
+% --------------------------------------------------------------------------
+% \resdelta{csv}{key_a}{key_b}[precision]
+% Computes key_a - key_b using \fpeval from xfp.
+% (Named \resdelta, not \delta, to avoid clashing with the Greek letter.)
+% --------------------------------------------------------------------------
+\DeclareRobustCommand{\resdelta}[3]{%
+  \@ifnextchar[%]
+    {\hl@delta@prec{#1}{#2}{#3}}%
+    {\hl@delta@prec{#1}{#2}{#3}[\hlgetdefprec{#1}]}%
+}
+\def\hl@delta@prec#1#2#3[#4]{%
+  \edef\hl@va{\hlget{#1}{#2}}%
+  \edef\hl@vb{\hlget{#1}{#3}}%
+  \num[round-mode=places,round-precision=#4,explicit-sign]{\fpeval{\hl@va - \hl@vb}}%
+}
+
+% --------------------------------------------------------------------------
+% \resratio{csv}{key_a}{key_b}[precision]
+% Computes key_a / key_b using \fpeval.
+% --------------------------------------------------------------------------
+\DeclareRobustCommand{\resratio}[3]{%
+  \@ifnextchar[%]
+    {\hl@ratio@prec{#1}{#2}{#3}}%
+    {\hl@ratio@prec{#1}{#2}{#3}[\hlgetdefprec{#1}]}%
+}
+\def\hl@ratio@prec#1#2#3[#4]{%
+  \edef\hl@va{\hlget{#1}{#2}}%
+  \edef\hl@vb{\hlget{#1}{#3}}%
+  \num[round-mode=places,round-precision=#4]{\fpeval{\hl@va / \hl@vb}}%
+}
+
+% --------------------------------------------------------------------------
+% \resultCI{csv}{mean_key,lo_key,hi_key}[precision]
+% Renders as: mean [lo, hi]
+% The three keys are comma-separated in a single brace group.
+% --------------------------------------------------------------------------
+\DeclareRobustCommand{\resultCI}[2]{%
+  \@ifnextchar[%]
+    {\hl@ci@prec{#1}{#2}}%
+    {\hl@ci@prec{#1}{#2}[\hlgetdefprec{#1}]}%
+}
+\def\hl@ci@prec#1#2[#3]{%
+  % Split #2 on commas: mean, lo, hi
+  \hl@splitthree{#2}{\hl@keyA}{\hl@keyB}{\hl@keyC}%
+  \num[round-mode=places,round-precision=#3]{\hlget{#1}{\hl@keyA}}%
+  \ [\num[round-mode=places,round-precision=#3]{\hlget{#1}{\hl@keyB}},
+     \num[round-mode=places,round-precision=#3]{\hlget{#1}{\hl@keyC}}]%
+}
+
+% --------------------------------------------------------------------------
+% \resultPM{csv}{mean_key,err_key}[precision]
+% Renders as: mean +/- err
+% --------------------------------------------------------------------------
+\DeclareRobustCommand{\resultPM}[2]{%
+  \@ifnextchar[%]
+    {\hl@pm@prec{#1}{#2}}%
+    {\hl@pm@prec{#1}{#2}[\hlgetdefprec{#1}]}%
+}
+\def\hl@pm@prec#1#2[#3]{%
+  \hl@splittwo{#2}{\hl@keyA}{\hl@keyB}%
+  \num[round-mode=places,round-precision=#3]{\hlget{#1}{\hl@keyA}}%
+  $\pm$%
+  \num[round-mode=places,round-precision=#3]{\hlget{#1}{\hl@keyB}}%
+}
+
+% --------------------------------------------------------------------------
+% Utility: split comma-delimited pairs and triples into named macros.
+% --------------------------------------------------------------------------
+\def\hl@splittwo#1#2#3{%
+  \hl@splittwoaux#1,\@nil{#2}{#3}%
+}
+\def\hl@splittwoaux#1,#2\@nil#3#4{%
+  \def#3{#1}\def#4{#2}%
+}
+
+\def\hl@splitthree#1#2#3#4{%
+  \hl@splitthreeaux#1,\@nil{#2}{#3}{#4}%
+}
+\def\hl@splitthreeaux#1,#2,#3\@nil#4#5#6{%
+  \def#4{#1}\def#5{#2}\def#6{#3}%
+}
+
+\makeatother

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,43 @@
+% paper/main.tex
+% Minimal article wrapper for the HalluLens EMNLP 2026 paper.
+% Run: make paper
+%
+% This file inputs macros.tex (citation macro definitions),
+% generated/values.tex (CSV-derived \csname definitions),
+% and the prose sections.
+
+\documentclass[11pt]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{geometry}
+\geometry{margin=1in}
+
+% --- Citation infrastructure ---
+\input{macros}
+\input{generated/values}
+
+% --- Bibliography ---
+\usepackage{natbib}
+
+% --- Hyperlinks (load last) ---
+\usepackage[hidelinks]{hyperref}
+
+% --- Title ---
+\title{Detecting Hallucinations via Mutual Information Analysis\\
+       of Intermediate Layer Activations}
+\author{Anonymous}
+\date{2026}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+\input{sections/00_abstract}
+\end{abstract}
+
+\section{Introduction}
+\input{sections/01_intro}
+
+\end{document}

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,36 +1,31 @@
 % paper/main.tex
-% Minimal article wrapper for the HalluLens EMNLP 2026 paper.
-% Run: make paper
-%
-% This file inputs macros.tex (citation macro definitions),
-% generated/values.tex (CSV-derived \csname definitions),
-% and the prose sections.
+% EMNLP 2026 long-paper submission (ARR-routed).
+% Uses the official ACL style (acl.sty); review option masks author
+% identity during peer review. Drop "review" for the camera-ready.
 
 \documentclass[11pt]{article}
 
-\usepackage[utf8]{inputenc}
-\usepackage[T1]{fontenc}
-\usepackage{geometry}
-\geometry{margin=1in}
+% ACL submission style. Drop the [review] option for the camera-ready.
+\usepackage[review]{acl}
 
-% --- Citation infrastructure ---
+\usepackage{times}
+\usepackage{latexsym}
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{microtype}
+\usepackage{inconsolata}
+\usepackage{graphicx}
+
+% --- Citation infrastructure (single-source-of-truth numbers from CSVs) ---
 \input{macros}
 \input{generated/values}
 
-% --- Bibliography ---
-\usepackage{natbib}
-
-% --- Hyperlinks (load last) ---
-\usepackage[hidelinks]{hyperref}
-
-% --- Title ---
-\title{Detecting Hallucinations via Mutual Information Analysis\\
+\title{Detecting Hallucinations via Mutual Information Analysis
        of Intermediate Layer Activations}
-\author{Anonymous}
-\date{2026}
+
+\author{Anonymous Submission}
 
 \begin{document}
-
 \maketitle
 
 \begin{abstract}
@@ -38,6 +33,21 @@
 \end{abstract}
 
 \section{Introduction}
+\label{sec:intro}
 \input{sections/01_intro}
+
+\section*{Limitations}
+\input{sections/99_limitations}
+
+% \section*{Ethics Statement}
+% \input{sections/99_ethics}
+
+% Bibliography: enable once references.bib has entries.
+% \bibliography{references}
+
+% \appendix
+% \section{Example Appendix}
+% \label{sec:appendix}
+% \input{sections/appendix_A}
 
 \end{document}

--- a/paper/sections/00_abstract.tex
+++ b/paper/sections/00_abstract.tex
@@ -1,0 +1,8 @@
+% paper/sections/00_abstract.tex
+% Placeholder abstract. All numeric literals must cite from CSV via citation macros.
+
+We present HalluLens, a method for detecting hallucinations in large language
+models by analyzing mutual information in intermediate layer activations.
+Our contrastive probe achieves an AUROC of
+\result{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}[3]
+on HotpotQA, demonstrating strong cross-dataset generalization.

--- a/paper/sections/01_intro.tex
+++ b/paper/sections/01_intro.tex
@@ -2,9 +2,9 @@
 % Demonstration section showing \result, \resdelta, and \resultCI usage.
 % All numeric literals in prose must resolve through citation macros.
 
-Hallucination remains a central challenge for deployed language models
-\citep{maynez2020faithfulness}. A model that confidently asserts false
-information undermines the trust required for real-world use.
+Hallucination remains a central challenge for deployed language models.
+A model that confidently asserts false information undermines the trust
+required for real-world use.
 
 We propose \textbf{HalluLens}, a probe-based detector that operates directly
 on intermediate layer activations, bypassing the need for external knowledge
@@ -26,7 +26,7 @@ on MMLU and
 \result{baseline_comparison}{sciq:icr_probe:auroc:mean}[3]
 on SciQ.
 The performance advantage over the SelfCheck baseline
-holds across all benchmarks (Table~\ref{tab:baseline}).
+holds across all benchmarks.
 
 \paragraph{Contributions.}
 We make the following contributions:
@@ -34,4 +34,4 @@ We make the following contributions:
     Llama-3.1 or Qwen3-8B backbone with no additional sampling overhead.
 (2) A reproducible benchmark suite covering six LLMsKnow tasks.
 (3) Open-source code and a paper build system ensuring all reported numbers
-    trace to a single CSV cell (Section~\ref{sec:reproducibility}).
+    trace to a single CSV cell.

--- a/paper/sections/01_intro.tex
+++ b/paper/sections/01_intro.tex
@@ -1,0 +1,37 @@
+% paper/sections/01_intro.tex
+% Demonstration section showing \result, \resdelta, and \resultCI usage.
+% All numeric literals in prose must resolve through citation macros.
+
+Hallucination remains a central challenge for deployed language models
+\citep{maynez2020faithfulness}. A model that confidently asserts false
+information undermines the trust required for real-world use.
+
+We propose \textbf{HalluLens}, a probe-based detector that operates directly
+on intermediate layer activations, bypassing the need for external knowledge
+sources or multiple sampling passes.
+
+\paragraph{Main result.}
+Our ICR-probe achieves an AUROC of
+\result{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}[3]
+on HotpotQA, a gain of
+\resdelta{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}{hotpotqa:selfcheck:auroc:mean}[3]
+percentage points over SelfCheck (95\% CI
+\resultCI{baseline_comparison}{hotpotqa:icr_probe:auroc:mean,hotpotqa:icr_probe:auroc_lo:mean,hotpotqa:icr_probe:auroc_hi:mean}[3]).
+
+\paragraph{Generalization.}
+The probe was trained on HotpotQA and evaluated on five additional datasets
+without re-training, achieving a mean AUROC of
+\result{baseline_comparison}{mmlu:icr_probe:auroc:mean}[3]
+on MMLU and
+\result{baseline_comparison}{sciq:icr_probe:auroc:mean}[3]
+on SciQ.
+The performance advantage over the SelfCheck baseline
+holds across all benchmarks (Table~\ref{tab:baseline}).
+
+\paragraph{Contributions.}
+We make the following contributions:
+(1) A lightweight hallucination probe that runs at inference time on a
+    Llama-3.1 or Qwen3-8B backbone with no additional sampling overhead.
+(2) A reproducible benchmark suite covering six LLMsKnow tasks.
+(3) Open-source code and a paper build system ensuring all reported numbers
+    trace to a single CSV cell (Section~\ref{sec:reproducibility}).

--- a/paper/sections/99_limitations.tex
+++ b/paper/sections/99_limitations.tex
@@ -1,0 +1,10 @@
+% paper/sections/99_limitations.tex
+% REQUIRED for EMNLP / ARR submission. Papers without a Limitations
+% section are desk-rejected. Replace this placeholder with real content
+% before submission.
+
+This is a placeholder Limitations section. The final submission must
+discuss honest limitations of the work: scope of evaluation
+(benchmarks, languages, model families), generalization caveats,
+known failure modes, and any reproducibility constraints (compute
+requirements, dataset access).

--- a/paper/templates/tab_baseline.tex.template
+++ b/paper/templates/tab_baseline.tex.template
@@ -1,0 +1,28 @@
+% paper/templates/tab_baseline.tex.template
+% Generated table: baseline AUROC comparison across datasets.
+% Produced by build_numbers.py when make values is run.
+% Cite in main.tex with: \input{generated/tab_baseline}
+\begin{tabular}{lcc}
+\toprule
+Dataset & ICR-Probe AUROC & SelfCheck AUROC \\
+\midrule
+HotpotQA
+  & \result{baseline_comparison}{hotpotqa:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{hotpotqa:selfcheck:auroc:mean}[3] \\
+MMLU
+  & \result{baseline_comparison}{mmlu:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{mmlu:selfcheck:auroc:mean}[3] \\
+NatQ
+  & \result{baseline_comparison}{natural_questions:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{natural_questions:selfcheck:auroc:mean}[3] \\
+PopQA
+  & \result{baseline_comparison}{popqa:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{popqa:selfcheck:auroc:mean}[3] \\
+SciQ
+  & \result{baseline_comparison}{sciq:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{sciq:selfcheck:auroc:mean}[3] \\
+SearchQA
+  & \result{baseline_comparison}{searchqa:icr_probe:auroc:mean}[3]
+  & \result{baseline_comparison}{searchqa:selfcheck:auroc:mean}[3] \\
+\bottomrule
+\end{tabular}

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -3,6 +3,10 @@
 Usage:
     python scripts/aggregate_results.py --runs-dir runs/baseline_comparison_hotpotqa
     python scripts/aggregate_results.py --runs-dir runs/ --output results/summary.csv
+
+    # Also emit a paper/data/ CSV with the §3 header block:
+    python scripts/aggregate_results.py --runs-dir runs/ \\
+        --paper-output paper/data/baseline_comparison.csv
 """
 
 from __future__ import annotations
@@ -10,7 +14,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Add project root to path
@@ -82,11 +88,68 @@ def aggregate(records: list[dict]) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
+def get_head_commit() -> str:
+    """Return the current HEAD commit SHA (short), or 'unknown' on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "unknown"
+    except FileNotFoundError:
+        return "unknown"
+
+
+def write_paper_csv(
+    summary: pd.DataFrame,
+    out_path: Path,
+    generator: str = "scripts/aggregate_results.py",
+) -> None:
+    """Write *summary* to *out_path* with the §3 header block.
+
+    The key_schema is ``dataset:method:metric`` matching the columns present.
+    This is an additional output path; existing CSV semantics are unchanged.
+    """
+    source_commit = get_head_commit()
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    key_schema = "dataset:method:metric"
+    default_precision = 3
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    header_lines = [
+        f"# source_commit: {source_commit}",
+        f"# generated: {generated}",
+        f"# generator: {generator}",
+        f"# key_schema: {key_schema}",
+        f"# default_precision: {default_precision}",
+    ]
+
+    # Write header then CSV (without index)
+    with open(out_path, "w") as fh:
+        for line in header_lines:
+            fh.write(line + "\n")
+        summary.drop(columns=["formatted"], errors="ignore").to_csv(fh, index=False)
+
+    print(f"Paper CSV (with §3 header): {out_path}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Aggregate experiment results")
     parser.add_argument("--runs-dir", required=True, help="Root directory of runs")
     parser.add_argument(
         "--output", default="results/summary.csv", help="Output CSV path"
+    )
+    parser.add_argument(
+        "--paper-output",
+        default=None,
+        help=(
+            "Optional additional output path in paper/data/ that includes the §3 "
+            "header block (e.g. paper/data/baseline_comparison.csv). "
+            "Does not change the primary --output CSV."
+        ),
     )
     args = parser.parse_args()
 
@@ -129,6 +192,10 @@ def main() -> None:
 
     # Print to stdout
     print("\n" + summary.to_string(index=False))
+
+    # Emit paper/data/ CSV with §3 header block (optional)
+    if args.paper_output:
+        write_paper_csv(summary, Path(args.paper_output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #64.

## Summary
- Scaffolds `paper/` so every numeric literal in prose and every figure annotation traces back to one cell in `paper/data/*.csv` or a `*.numbers.csv` sidecar; `make paper` rebuilds end-to-end.
- Late-binding citation macros (`\result`, `\resdelta`, `\resratio`, `\resultCI`, `\resultPM`) resolve at LaTeX compile time via `\csname hl@<csv>@<key>\endcsname` against an auto-generated `values.tex`; missing keys raise `\PackageError`.
- Figure renderers in `paper/figures_src/` produce a PDF + a `*.numbers.csv` sidecar pair; captions cite the sidecar via the `fig.<stem>` namespace.
- `scripts/aggregate_results.py` gains an optional `--paper-output` flag that emits a §3-headed CSV into `paper/data/`.

## Notes for review
- `\delta` from the spec is shipped as `\resdelta` (and `\ratio` as `\resratio`) — `\delta` already denotes Greek δ in math mode. Documented in `paper/README.md` under **Note on macro names**.
- Sidecar/data namespace collision (open question §9.1) resolved by prefixing sidecar stems with `fig.` in `values.tex` keys. Documented in README.
- Drafted with assistance from Claude Opus 4.7 (orchestration + review) and Claude Sonnet (implementation).

## Test plan
- [x] `make figures values lint` runs end-to-end from a clean state and exits 0.
- [x] `build_numbers.py` produces `generated/values.tex` (74 cells across data + sidecar) and `generated/provenance.txt` (6 citations resolved).
- [x] `lint.py` is clean on the demo `sections/*.tex`; manually verified it flags `42` and `85.2\%` as bare digits and accepts `2024` (year) and whitelisted strings.
- [x] Figure renderer writes both `transfer_llama_linear.pdf` and `transfer_llama_linear.numbers.csv`.
- [x] `paper/.gitignore` excludes `generated/`, `__pycache__/`, LaTeX byproducts, and root-level `main.pdf`.
- [ ] **`make paper` (latexmk) not exercised here** — LaTeX is not installed in this dev container. Reviewers with a LaTeX install should run `make paper` and confirm the demo intro typesets without `\PackageError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)