### PR TITLE
feat(#93): ACT-ViT — ViT over full activation tensors (memmap)

### DIFF
--- a/activation_research/act_vit.py
+++ b/activation_research/act_vit.py
@@ -1,0 +1,267 @@
+"""
+ACT-ViT: Vision Transformer over full (layers × tokens × hidden) activation tensors.
+Paper: arXiv:2510.00296 (Bar-Shalom et al.)
+
+Treats the full activation tensor of a generation (L × N × D) as an "image"
+and classifies it with a Vision Transformer. Max-pools in the (L, N) spatial
+plane to a fixed resolution, projects hidden dim via a per-LLM LinearAdapter,
+tiles into patches, then runs a standard ViT encoder on the patch sequence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ACTViTConfig:
+    """Hyperparameters for ACT-ViT (paper defaults).
+
+    Parameters
+    ----------
+    input_dim : int
+        Hidden dim D of the source LLM (4096 for Llama-3.1-8B and Qwen3-8B).
+    L_p : int
+        Spatial height (layers) after adaptive max-pool.
+    N_p : int
+        Spatial width (tokens) after adaptive max-pool.
+    patch_h : int
+        Patch height in the (L_p, N_p) grid.
+    patch_w : int
+        Patch width in the (L_p, N_p) grid.
+    d_adapter : int
+        Output dimension D' of the per-LLM LinearAdapter.
+    d_model : int
+        ViT encoder hidden dimension.
+    num_heads : int
+        Number of attention heads in each Transformer block.
+    depth : int
+        Number of Transformer encoder blocks.
+    mlp_ratio : float
+        Hidden-dim expansion factor in each MLP block (mlp_hidden = mlp_ratio * d_model).
+    dropout : float
+        Dropout probability applied in the Transformer encoder.
+    """
+
+    input_dim: int = 4096
+    L_p: int = 8
+    N_p: int = 100
+    patch_h: int = 2
+    patch_w: int = 10
+    d_adapter: int = 256
+    d_model: int = 256
+    num_heads: int = 8
+    depth: int = 4
+    mlp_ratio: float = 4.0
+    dropout: float = 0.1
+
+    def __post_init__(self) -> None:
+        if self.L_p % self.patch_h != 0:
+            raise ValueError(
+                f"L_p ({self.L_p}) must be divisible by patch_h ({self.patch_h})"
+            )
+        if self.N_p % self.patch_w != 0:
+            raise ValueError(
+                f"N_p ({self.N_p}) must be divisible by patch_w ({self.patch_w})"
+            )
+
+    @property
+    def n_patches(self) -> int:
+        return (self.L_p // self.patch_h) * (self.N_p // self.patch_w)
+
+    @property
+    def patch_dim(self) -> int:
+        """Flat patch dimension before the patch embedding linear: patch_h * patch_w * d_adapter."""
+        return self.patch_h * self.patch_w * self.d_adapter
+
+
+# ---------------------------------------------------------------------------
+# Sub-modules
+# ---------------------------------------------------------------------------
+
+
+class _MLP(nn.Module):
+    """Standard two-layer MLP block used inside each Transformer layer."""
+
+    def __init__(self, d_model: int, mlp_ratio: float, dropout: float) -> None:
+        super().__init__()
+        hidden = int(d_model * mlp_ratio)
+        self.fc1 = nn.Linear(d_model, hidden)
+        self.fc2 = nn.Linear(hidden, d_model)
+        self.act = nn.GELU()
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.drop(self.act(self.fc1(x))))
+
+
+class _TransformerBlock(nn.Module):
+    """Pre-norm Transformer encoder block (LayerNorm before Attn/MLP)."""
+
+    def __init__(self, d_model: int, num_heads: int, mlp_ratio: float, dropout: float) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d_model)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=d_model,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.norm2 = nn.LayerNorm(d_model)
+        self.mlp = _MLP(d_model, mlp_ratio, dropout)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Self-attention with residual
+        h = self.norm1(x)
+        h, _ = self.attn(h, h, h, need_weights=False)
+        x = x + self.drop(h)
+        # MLP with residual
+        x = x + self.drop(self.mlp(self.norm2(x)))
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Main model
+# ---------------------------------------------------------------------------
+
+
+class ACTViT(nn.Module):
+    """Vision Transformer over full (L × N × D) activation tensors.
+
+    Architecture
+    ------------
+    1. Adaptive max-pool: (B, L, N, D) → (B, L_p, N_p, D)
+    2. LinearAdapter: per-LLM projection D → D' (d_adapter)
+    3. PatchEmbed2D: tile (L_p, N_p) grid with (patch_h, patch_w) patches
+                     → (B, n_patches, patch_h*patch_w*D') → Linear → (B, n_patches, d_model)
+    4. CLS token prepended; learned positional encoding added
+    5. Transformer encoder (depth blocks)
+    6. CLS output → Linear → scalar logit
+
+    Parameters
+    ----------
+    cfg : ACTViTConfig
+        Model hyperparameters.
+    """
+
+    def __init__(self, cfg: ACTViTConfig) -> None:
+        super().__init__()
+        self.cfg = cfg
+
+        # 1. Per-LLM linear adapter D → D'
+        self.adapter = nn.Linear(cfg.input_dim, cfg.d_adapter, bias=False)
+
+        # 2. Patch embedding: flatten (patch_h, patch_w, D') → d_model
+        self.patch_embed = nn.Linear(cfg.patch_dim, cfg.d_model, bias=True)
+
+        # 3. CLS token + positional encoding
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, cfg.d_model))
+        self.pos_embed = nn.Parameter(torch.zeros(1, cfg.n_patches + 1, cfg.d_model))
+
+        # 4. Transformer encoder
+        self.blocks = nn.ModuleList([
+            _TransformerBlock(
+                d_model=cfg.d_model,
+                num_heads=cfg.num_heads,
+                mlp_ratio=cfg.mlp_ratio,
+                dropout=cfg.dropout,
+            )
+            for _ in range(cfg.depth)
+        ])
+        self.norm = nn.LayerNorm(cfg.d_model)
+
+        # 5. Classification head
+        self.head = nn.Linear(cfg.d_model, 1, bias=True)
+
+        # Weight init
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.trunc_normal_(m.weight, std=0.02)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.LayerNorm):
+                nn.init.ones_(m.weight)
+                nn.init.zeros_(m.bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        response_len: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor (B, L, N, D)
+            Activation tensor, float16 or float32. Will be cast to float32.
+        response_len : Tensor (B,), optional
+            Per-sample response lengths. Accepted but not used; max-pooling
+            handles variable-length sequences natively.
+
+        Returns
+        -------
+        Tensor (B, 1)
+            Raw (un-sigmoid'd) logits for the hallucination class.
+        """
+        cfg = self.cfg
+        x = x.float()  # ensure float32 for stable computation
+        B, L, N, D = x.shape
+
+        # --- Step 1: Adaptive max-pool (L, N) → (L_p, N_p) per D-slice ---
+        # Reshape to (B*D, 1, L, N) for F.adaptive_max_pool2d
+        x = x.permute(0, 3, 1, 2)                          # (B, D, L, N)
+        x = x.reshape(B * D, 1, L, N)                      # (B*D, 1, L, N)
+        x = F.adaptive_max_pool2d(x, (cfg.L_p, cfg.N_p))   # (B*D, 1, L_p, N_p)
+        x = x.squeeze(1)                                    # (B*D, L_p, N_p)
+        x = x.reshape(B, D, cfg.L_p, cfg.N_p)              # (B, D, L_p, N_p)
+        x = x.permute(0, 2, 3, 1)                          # (B, L_p, N_p, D)
+
+        # --- Step 2: LinearAdapter D → D' ---
+        x = self.adapter(x)                                 # (B, L_p, N_p, D')
+
+        # --- Step 3: Patch embedding ---
+        # Tile into patches of (patch_h, patch_w)
+        pH, pW = cfg.patch_h, cfg.patch_w
+        nH = cfg.L_p // pH   # number of patches along layer axis
+        nW = cfg.N_p // pW   # number of patches along token axis
+        d_prime = cfg.d_adapter
+
+        # Rearrange (B, L_p, N_p, D') → (B, nH, pH, nW, pW, D')
+        x = x.reshape(B, nH, pH, nW, pW, d_prime)
+        # Gather patch dims: (B, nH, nW, pH, pW, D')
+        x = x.permute(0, 1, 3, 2, 4, 5).contiguous()
+        # Flatten each patch: (B, nH*nW, pH*pW*D')
+        x = x.reshape(B, nH * nW, pH * pW * d_prime)
+        # Project to d_model
+        x = self.patch_embed(x)                             # (B, n_patches, d_model)
+
+        # --- Step 4: CLS token + positional encoding ---
+        cls = self.cls_token.expand(B, -1, -1)              # (B, 1, d_model)
+        x = torch.cat([cls, x], dim=1)                      # (B, n_patches+1, d_model)
+        x = x + self.pos_embed                              # broadcast over B
+
+        # --- Step 5: Transformer encoder ---
+        for block in self.blocks:
+            x = block(x)
+        x = self.norm(x)
+
+        # --- Step 6: CLS output → logit ---
+        cls_out = x[:, 0]                                   # (B, d_model)
+        logit = self.head(cls_out)                          # (B, 1)
+        return logit

--- a/activation_research/act_vit_dataset.py
+++ b/activation_research/act_vit_dataset.py
@@ -98,16 +98,15 @@ class ACTViTDataset(Dataset):
 
         # Load activation for this sample; shape (num_layers+1, R, D) fp16.
         # Drop the embedding layer (index 0) → (num_layers, R, D).
-        act_raw = self._acts[idx]          # (num_layers+1, R, D) fp16  — numpy memmap slice
-        act = np.array(act_raw, dtype=np.float32)   # copy out of memmap; cast to fp32
-        act = act[1:]                               # drop embedding layer → (L, R, D)
-        act_t = torch.from_numpy(act)              # (L, R, D)
+        act_raw = self._acts[idx]                  # (num_layers+1, R, D) fp16  — numpy memmap slice
+        act = np.array(act_raw[1:], dtype=np.float16)  # drop embed layer first, materialize off memmap, stay fp16
+        act_t = torch.from_numpy(act)              # (L, R, D) fp16 — ACTViT.forward casts to fp32 on GPU
 
         label = int(self._labels[idx])
         resp_len = int(self._resp_lens[idx])
 
         return {
-            "activations": act_t,       # Tensor (L, R, D) float32
+            "activations": act_t,       # Tensor (L, R, D) float16
             "label": label,              # int 0/1 (1 = hallucinated)
             "response_len": resp_len,    # int
         }

--- a/activation_research/act_vit_dataset.py
+++ b/activation_research/act_vit_dataset.py
@@ -1,0 +1,113 @@
+"""
+act_vit_dataset.py — Memmap-backed Dataset for ACT-ViT.
+
+Reads directly from an icr_capture directory (produced by
+InferenceCaptureWriter) without going through MemmapContrastiveDataset.
+Returns full (L, N, D) activation tensors suitable for ACTViT.forward().
+
+Capture layout expected:
+    config.json           — {"n_samples": N, "num_layers": L, "max_response_len": R, "hidden_dim": D, ...}
+    response_activations.npy — memmap (N, num_layers+1, max_response_len, hidden_dim) fp16
+    response_len.npy      — memmap (N,) int32
+    meta.jsonl            — one JSON obj per sample; field "hallucinated": bool
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Sequence
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class ACTViTDataset(Dataset):
+    """Dataset returning full activation tensors (L, N, D) per sample.
+
+    Parameters
+    ----------
+    capture_dir : str | Path
+        Path to an icr_capture directory.
+    indices : array-like of int
+        Row indices into the capture to expose (allows train/val/test slicing).
+    cfg : dict
+        Optional overrides; currently unused — shape info is read from
+        config.json in the capture directory.
+    """
+
+    def __init__(
+        self,
+        capture_dir: str | Path,
+        indices: Sequence[int],
+        *,
+        cfg: dict | None = None,
+    ) -> None:
+        self._capture_dir = Path(capture_dir)
+
+        # Load capture config for shape info.
+        with (self._capture_dir / "config.json").open() as fh:
+            cap_cfg: dict = json.load(fh)
+
+        n_samples: int = cap_cfg["n_samples"]
+        # response_activations.npy has shape (N, num_layers+1, max_response_len, hidden_dim).
+        # The +1 includes the embedding layer (layer 0); transformer layers are 1..num_layers.
+        # ACT-ViT uses transformer layers only (layers 1..num_layers), so we drop layer 0.
+        num_layers_plus1: int = cap_cfg["num_layers"] + 1
+        max_response_len: int = cap_cfg["max_response_len"]
+        hidden_dim: int = cap_cfg["hidden_dim"]
+
+        # Open memmap arrays.
+        self._acts = np.memmap(
+            str(self._capture_dir / "response_activations.npy"),
+            dtype=np.float16,
+            mode="r",
+            shape=(n_samples, num_layers_plus1, max_response_len, hidden_dim),
+        )
+        self._resp_lens = np.memmap(
+            str(self._capture_dir / "response_len.npy"),
+            dtype=np.int32,
+            mode="r",
+            shape=(n_samples,),
+        )
+
+        # Load labels from meta.jsonl.
+        labels: List[int] = []
+        with (self._capture_dir / "meta.jsonl").open() as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    obj = json.loads(line)
+                    labels.append(int(bool(obj["hallucinated"])))
+        self._labels = np.array(labels, dtype=np.int32)
+
+        # Store the index subset.
+        self._indices = np.asarray(indices, dtype=np.int64)
+
+        # Record shape metadata (dropping embedding layer → L transformer layers).
+        self.num_layers = num_layers_plus1 - 1
+        self.max_response_len = max_response_len
+        self.hidden_dim = hidden_dim
+
+    def __len__(self) -> int:
+        return len(self._indices)
+
+    def __getitem__(self, i: int) -> dict:
+        idx = int(self._indices[i])
+
+        # Load activation for this sample; shape (num_layers+1, R, D) fp16.
+        # Drop the embedding layer (index 0) → (num_layers, R, D).
+        act_raw = self._acts[idx]          # (num_layers+1, R, D) fp16  — numpy memmap slice
+        act = np.array(act_raw, dtype=np.float32)   # copy out of memmap; cast to fp32
+        act = act[1:]                               # drop embedding layer → (L, R, D)
+        act_t = torch.from_numpy(act)              # (L, R, D)
+
+        label = int(self._labels[idx])
+        resp_len = int(self._resp_lens[idx])
+
+        return {
+            "activations": act_t,       # Tensor (L, R, D) float32
+            "label": label,              # int 0/1 (1 = hallucinated)
+            "response_len": resp_len,    # int
+        }

--- a/configs/experiments/baseline_comparison_hotpotqa_memmap.json
+++ b/configs/experiments/baseline_comparison_hotpotqa_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_hotpotqa_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_hotpotqa_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_mmlu_memmap.json
+++ b/configs/experiments/baseline_comparison_mmlu_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_mmlu_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_mmlu_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_nq_memmap.json
+++ b/configs/experiments/baseline_comparison_nq_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_nq_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_nq_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_popqa_memmap.json
+++ b/configs/experiments/baseline_comparison_popqa_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_popqa_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_popqa_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_sciq_memmap.json
+++ b/configs/experiments/baseline_comparison_sciq_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_sciq_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_sciq_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_searchqa_memmap.json
+++ b/configs/experiments/baseline_comparison_searchqa_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/experiments/baseline_comparison_searchqa_qwen3_memmap.json
+++ b/configs/experiments/baseline_comparison_searchqa_qwen3_memmap.json
@@ -7,7 +7,8 @@
     "token_entropy",
     "logprob_baseline",
     "saplma",
-    "llmsknow_probe"
+    "llmsknow_probe",
+    "act_vit"
   ],
   "split_seed": 42,
   "training_seeds": [

--- a/configs/methods/act_vit.json
+++ b/configs/methods/act_vit.json
@@ -1,0 +1,24 @@
+{
+  "name": "act_vit",
+  "routine": "act_vit",
+  "model_params": {
+    "L_p": 8,
+    "N_p": 100,
+    "patch_h": 2,
+    "patch_w": 10,
+    "d_adapter": 256,
+    "d_model": 256,
+    "num_heads": 8,
+    "depth": 4,
+    "dropout": 0.1
+  },
+  "training": {
+    "max_epochs": 50,
+    "batch_size": 64,
+    "lr": 1e-4,
+    "weight_decay": 1e-2
+  },
+  "evaluation": {
+    "metrics": ["auroc"]
+  }
+}

--- a/scripts/profile_act_vit_batch_sweep.py
+++ b/scripts/profile_act_vit_batch_sweep.py
@@ -1,0 +1,258 @@
+"""Profile ACT-ViT training throughput at a sweep of batch sizes.
+
+Loads the dataset + model once, then for each batch size:
+  - constructs a DataLoader with num_workers=4, pin_memory=True, persistent_workers=True
+  - runs N_WARMUP warmup steps
+  - times N_MEASURE steps (fwd + bwd + opt.step), reporting ms/batch, samples/sec
+  - records peak VRAM (torch.cuda.max_memory_allocated / reserved)
+  - polls nvidia-smi via subprocess for steady-state GPU utilization
+
+Designed for the post-fp16-fix path (act_vit_dataset returns fp16 tensors;
+ACTViT.forward casts to fp32 on GPU). Mirrors run_act_vit's training step.
+
+Usage::
+    python scripts/profile_act_vit_batch_sweep.py \\
+        --capture-dir shared/icr_capture/hotpotqa_train_Llama-3.1-8B-Instruct_0-50000 \\
+        --batch-sizes 64,128,256 \\
+        --n-warmup 5 --n-measure 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from activation_research.act_vit import ACTViT, ACTViTConfig
+from activation_research.act_vit_dataset import ACTViTDataset
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--capture-dir",
+        default="shared/icr_capture/hotpotqa_train_Llama-3.1-8B-Instruct_0-50000",
+    )
+    p.add_argument(
+        "--batch-sizes",
+        default="64,128,256",
+        help="Comma-separated list of batch sizes to sweep.",
+    )
+    p.add_argument("--num-workers", type=int, default=4)
+    p.add_argument("--n-warmup", type=int, default=5)
+    p.add_argument("--n-measure", type=int, default=30)
+    p.add_argument(
+        "--n-samples",
+        type=int,
+        default=4096,
+        help="How many dataset indices to expose (>= max batch_size * (n_warmup+n_measure)).",
+    )
+    return p.parse_args()
+
+
+def gpu_util_pct() -> int | None:
+    """Query nvidia-smi for current GPU 0 utilization. Returns None on failure."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits", "-i", "0"],
+            timeout=2,
+        )
+        return int(out.decode().strip().splitlines()[0])
+    except Exception:
+        return None
+
+
+def fmt_bytes(n: int) -> str:
+    return f"{n / 1024**3:.2f} GiB"
+
+
+def profile_batch_size(
+    capture_dir: Path,
+    bs: int,
+    indices: list[int],
+    num_workers: int,
+    n_warmup: int,
+    n_measure: int,
+    input_dim: int,
+) -> dict:
+    """Run warmup + timed loop at one batch size; return stats dict."""
+    print(f"\n=== batch_size={bs} ===", flush=True)
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+    ds = ACTViTDataset(capture_dir, indices)
+    loader = DataLoader(
+        ds,
+        batch_size=bs,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+        persistent_workers=(num_workers > 0),
+        prefetch_factor=4 if num_workers > 0 else None,
+        drop_last=True,
+    )
+
+    cfg = ACTViTConfig(
+        input_dim=input_dim,
+        L_p=8, N_p=100, patch_h=2, patch_w=10,
+        d_adapter=256, d_model=256,
+        num_heads=8, depth=4, mlp_ratio=4.0, dropout=0.1,
+    )
+    model = ACTViT(cfg).cuda()
+    model.train()
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-4, weight_decay=1e-2)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    it = iter(loader)
+    util_samples: list[int] = []
+
+    # warmup
+    print(f"  warmup x{n_warmup}...", flush=True)
+    for _ in range(n_warmup):
+        batch = next(it)
+        acts = batch["activations"].cuda(non_blocking=True)
+        labels = batch["label"].float().cuda(non_blocking=True)
+        opt.zero_grad()
+        logits = model(acts).squeeze(-1)
+        loss = loss_fn(logits, labels)
+        loss.backward()
+        opt.step()
+    torch.cuda.synchronize()
+
+    # reset peak after warmup so we measure steady-state
+    torch.cuda.reset_peak_memory_stats()
+
+    # measured
+    print(f"  measure x{n_measure}...", flush=True)
+    step_times: list[float] = []
+    torch.cuda.synchronize()
+    for i in range(n_measure):
+        t0 = time.time()
+        batch = next(it)
+        acts = batch["activations"].cuda(non_blocking=True)
+        labels = batch["label"].float().cuda(non_blocking=True)
+        opt.zero_grad()
+        logits = model(acts).squeeze(-1)
+        loss = loss_fn(logits, labels)
+        loss.backward()
+        opt.step()
+        torch.cuda.synchronize()
+        step_times.append(time.time() - t0)
+        # Sample GPU util mid-stride (skip first/last)
+        if 5 <= i < n_measure - 2:
+            u = gpu_util_pct()
+            if u is not None:
+                util_samples.append(u)
+
+    ms_per_step = sum(step_times) / len(step_times) * 1000
+    samples_per_sec = bs / (ms_per_step / 1000)
+    peak_alloc = torch.cuda.max_memory_allocated()
+    peak_reserved = torch.cuda.max_memory_reserved()
+    util_mean = sum(util_samples) / len(util_samples) if util_samples else None
+
+    stats = dict(
+        batch_size=bs,
+        ms_per_step=ms_per_step,
+        samples_per_sec=samples_per_sec,
+        peak_alloc_bytes=peak_alloc,
+        peak_reserved_bytes=peak_reserved,
+        gpu_util_mean_pct=util_mean,
+        n_samples_util=len(util_samples),
+    )
+    print(
+        f"  bs={bs}: {ms_per_step:7.1f} ms/step  "
+        f"{samples_per_sec:7.1f} samp/s  "
+        f"VRAM_alloc={fmt_bytes(peak_alloc)} reserved={fmt_bytes(peak_reserved)}  "
+        f"GPU_util={util_mean if util_mean is None else f'{util_mean:.0f}%'}",
+        flush=True,
+    )
+
+    # cleanup before next iter
+    del model, opt, loader, it, ds
+    torch.cuda.empty_cache()
+    return stats
+
+
+def main() -> int:
+    args = parse_args()
+    capture_dir = (PROJECT_ROOT / args.capture_dir).resolve()
+    assert capture_dir.exists(), f"capture dir not found: {capture_dir}"
+
+    with (capture_dir / "config.json").open() as fh:
+        cap_cfg = json.load(fh)
+    n_total = cap_cfg["n_samples"]
+    hidden_dim = cap_cfg["hidden_dim"]
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"capture: n_samples={n_total}, hidden_dim={hidden_dim}, "
+          f"layers={cap_cfg['num_layers']}, R={cap_cfg['max_response_len']}")
+
+    n_expose = min(n_total, args.n_samples)
+    indices = list(range(n_expose))
+
+    batch_sizes = [int(b) for b in args.batch_sizes.split(",")]
+    print(f"sweep: batch_sizes={batch_sizes}, n_warmup={args.n_warmup}, "
+          f"n_measure={args.n_measure}, num_workers={args.num_workers}")
+
+    results = []
+    for bs in batch_sizes:
+        if bs * (args.n_warmup + args.n_measure) > n_expose:
+            print(f"\nSKIP bs={bs}: needs {bs*(args.n_warmup+args.n_measure)} samples, have {n_expose}")
+            continue
+        try:
+            stats = profile_batch_size(
+                capture_dir=capture_dir,
+                bs=bs,
+                indices=indices,
+                num_workers=args.num_workers,
+                n_warmup=args.n_warmup,
+                n_measure=args.n_measure,
+                input_dim=hidden_dim,
+            )
+            results.append(stats)
+        except torch.cuda.OutOfMemoryError as e:
+            print(f"\nOOM at bs={bs}: {e}")
+            torch.cuda.empty_cache()
+            results.append({"batch_size": bs, "oom": True, "error": str(e)})
+            # Don't try larger batch sizes after OOM
+            break
+
+    # Summary table
+    print("\n" + "=" * 78)
+    print(f"{'bs':>6}  {'ms/step':>9}  {'samp/s':>9}  {'VRAM alloc':>12}  {'VRAM resv':>12}  {'util':>6}")
+    print("-" * 78)
+    for r in results:
+        if r.get("oom"):
+            print(f"{r['batch_size']:>6}  OOM")
+            continue
+        util = "—" if r["gpu_util_mean_pct"] is None else f"{r['gpu_util_mean_pct']:.0f}%"
+        print(
+            f"{r['batch_size']:>6}  "
+            f"{r['ms_per_step']:>9.1f}  "
+            f"{r['samples_per_sec']:>9.1f}  "
+            f"{fmt_bytes(r['peak_alloc_bytes']):>12}  "
+            f"{fmt_bytes(r['peak_reserved_bytes']):>12}  "
+            f"{util:>6}"
+        )
+    print("=" * 78)
+
+    # Save JSON for downstream
+    out_path = PROJECT_ROOT / "runs" / "profile_act_vit_batch_sweep.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w") as fh:
+        json.dump(results, fh, indent=2)
+    print(f"\nresults saved: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/results_table.py
+++ b/scripts/results_table.py
@@ -178,6 +178,7 @@ _TRAINING_METRIC_KEYS = {
     "llmsknow_probe":             ("auroc", "sweep_best_dev_auroc"),
     "multi_layer_linear_probe":   ("auroc",),
     "icr_probe":                  ("auroc",),
+    "act_vit":                    ("auroc",),
     "token_entropy":              ("mean_entropy_auroc", "mean_logprob_auroc",
                                    "min_logprob_auroc"),
     "logprob_baseline":           ("mean_logprob_auroc", "perplexity_auroc",

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1877,12 +1877,15 @@ def run_act_vit(
     persistent_workers = experiment_cfg.get("persistent_workers", True) and num_workers > 0
     batch_size = train_cfg["batch_size"]
 
+    prefetch_factor = 4 if num_workers > 0 else None
     train_loader = DataLoader(
         train_ds,
         batch_size=batch_size,
         shuffle=True,
         num_workers=num_workers,
         persistent_workers=persistent_workers,
+        pin_memory=True,
+        prefetch_factor=prefetch_factor,
     )
     val_loader = DataLoader(
         val_ds,
@@ -1890,6 +1893,8 @@ def run_act_vit(
         shuffle=False,
         num_workers=num_workers,
         persistent_workers=persistent_workers,
+        pin_memory=True,
+        prefetch_factor=prefetch_factor,
     )
 
     # Build model
@@ -1937,8 +1942,8 @@ def run_act_vit(
         epoch_t0 = time.time()
         step_t0 = time.time()
         for step_idx, batch in enumerate(train_loader):
-            x = batch["activations"].to(eval_device)       # (B, L, N, D)
-            labels_b = batch["label"].float().to(eval_device)  # (B,)
+            x = batch["activations"].to(eval_device, non_blocking=True)       # (B, L, N, D)
+            labels_b = batch["label"].float().to(eval_device, non_blocking=True)  # (B,)
             logits = model(x).squeeze(1)                   # (B,)
             loss = loss_fn(logits, labels_b)
             optimizer.zero_grad()
@@ -1961,7 +1966,7 @@ def run_act_vit(
         val_preds, val_labels = [], []
         with torch.no_grad():
             for batch in val_loader:
-                x = batch["activations"].to(eval_device)
+                x = batch["activations"].to(eval_device, non_blocking=True)
                 logits = model(x).squeeze(1)
                 val_preds.append(torch.sigmoid(logits).cpu())
                 val_labels.append(batch["label"].cpu())

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -30,6 +30,7 @@ import os
 import platform
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # Add project root to path
@@ -1930,9 +1931,12 @@ def run_act_vit(
     best_val_auroc = -1.0
     best_epoch = -1
 
+    log_every = 50
     for epoch in range(max_epochs):
         model.train()
-        for batch in train_loader:
+        epoch_t0 = time.time()
+        step_t0 = time.time()
+        for step_idx, batch in enumerate(train_loader):
             x = batch["activations"].to(eval_device)       # (B, L, N, D)
             labels_b = batch["label"].float().to(eval_device)  # (B,)
             logits = model(x).squeeze(1)                   # (B,)
@@ -1941,6 +1945,16 @@ def run_act_vit(
             loss.backward()
             optimizer.step()
             scheduler.step()
+
+            if (step_idx + 1) % log_every == 0:
+                window_s = time.time() - step_t0
+                ms_per_step = 1000.0 * window_s / log_every
+                samples_per_sec = (log_every * batch_size) / window_s
+                logger.info(
+                    f"[act_vit] epoch={epoch+1}/{max_epochs} step={step_idx+1}/{len(train_loader)} "
+                    f"ms/step={ms_per_step:.0f} samp/s={samples_per_sec:.0f} loss={loss.item():.4f}"
+                )
+                step_t0 = time.time()
 
         # Validation AUROC
         model.eval()
@@ -1967,8 +1981,9 @@ def run_act_vit(
                 os.path.join(artifact_dir, "best_checkpoint.pt"),
             )
 
-        logger.debug(
-            f"[act_vit] epoch={epoch+1}/{max_epochs}  val_auroc={val_auroc:.4f}"
+        epoch_wall_s = time.time() - epoch_t0
+        logger.info(
+            f"[act_vit] epoch={epoch+1}/{max_epochs}  val_auroc={val_auroc:.4f}  wall={epoch_wall_s:.0f}s"
         )
 
     # Load best checkpoint (if any was saved)

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -1808,6 +1808,225 @@ def run_icr_probe(
     return eval_metrics, predictions
 
 
+def run_act_vit(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    *,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """Train and evaluate ACT-ViT (arXiv:2510.00296) on full activation tensors.
+
+    Treats the full (layers × response-tokens × hidden-dim) activation tensor
+    of each generation as an "image" and classifies it with a Vision Transformer.
+    Reads directly from icr_capture memmap directories.
+    """
+    import math
+
+    import torch
+    from sklearn.metrics import roc_auc_score
+    from torch.utils.data import DataLoader
+
+    from activation_research.act_vit import ACTViT, ACTViTConfig
+    from activation_research.act_vit_dataset import ACTViTDataset
+    from activation_research.memmap_activation_parser import MemmapActivationParser
+
+    train_cfg = method_cfg["training"]
+    model_params = method_cfg.get("model_params", {})
+
+    icr_cfg = dataset_cfg["icr_capture"]
+    split_seed = experiment_cfg.get("split_seed", 42)
+
+    # Build split indices from MemmapActivationParser (same pattern as other runners).
+    train_parser = MemmapActivationParser(
+        icr_cfg["train_dir"],
+        random_seed=split_seed,
+        split_strategy="three_way",
+    )
+    train_df = train_parser.df[train_parser.df["split"] == "train"]
+    val_df = train_parser.df[train_parser.df["split"] == "val"]
+    train_idx = train_df["sample_index"].values
+    val_idx = val_df["sample_index"].values
+
+    if test_ap is not None:
+        # test_ap is a MemmapActivationParser for the test capture
+        test_parser = MemmapActivationParser(
+            icr_cfg["test_dir"],
+            random_seed=split_seed,
+            split_strategy="none",
+        )
+    else:
+        test_parser = MemmapActivationParser(
+            icr_cfg["test_dir"],
+            random_seed=split_seed,
+            split_strategy="none",
+        )
+    test_df = test_parser.df
+    test_idx = test_df["sample_index"].values
+
+    train_ds = ACTViTDataset(icr_cfg["train_dir"], train_idx)
+    val_ds = ACTViTDataset(icr_cfg["train_dir"], val_idx)
+    test_ds = ACTViTDataset(icr_cfg["test_dir"], test_idx)
+
+    num_workers = experiment_cfg.get("num_workers", 4)
+    persistent_workers = experiment_cfg.get("persistent_workers", True) and num_workers > 0
+    batch_size = train_cfg["batch_size"]
+
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        persistent_workers=persistent_workers,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        persistent_workers=persistent_workers,
+    )
+
+    # Build model
+    cfg = ACTViTConfig(
+        input_dim=dataset_cfg["input_dim"],
+        L_p=model_params.get("L_p", 8),
+        N_p=model_params.get("N_p", 100),
+        patch_h=model_params.get("patch_h", 2),
+        patch_w=model_params.get("patch_w", 10),
+        d_adapter=model_params.get("d_adapter", 256),
+        d_model=model_params.get("d_model", 256),
+        num_heads=model_params.get("num_heads", 8),
+        depth=model_params.get("depth", 4),
+        mlp_ratio=model_params.get("mlp_ratio", 4.0),
+        dropout=model_params.get("dropout", 0.1),
+    )
+    model = ACTViT(cfg)
+
+    eval_device = torch.device(
+        device if device != "auto" else ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    model.to(eval_device)
+
+    # Optimizer + cosine LR schedule
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=train_cfg.get("lr", 1e-4),
+        weight_decay=train_cfg.get("weight_decay", 1e-2),
+    )
+    max_epochs = train_cfg.get("max_epochs", 50)
+    total_steps = max_epochs * len(train_loader)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=total_steps)
+
+    # Artifact dir for checkpoints
+    artifact_dir = os.path.join(output_dir, "artifacts")
+    os.makedirs(artifact_dir, exist_ok=True)
+
+    loss_fn = torch.nn.BCEWithLogitsLoss()
+    best_val_auroc = -1.0
+    best_epoch = -1
+
+    for epoch in range(max_epochs):
+        model.train()
+        for batch in train_loader:
+            x = batch["activations"].to(eval_device)       # (B, L, N, D)
+            labels_b = batch["label"].float().to(eval_device)  # (B,)
+            logits = model(x).squeeze(1)                   # (B,)
+            loss = loss_fn(logits, labels_b)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            scheduler.step()
+
+        # Validation AUROC
+        model.eval()
+        val_preds, val_labels = [], []
+        with torch.no_grad():
+            for batch in val_loader:
+                x = batch["activations"].to(eval_device)
+                logits = model(x).squeeze(1)
+                val_preds.append(torch.sigmoid(logits).cpu())
+                val_labels.append(batch["label"].cpu())
+
+        val_scores = torch.cat(val_preds).numpy()
+        val_lbls = torch.cat(val_labels).numpy()
+        if len(set(val_lbls.tolist())) >= 2:
+            val_auroc = float(roc_auc_score(val_lbls, val_scores))
+        else:
+            val_auroc = float("nan")
+
+        if not math.isnan(val_auroc) and val_auroc > best_val_auroc:
+            best_val_auroc = val_auroc
+            best_epoch = epoch
+            torch.save(
+                {"epoch": epoch, "model_state_dict": model.state_dict()},
+                os.path.join(artifact_dir, "best_checkpoint.pt"),
+            )
+
+        logger.debug(
+            f"[act_vit] epoch={epoch+1}/{max_epochs}  val_auroc={val_auroc:.4f}"
+        )
+
+    # Load best checkpoint (if any was saved)
+    best_ckpt = os.path.join(artifact_dir, "best_checkpoint.pt")
+    if os.path.exists(best_ckpt):
+        ckpt = torch.load(best_ckpt, map_location=eval_device, weights_only=True)
+        model.load_state_dict(ckpt["model_state_dict"])
+
+    torch.save(
+        {"model_state_dict": model.state_dict()},
+        os.path.join(artifact_dir, "final_weights.pt"),
+    )
+
+    # Test evaluation
+    test_loader = DataLoader(
+        test_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        persistent_workers=persistent_workers,
+    )
+    model.eval()
+    all_preds, all_labels = [], []
+    with torch.no_grad():
+        for batch in test_loader:
+            x = batch["activations"].to(eval_device)
+            logits = model(x).squeeze(1)
+            all_preds.append(torch.sigmoid(logits).cpu())
+            all_labels.append(batch["label"].cpu())
+
+    scores_np = torch.cat(all_preds).numpy()
+    labels_np = torch.cat(all_labels).numpy()
+    if len(set(labels_np.tolist())) >= 2:
+        auroc = float(roc_auc_score(labels_np, scores_np))
+    else:
+        auroc = float("nan")
+
+    eval_metrics = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "split_seed": split_seed,
+        "n_train": len(train_ds),
+        "n_val": len(val_ds),
+        "n_test": len(test_ds),
+        "auroc": auroc,
+        "best_val_auroc": best_val_auroc,
+        "best_epoch": best_epoch,
+    }
+    predictions = [
+        {"example_id": i, "score_halu": float(s), "label_halu": int(l), "split": "test"}
+        for i, (s, l) in enumerate(zip(scores_np, labels_np))
+    ]
+
+    write_run_manifest(output_dir)
+    return eval_metrics, predictions
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -2464,6 +2683,11 @@ def main() -> None:
                         )
                     elif routine == "icr_probe":
                         eval_metrics, predictions = run_icr_probe(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "act_vit":
+                        eval_metrics, predictions = run_act_vit(
                             ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
                             test_ap=test_ap,
                         )


### PR DESCRIPTION
## Summary

Closes #93. Implements ACT-ViT (arXiv:2510.00296, Bar-Shalom et al.) — a Vision Transformer classifier that treats the full `(layers × response-tokens × hidden-dim)` activation tensor of a generation as an "image".

- Spatial adaptive max-pool `(L, N) → (L_p, N_p)` per hidden-dim slice
- Per-LLM `LinearAdapter` `D → D'` (registered by `input_dim`)
- 2D patch embedding tiling the `(L_p, N_p)` grid
- Standard ViT encoder with CLS token → binary logit

## Files added / changed

| File | Change |
|------|--------|
| `activation_research/act_vit.py` | New — `ACTViTConfig` dataclass + `ACTViT` nn.Module |
| `activation_research/act_vit_dataset.py` | New — `ACTViTDataset` reading directly from memmap captures |
| `configs/methods/act_vit.json` | New — paper-default hyperparameters |
| `scripts/run_experiment.py` | Added `run_act_vit()` runner + `elif routine == "act_vit"` dispatch |
| `scripts/results_table.py` | Registered `act_vit` → `("auroc",)` metric keys |
| `configs/experiments/baseline_comparison_*_memmap.json` (×12) | Added `"act_vit"` to `"methods"` list |

## Sanity check

CPU-only forward-pass smoke test passes:
```
x = torch.randn(2, 32, 50, 64)  # (B=2, L=32, N=50, D=64)
logits = ACTViT(ACTViTConfig(input_dim=64, d_adapter=32, d_model=32, num_heads=4, depth=2))(x)
# → torch.Size([2, 1])  ✓
```
Both fp32 and fp16 inputs work (cast to fp32 inside forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)