### PR TITLE
chore: dispatch wrappers + #82 direction configs

### DIFF
--- a/configs/methods/contrastive_logprob_attn_recon_l10_a10_full_bwd.json
+++ b/configs/methods/contrastive_logprob_attn_recon_l10_a10_full_bwd.json
@@ -1,0 +1,58 @@
+{
+  "name": "contrastive_logprob_attn_recon_l10_a10_full_bwd",
+  "routine": "contrastive_logprob_attn_recon",
+  "model_class": "logprob_attn_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4,
+    "attn_direction": "backward",
+    "attn_offset_k": 1,
+    "attn_target": "full",
+    "attn_r_max": 64,
+    "attn_recon_hidden_dim": 256,
+    "attn_recon_lambda": 1.0,
+    "attn_var_threshold": 1e-5
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 512,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "dataset_class": "memmap_contrastive_dataset",
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "include_response_attention": true,
+    "attention_summary": "full",
+    "attention_target_layer_offset_backward": 1,
+    "attention_target_layer_offset_forward": 1
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 256
+  }
+}

--- a/configs/methods/contrastive_logprob_attn_recon_l10_a10_full_fwd.json
+++ b/configs/methods/contrastive_logprob_attn_recon_l10_a10_full_fwd.json
@@ -1,0 +1,58 @@
+{
+  "name": "contrastive_logprob_attn_recon_l10_a10_full_fwd",
+  "routine": "contrastive_logprob_attn_recon",
+  "model_class": "logprob_attn_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4,
+    "attn_direction": "forward",
+    "attn_offset_k": 1,
+    "attn_target": "full",
+    "attn_r_max": 64,
+    "attn_recon_hidden_dim": 256,
+    "attn_recon_lambda": 1.0,
+    "attn_var_threshold": 1e-5
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 512,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "dataset_class": "memmap_contrastive_dataset",
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "include_response_attention": true,
+    "attention_summary": "full",
+    "attention_target_layer_offset_backward": 1,
+    "attention_target_layer_offset_forward": 1
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 256
+  }
+}

--- a/scripts/dispatch/icr_77_sequential.sh
+++ b/scripts/dispatch/icr_77_sequential.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Sequential dispatch of ICR probe across all 12 (dataset x model) cells.
+# Priority order: largest first so we get a runtime signal early.
+#
+# Note: run_experiment.py --seeds takes a comma-separated string,
+# NOT space-separated. The earlier wrapper passed `0 1 2 3 4` and
+# argparse rejected the trailing positionals; see PR adding this file.
+set -uo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+CELLS=(
+  searchqa
+  searchqa_qwen3
+  hotpotqa
+  hotpotqa_qwen3
+  mmlu
+  mmlu_qwen3
+  nq
+  nq_qwen3
+  popqa
+  popqa_qwen3
+  sciq
+  sciq_qwen3
+)
+
+ok=0
+fail=0
+echo "icr_77 start: $(date)  host=$(hostname)"
+for cell in "${CELLS[@]}"; do
+  echo "===================================================="
+  echo "icr_77: starting $cell at $(date)"
+  echo "===================================================="
+  cfg="configs/experiments/baseline_comparison_${cell}.json"
+  if [ ! -f "$cfg" ]; then
+    echo "icr_77: MISSING CONFIG $cfg"
+    fail=$((fail+1))
+    continue
+  fi
+  if "$PYTHON" scripts/run_experiment.py --experiment "$cfg" --methods icr_probe --seeds 0,1,2,3,4; then
+    echo "icr_77: $cell OK at $(date)"
+    ok=$((ok+1))
+  else
+    rc=$?
+    echo "icr_77: $cell FAIL rc=$rc at $(date)"
+    fail=$((fail+1))
+  fi
+done
+echo "===================================================="
+echo "icr_77 end: $(date)  ok=$ok  fail=$fail  total=${#CELLS[@]}"
+echo "===================================================="

--- a/scripts/dispatch/smoketest_82.sh
+++ b/scripts/dispatch/smoketest_82.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Smoketest the full-attention recon path on NQ at seed 0.
+# Limits to 1 epoch x 5 steps so the run completes in ~2-5 min — verifies
+# the new attn_target='full' code path works end-to-end on real data
+# before launching the multi-hour direction sweep.
+set -uo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+echo "smoketest_82 start: $(date)"
+SWEEP_DATASETS=nq SWEEP_SEED=0 SWEEP_MAX_EPOCHS=1 SWEEP_STEPS_PER_EPOCH=5 \
+    bash scripts/sweep_issue_75_lambda.sh contrastive_logprob_attn_recon_l10_a10_full
+rc=$?
+echo "smoketest_82 end: $(date)  rc=$rc"
+exit $rc


### PR DESCRIPTION
## Summary
Consolidating ad-hoc dispatch wrappers and the two new direction configs for issue #82's first-pass ablation onto main, so we can dispatch from a tracked checkout instead of uncommitted worktrees.

## What's in here
| File | Why |
|---|---|
| `configs/methods/contrastive_logprob_attn_recon_l10_a10_full_fwd.json` | full target, forward only — for the #82 direction ablation |
| `configs/methods/contrastive_logprob_attn_recon_l10_a10_full_bwd.json` | full target, backward only |
| `scripts/dispatch/icr_77_sequential.sh` | sequential 12-cell ICR probe sweep (uses `--seeds 0,1,2,3,4`; the earlier ad-hoc copy used space-separated which argparse rejected — all 12 cells failed in <60s) |
| `scripts/dispatch/smoketest_82.sh` | 1 epoch × 5 steps for fast smoketest of `attn_target='full'` before launching the multi-hour direction sweep |

## Test plan
- [x] `_fwd` config is copy of `_full` with `attn_direction='forward'` only diff (mirrors existing stats `_fwd` pattern)
- [x] `_bwd` ditto with `attn_direction='backward'`
- [x] ICR wrapper uses corrected `--seeds 0,1,2,3,4` syntax matching `run_experiment.py` argparser
- [ ] Smoketest will run as the next dispatch — validates the full-attention code path on real NQ data before fan-out

Related: #77 (ICR probe dispatch), #82 (full attention recon ablation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)