### PR TITLE
feat(#102): shared-trunk projection-head variant (D2) + C0 unsupervised baseline

### DIFF
--- a/activation_research/model.py
+++ b/activation_research/model.py
@@ -259,6 +259,196 @@ class TwinConcatModel(nn.Module):
         return torch.cat([self.head_a(x), self.head_b(x)], dim=-1)
 
 
+class SharedTrunkSplitOutputCompressor(nn.Module):
+    """D1 shared-trunk variant: a single trunk with ``final_dim = 2 * half_dim``.
+
+    During training the output is sliced into two halves and each half receives
+    its own SupCon loss with opposite ``ignore_label``::
+
+        z = compressor(x)                   # (B, 2D)
+        z_A, z_B = z[:, :D], z[:, D:]       # each (B, D)
+        L_supcon_A = SupCon(z_A, labels, ignore_label=1)
+        L_supcon_B = SupCon(z_B, labels, ignore_label=0)
+        L_recon    = recon_loss(decoder(z), logprob_target)
+        loss       = L_supcon_A + L_supcon_B + λ · L_recon
+
+    The reconstruction decoder operates on the full ``z`` (2D-dim).
+
+    **Eval surface:** full ``z`` (2D-dim) — KNN/Maha only (no cosine).
+
+    Parameters
+    ----------
+    input_dim : int
+        Activation dimension (e.g. 4096 for Llama-8B).
+    half_dim : int
+        ``D``; total output is ``2 * half_dim``.
+    dropout, input_dropout : float
+    normalize_input : bool
+    recon_seq_len, recon_hidden_dim, recon_lambda, logprob_var_threshold :
+        Forwarded to the inner ``LogprobReconProgressiveCompressor``.
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 4096,
+        half_dim: int = 256,
+        dropout: float = 0.1,
+        input_dropout: float = 0.2,
+        normalize_input: bool = False,
+        recon_seq_len: int = 64,
+        recon_hidden_dim: int = 256,
+        recon_lambda: float = 1.0,
+        logprob_var_threshold: float = 1e-4,
+    ):
+        super().__init__()
+        self.half_dim = int(half_dim)
+        self.recon_lambda = float(recon_lambda)
+
+        self._inner = LogprobReconProgressiveCompressor(
+            input_dim=int(input_dim),
+            final_dim=2 * self.half_dim,
+            dropout=float(dropout),
+            input_dropout=float(input_dropout),
+            normalize_input=bool(normalize_input),
+            recon_seq_len=int(recon_seq_len),
+            recon_hidden_dim=int(recon_hidden_dim),
+            recon_lambda=float(recon_lambda),
+            logprob_var_threshold=float(logprob_var_threshold),
+        )
+
+    def recon_loss(self, logprob_pred: torch.Tensor, logprob_target: torch.Tensor):
+        """Delegate to the inner module's ``recon_loss``."""
+        return self._inner.recon_loss(logprob_pred, logprob_target)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return full trunk embedding ``z`` of shape ``(B, 2*half_dim)``.
+
+        This is the eval surface — the two halves are NOT separated here.
+        """
+        return self._inner(x)
+
+    def forward_slices(self, x: torch.Tensor):
+        """Return ``(z, z_A, z_B)`` for the dual-loss trainer.
+
+        z   : (B, 2*half_dim) — full embedding (also passed to decoder)
+        z_A : (B, half_dim)   — first half  (trained with ignore_label=1)
+        z_B : (B, half_dim)   — second half (trained with ignore_label=0)
+        """
+        z, logprob_pred = self._inner.forward_with_recon(x)
+        z_A = z[:, : self.half_dim]
+        z_B = z[:, self.half_dim :]
+        return z, z_A, z_B, logprob_pred
+
+    def forward_with_recon(self, x: torch.Tensor):
+        """Return ``(z, logprob_pred)`` from the inner module."""
+        return self._inner.forward_with_recon(x)
+
+
+class SharedTrunkProjectionHeadCompressor(nn.Module):
+    """D2 shared-trunk variant: trunk + two small projection MLPs.
+
+    SupCon losses are computed on the head outputs; the decoder reconstructs
+    logprobs from the trunk embedding.  At eval-time ``forward(x)`` returns
+    **only the trunk** ``z`` — heads are discarded.
+
+    Training objective::
+
+        z  = compressor(x)                  # (B, trunk_dim)
+        zA = head_A(z)                       # (B, head_dim)
+        zB = head_B(z)                       # (B, head_dim)
+        L_supcon_A = SupCon(zA, labels, ignore_label=1)
+        L_supcon_B = SupCon(zB, labels, ignore_label=0)
+        L_recon    = recon_loss(decoder(z), logprob_target)
+        loss       = L_supcon_A + L_supcon_B + λ · L_recon
+
+    **Eval surface:** trunk ``z`` (trunk_dim) — KNN/Maha + cosine all apply.
+
+    Parameters
+    ----------
+    input_dim : int
+        Activation dimension (e.g. 4096 for Llama-8B).
+    trunk_dim : int
+        Trunk output dimension (eval surface).
+    head_dim : int
+        Projection head output dimension (used for SupCon only).
+    head_hidden_dim : int
+        Hidden dimension of each ``Linear → GELU → Linear`` projection head.
+    dropout, input_dropout : float
+    normalize_input : bool
+    recon_seq_len, recon_hidden_dim, recon_lambda, logprob_var_threshold :
+        Forwarded to the inner ``LogprobReconProgressiveCompressor``.
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 4096,
+        trunk_dim: int = 512,
+        head_dim: int = 256,
+        head_hidden_dim: int = 256,
+        dropout: float = 0.1,
+        input_dropout: float = 0.2,
+        normalize_input: bool = False,
+        recon_seq_len: int = 64,
+        recon_hidden_dim: int = 256,
+        recon_lambda: float = 1.0,
+        logprob_var_threshold: float = 1e-4,
+    ):
+        super().__init__()
+        self.trunk_dim = int(trunk_dim)
+        self.head_dim = int(head_dim)
+        self.recon_lambda = float(recon_lambda)
+
+        self._inner = LogprobReconProgressiveCompressor(
+            input_dim=int(input_dim),
+            final_dim=int(trunk_dim),
+            dropout=float(dropout),
+            input_dropout=float(input_dropout),
+            normalize_input=bool(normalize_input),
+            recon_seq_len=int(recon_seq_len),
+            recon_hidden_dim=int(recon_hidden_dim),
+            recon_lambda=float(recon_lambda),
+            logprob_var_threshold=float(logprob_var_threshold),
+        )
+
+        self.head_A = nn.Sequential(
+            nn.Linear(int(trunk_dim), int(head_hidden_dim)),
+            nn.GELU(),
+            nn.Linear(int(head_hidden_dim), int(head_dim)),
+        )
+        self.head_B = nn.Sequential(
+            nn.Linear(int(trunk_dim), int(head_hidden_dim)),
+            nn.GELU(),
+            nn.Linear(int(head_hidden_dim), int(head_dim)),
+        )
+
+    def recon_loss(self, logprob_pred: torch.Tensor, logprob_target: torch.Tensor):
+        """Delegate to the inner module's ``recon_loss``."""
+        return self._inner.recon_loss(logprob_pred, logprob_target)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Return trunk embedding ``z`` of shape ``(B, trunk_dim)``.
+
+        Projection heads are NOT called — this is the eval surface.
+        """
+        return self._inner(x)
+
+    def forward_with_heads(self, x: torch.Tensor):
+        """Return ``(z, zA, zB)`` for the dual-loss trainer.
+
+        z  : (B, trunk_dim)  — trunk (also the eval surface + recon input)
+        zA : (B, head_dim)   — head A output (trained with ignore_label=1)
+        zB : (B, head_dim)   — head B output (trained with ignore_label=0)
+        """
+        z, logprob_pred = self._inner.forward_with_recon(x)
+        zA = self.head_A(z)
+        zB = self.head_B(z)
+        return z, zA, zB, logprob_pred
+
+    def forward_with_recon(self, x: torch.Tensor):
+        """Return ``(z, logprob_pred)`` from the inner module."""
+        return self._inner.forward_with_recon(x)
+
+
 class LogprobAttnReconProgressiveCompressor(nn.Module):
     """ProgressiveCompressor with combined logprob (Mechanism F) + attention
     summary (Mechanism K) auxiliary reconstruction heads.

--- a/activation_research/training.py
+++ b/activation_research/training.py
@@ -1102,6 +1102,404 @@ def _contrastive_collate_with_logprob_attn(batch):
     return out
 
 
+def train_contrastive_logprob_recon_dualloss(
+    model,
+    train_dataset,
+    test_dataset=None,
+    epochs=10,
+    batch_size=512,
+    lr=1e-6,
+    temperature=0.07,
+    device="cuda",
+    num_workers=16,
+    sub_batch_size=64,
+    checkpoint_dir="checkpoints",
+    save_every=1,
+    resume_from=None,
+    persistent_workers=True,
+    cleanup_legacy_checkpoints: bool = True,
+    snapshot_every: int = 0,
+    snapshot_keep_last: int = 5,
+    same_sample_weight=1.0,
+    same_class_weight=1.0,
+    balanced_sampling=False,
+    recon_lambda: float = None,
+    use_infinite_index_stream: bool = False,
+    infinite_stream_shuffle: bool = True,
+    infinite_stream_seed: int = 0,
+    steps_per_epoch_override: int = None,
+    grad_clip_norm: float = None,
+    augment_fn=None,
+    ignore_labels: tuple = (1, 0),
+):
+    """Train a ``SharedTrunkSplitOutputCompressor`` or ``SharedTrunkProjectionHeadCompressor``
+    with a dual SupCon loss over two output heads plus auxiliary logprob reconstruction.
+
+    Loss per step:
+
+        L_A = SupCon(z_A, labels, ignore_label=ignore_labels[0])
+        L_B = SupCon(z_B, labels, ignore_label=ignore_labels[1])
+        L   = L_A + L_B + λ · L_recon(decoder(z), ℓ)
+
+    For ``SharedTrunkSplitOutputCompressor`` (D1), ``z`` is the full 2D output,
+    ``z_A`` and ``z_B`` are sliced halves.  For
+    ``SharedTrunkProjectionHeadCompressor`` (D2), ``z`` is the trunk, ``z_A``
+    and ``z_B`` are projection head outputs.
+
+    All other training mechanics (checkpointing, AMP, grad clip, infinite stream,
+    balanced sampler, augmentations) mirror ``train_contrastive_logprob_recon``.
+
+    Parameters
+    ----------
+    model : SharedTrunkSplitOutputCompressor or SharedTrunkProjectionHeadCompressor
+    train_dataset, test_dataset : dataset
+    epochs, batch_size, lr, temperature, device, num_workers, sub_batch_size,
+    checkpoint_dir, save_every, resume_from, persistent_workers,
+    cleanup_legacy_checkpoints, snapshot_every, snapshot_keep_last,
+    same_sample_weight, same_class_weight, balanced_sampling,
+    use_infinite_index_stream, infinite_stream_shuffle,
+    infinite_stream_seed, steps_per_epoch_override, grad_clip_norm, augment_fn :
+        Same semantics as ``train_contrastive_logprob_recon``.
+    recon_lambda : float or None
+        Override ``model.recon_lambda``.  Pass ``None`` to use the model default.
+    ignore_labels : tuple of (int, int)
+        ``(ignore_label_A, ignore_label_B)`` — head A and head B respectively.
+        Default ``(1, 0)``.
+    """
+    from activation_research.model import (
+        SharedTrunkSplitOutputCompressor,
+        SharedTrunkProjectionHeadCompressor,
+    )
+
+    _lambda = float(recon_lambda) if recon_lambda is not None else model.recon_lambda
+
+    if steps_per_epoch_override is not None and not use_infinite_index_stream:
+        raise ValueError("steps_per_epoch_override requires use_infinite_index_stream=True")
+
+    base_dataset_len = None
+    if use_infinite_index_stream:
+        if not hasattr(train_dataset, "__len__"):
+            raise TypeError("use_infinite_index_stream=True requires train_dataset to have __len__")
+        base_dataset_len = len(train_dataset)
+        sub_batch_size = batch_size
+
+    # Choose how to call the model depending on its variant.
+    _is_d1 = isinstance(model, SharedTrunkSplitOutputCompressor)
+
+    def _call_model_dual(m, x):
+        """Return (z, z_A, z_B, logprob_pred) from the appropriate helper."""
+        if _is_d1:
+            return m.forward_slices(x)  # (z_full, z_A, z_B, logprob_pred)
+        else:
+            return m.forward_with_heads(x)  # (z_trunk, z_A, z_B, logprob_pred)
+
+    assert batch_size % sub_batch_size == 0, "batch_size must be divisible by sub_batch_size"
+
+    os.makedirs(checkpoint_dir, exist_ok=True)
+
+    model = model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    loss_fn_A = SupConLoss(
+        temperature=temperature,
+        ignore_label=int(ignore_labels[0]),
+        same_sample_weight=same_sample_weight,
+        same_class_weight=same_class_weight,
+    )
+    loss_fn_B = SupConLoss(
+        temperature=temperature,
+        ignore_label=int(ignore_labels[1]),
+        same_sample_weight=same_sample_weight,
+        same_class_weight=same_class_weight,
+    )
+
+    start_epoch = 0
+    best_loss = float("inf")
+
+    if resume_from is not None:
+        checkpoint_path = (
+            resume_from if os.path.isabs(resume_from) else os.path.join(checkpoint_dir, resume_from)
+        )
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"Resume checkpoint not found: {checkpoint_path}")
+        ckpt = torch.load(checkpoint_path, map_location=device)
+        model.load_state_dict(ckpt["model_state_dict"])
+        optimizer.load_state_dict(ckpt["optimizer_state_dict"])
+        start_epoch = ckpt.get("epoch", 0) + 1
+        best_loss = ckpt.get("best_loss", float("inf"))
+        logger.info(f"Resumed training from epoch {start_epoch}")
+
+    is_iterable = isinstance(train_dataset, IterableDataset)
+    if use_infinite_index_stream and not is_iterable:
+        train_dataset = InfiniteIndexStream(
+            train_dataset,
+            shuffle=bool(infinite_stream_shuffle),
+            seed=int(infinite_stream_seed),
+        )
+        is_iterable = True
+    if is_iterable and balanced_sampling:
+        logger.warning("Balanced sampling is not supported for iterable datasets; disabling sampler.")
+    sampler = (
+        _build_balanced_sampler(train_dataset)
+        if balanced_sampling and not is_iterable
+        else None
+    )
+    use_persistent_workers = bool(persistent_workers and num_workers and num_workers > 0)
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=sub_batch_size,
+        shuffle=(sampler is None and not is_iterable),
+        sampler=sampler,
+        num_workers=num_workers,
+        pin_memory=True,
+        persistent_workers=use_persistent_workers,
+        collate_fn=_contrastive_collate_with_logprob,
+    )
+
+    steps_per_epoch = None
+    train_iter = None
+    if use_infinite_index_stream:
+        inferred = int(math.ceil(base_dataset_len / float(batch_size)))
+        if steps_per_epoch_override is not None:
+            steps_per_epoch = int(steps_per_epoch_override)
+        else:
+            steps_per_epoch = inferred
+        train_iter = iter(train_loader)
+
+    test_loader = None
+    if test_dataset is not None:
+        test_loader = DataLoader(
+            test_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            pin_memory=True,
+            persistent_workers=use_persistent_workers,
+            collate_fn=_contrastive_collate_with_logprob,
+        )
+
+    from utils.progress import tqdm as _tqdm
+
+    for epoch in _tqdm(range(start_epoch, epochs), desc="Epochs"):
+        logger.info(f"Starting epoch {epoch + 1}/{epochs}")
+        model.train()
+
+        total_loss = total_supcon_a = total_supcon_b = total_recon = 0.0
+        total_intra_cos = total_intra_inter = 0.0
+        n_batches = 0
+        _diag_steps = 0  # count of steps where per-head cosine diagnostics are logged
+
+        if use_infinite_index_stream:
+            total_steps = steps_per_epoch
+            loop = _tqdm(range(total_steps), desc=f"Epoch {epoch + 1}/{epochs}", leave=False)
+        else:
+            try:
+                total_steps = len(train_loader)
+            except TypeError:
+                total_steps = None
+            loop = _tqdm(train_loader, desc=f"Epoch {epoch + 1}/{epochs}", leave=False)
+
+        buffer_views = []
+        buffer_view_indices = []
+        buffer_logprobs = []
+        buffer_labels = []
+        buffer_sample_ids = []
+
+        i = 0
+        for _loop_item in loop:
+            i += 1
+            batch = next(train_iter) if use_infinite_index_stream else _loop_item
+
+            views = batch["views_activations"].to(device, non_blocking=True)
+            buffer_views.append(views)
+
+            if "view_indices" in batch:
+                buffer_view_indices.append(batch["view_indices"].to(device, non_blocking=True))
+
+            if "logprob" in batch:
+                buffer_logprobs.append(batch["logprob"].to(device, non_blocking=True))
+
+            labels = batch["halu"].to(device, non_blocking=True)
+            if labels.dim() == 0:
+                labels = labels.unsqueeze(0)
+            elif labels.dim() > 1:
+                labels = labels.view(-1)
+            buffer_labels.append(labels)
+
+            hashkeys = batch["hashkey"]
+            if isinstance(hashkeys, str):
+                hashkeys = [hashkeys]
+            sample_ids = torch.tensor(
+                [hash(hk) % 1_000_000 for hk in hashkeys], dtype=torch.long, device=device
+            )
+            buffer_sample_ids.append(sample_ids)
+
+            buffer_full = len(buffer_views) * sub_batch_size == batch_size
+            last_batch = total_steps is not None and i == total_steps
+
+            if buffer_full or last_batch:
+                views_full = torch.cat(buffer_views, dim=0)
+                view_idx_full = torch.cat(buffer_view_indices, dim=0) if buffer_view_indices else None
+                logprob_full = torch.cat(buffer_logprobs, dim=0) if buffer_logprobs else None
+                labels_full = torch.cat(buffer_labels, dim=0)
+                sample_ids_full = torch.cat(buffer_sample_ids, dim=0)
+
+                buffer_views = []
+                buffer_view_indices = []
+                buffer_logprobs = []
+                buffer_labels = []
+                buffer_sample_ids = []
+
+                if augment_fn is not None:
+                    if n_batches == 0:
+                        _pre = torch.nn.functional.cosine_similarity(
+                            views_full[:, 0].reshape(views_full.shape[0], -1),
+                            views_full[:, 1].reshape(views_full.shape[0], -1),
+                            dim=1,
+                        ).mean()
+                    views_full = augment_fn(views_full, labels_full)
+                    if n_batches == 0:
+                        _post = torch.nn.functional.cosine_similarity(
+                            views_full[:, 0].reshape(views_full.shape[0], -1),
+                            views_full[:, 1].reshape(views_full.shape[0], -1),
+                            dim=1,
+                        ).mean()
+                        logger.info(f"aug_view_cosine: pre={_pre:.4f} post={_post:.4f} delta={_post - _pre:.4f}")
+
+                bsz, num_views, seq_len, hidden_dim = views_full.shape
+                x_flat = views_full.reshape(bsz * num_views, seq_len, hidden_dim)
+
+                z_flat, zA_flat, zB_flat, logprob_pred_flat = _call_model_dual(model, x_flat)
+
+                # Reshape for SupCon: (B, num_views, dim)
+                z_views = z_flat.reshape(bsz, num_views, -1)
+                zA_views = zA_flat.reshape(bsz, num_views, -1)
+                zB_views = zB_flat.reshape(bsz, num_views, -1)
+
+                # Per-head view cosine diagnostic (first 100 steps)
+                if _diag_steps < 100:
+                    with torch.no_grad():
+                        _cos_A = torch.nn.functional.cosine_similarity(
+                            zA_views[:, 0], zA_views[:, 1], dim=-1
+                        ).mean().item()
+                        _cos_B = torch.nn.functional.cosine_similarity(
+                            zB_views[:, 0], zB_views[:, 1], dim=-1
+                        ).mean().item()
+                    logger.debug(f"step={i} view_cos_A={_cos_A:.4f} view_cos_B={_cos_B:.4f}")
+                    _diag_steps += 1
+
+                supcon_A = loss_fn_A(zA_views, labels=labels_full, sample_ids=sample_ids_full)
+                supcon_B = loss_fn_B(zB_views, labels=labels_full, sample_ids=sample_ids_full)
+
+                # Auxiliary reconstruction loss
+                recon = torch.zeros(1, device=device).squeeze()
+                recon_diag = {}
+                if logprob_full is not None and _lambda > 0.0:
+                    logprob_expanded = logprob_full.unsqueeze(1).expand(-1, num_views, -1)
+                    logprob_expanded = logprob_expanded.reshape(bsz * num_views, -1)
+                    nan_mask = logprob_expanded.isnan()
+                    if nan_mask.any():
+                        row_means = logprob_expanded.nanmean(dim=-1, keepdim=True)
+                        logprob_expanded = logprob_expanded.masked_fill(nan_mask, 0.0)
+                        logprob_expanded = logprob_expanded + nan_mask.float() * row_means
+                    recon, recon_diag = model.recon_loss(logprob_pred_flat, logprob_expanded)
+
+                loss = supcon_A + supcon_B + _lambda * recon
+
+                optimizer.zero_grad()
+                loss.backward()
+                if grad_clip_norm is not None and float(grad_clip_norm) > 0:
+                    torch.nn.utils.clip_grad_norm_(
+                        model.parameters(), max_norm=float(grad_clip_norm)
+                    )
+                optimizer.step()
+
+                total_loss += loss.item()
+                total_supcon_a += supcon_A.item()
+                total_supcon_b += supcon_B.item()
+                total_recon += float(recon)
+                total_intra_cos += intra_sample_cosine_mean(z_views)
+                total_intra_inter += intra_inter_margin(z_views)
+                n_batches += 1
+
+                avg_loss = total_loss / n_batches
+                loop.set_postfix(
+                    loss=avg_loss,
+                    supcon_a=total_supcon_a / n_batches,
+                    supcon_b=total_supcon_b / n_batches,
+                    recon=total_recon / n_batches,
+                    suppressed=recon_diag.get("suppressed", "N/A"),
+                )
+
+        avg_loss = total_loss / max(1, n_batches)
+        avg_supcon_a = total_supcon_a / max(1, n_batches)
+        avg_supcon_b = total_supcon_b / max(1, n_batches)
+        avg_recon = total_recon / max(1, n_batches)
+        avg_intra_cos = total_intra_cos / max(1, n_batches)
+        avg_intra_inter = total_intra_inter / max(1, n_batches)
+        print(
+            f"Epoch {epoch + 1}/{epochs} - Loss: {avg_loss:.4f} "
+            f"(SupConA={avg_supcon_a:.4f}, SupConB={avg_supcon_b:.4f}, Recon={avg_recon:.4f}) "
+            f"- IntraCos: {avg_intra_cos:.4f} - IntraInterMargin: {avg_intra_inter:.4f}"
+        )
+
+        # Test evaluation uses head A's loss_fn by convention (no eval for dual loss)
+        test_loss = float("inf")
+        test_intra_cos = test_intra_inter = 0.0
+        if test_loader is not None:
+            test_loss, test_intra_cos, test_intra_inter = evaluate(
+                model,
+                test_loader,
+                batch_size=batch_size,
+                loss_fn=loss_fn_A,
+                device=device,
+                sub_batch_size=sub_batch_size,
+                use_labels=True,
+                ignore_label=int(ignore_labels[0]),
+            )
+            print(
+                f"Epoch {epoch + 1}/{epochs} - Test Loss: {test_loss:.4f} "
+                f"- Test IntraCos: {test_intra_cos:.4f} - Test IntraInterMargin: {test_intra_inter:.4f}"
+            )
+
+        is_last_epoch = epoch == epochs - 1
+        if (epoch + 1) % save_every == 0 or is_last_epoch:
+            checkpoint = {
+                "epoch": epoch,
+                "model_state_dict": model.state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "train_loss": avg_loss,
+                "train_supcon_a": avg_supcon_a,
+                "train_supcon_b": avg_supcon_b,
+                "train_recon": avg_recon,
+                "train_intra_cos": avg_intra_cos,
+                "train_intra_inter_margin": avg_intra_inter,
+                "test_loss": test_loss,
+                "test_intra_cos": test_intra_cos,
+                "test_intra_inter_margin": test_intra_inter,
+                "best_loss": min(best_loss, test_loss),
+                "temperature": temperature,
+                "lr": lr,
+                "recon_lambda": _lambda,
+            }
+
+            last_path = os.path.join(checkpoint_dir, "contrastive_last.pt")
+            _atomic_torch_save(checkpoint, last_path)
+
+            _save_and_prune_snapshots(
+                checkpoint_dir=checkpoint_dir,
+                snapshot_prefix="contrastive",
+                epoch_one_indexed=epoch + 1,
+                checkpoint=checkpoint,
+                snapshot_every=snapshot_every,
+                snapshot_keep_last=snapshot_keep_last,
+                is_last_epoch=is_last_epoch,
+            )
+
+            if cleanup_legacy_checkpoints:
+                _cleanup_legacy_checkpoints(checkpoint_dir, keep_filenames={"contrastive_last.pt"})
+
+
 def train_contrastive_logprob_attn_recon(
     model,
     train_dataset,

--- a/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "sharedtrunk_grid_nq_llama_memmap",
+  "dataset": "nq_memmap",
+  "methods": [
+    "contrastive_logprob_recon_d1a",
+    "contrastive_logprob_recon_d1b",
+    "contrastive_logprob_recon_d2a",
+    "contrastive_logprob_recon_d2b"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
@@ -2,8 +2,6 @@
   "experiment_name": "sharedtrunk_grid_nq_llama_memmap",
   "dataset": "nq_memmap",
   "methods": [
-    "contrastive_logprob_recon_d1a",
-    "contrastive_logprob_recon_d1b",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_llama_memmap.json
@@ -2,6 +2,7 @@
   "experiment_name": "sharedtrunk_grid_nq_llama_memmap",
   "dataset": "nq_memmap",
   "methods": [
+    "contrastive_logprob_recon_c0",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
@@ -2,6 +2,7 @@
   "experiment_name": "sharedtrunk_grid_nq_qwen3_memmap",
   "dataset": "nq_qwen3_memmap",
   "methods": [
+    "contrastive_logprob_recon_c0",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "sharedtrunk_grid_nq_qwen3_memmap",
+  "dataset": "nq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_d1a",
+    "contrastive_logprob_recon_d1b",
+    "contrastive_logprob_recon_d2a",
+    "contrastive_logprob_recon_d2b"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_nq_qwen3_memmap.json
@@ -2,8 +2,6 @@
   "experiment_name": "sharedtrunk_grid_nq_qwen3_memmap",
   "dataset": "nq_qwen3_memmap",
   "methods": [
-    "contrastive_logprob_recon_d1a",
-    "contrastive_logprob_recon_d1b",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
@@ -2,6 +2,7 @@
   "experiment_name": "sharedtrunk_grid_sciq_llama_memmap",
   "dataset": "sciq_memmap",
   "methods": [
+    "contrastive_logprob_recon_c0",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "sharedtrunk_grid_sciq_llama_memmap",
+  "dataset": "sciq_memmap",
+  "methods": [
+    "contrastive_logprob_recon_d1a",
+    "contrastive_logprob_recon_d1b",
+    "contrastive_logprob_recon_d2a",
+    "contrastive_logprob_recon_d2b"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_llama_memmap.json
@@ -2,8 +2,6 @@
   "experiment_name": "sharedtrunk_grid_sciq_llama_memmap",
   "dataset": "sciq_memmap",
   "methods": [
-    "contrastive_logprob_recon_d1a",
-    "contrastive_logprob_recon_d1b",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
@@ -2,6 +2,7 @@
   "experiment_name": "sharedtrunk_grid_sciq_qwen3_memmap",
   "dataset": "sciq_qwen3_memmap",
   "methods": [
+    "contrastive_logprob_recon_c0",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "sharedtrunk_grid_sciq_qwen3_memmap",
+  "dataset": "sciq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_d1a",
+    "contrastive_logprob_recon_d1b",
+    "contrastive_logprob_recon_d2a",
+    "contrastive_logprob_recon_d2b"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
+++ b/configs/experiments/sharedtrunk_grid_sciq_qwen3_memmap.json
@@ -2,8 +2,6 @@
   "experiment_name": "sharedtrunk_grid_sciq_qwen3_memmap",
   "dataset": "sciq_qwen3_memmap",
   "methods": [
-    "contrastive_logprob_recon_d1a",
-    "contrastive_logprob_recon_d1b",
     "contrastive_logprob_recon_d2a",
     "contrastive_logprob_recon_d2b"
   ],

--- a/configs/methods/contrastive_logprob_recon_d1a.json
+++ b/configs/methods/contrastive_logprob_recon_d1a.json
@@ -1,0 +1,45 @@
+{
+  "name": "contrastive_logprob_recon_d1a",
+  "routine": "contrastive_logprob_recon_shared_trunk",
+  "model_params": {
+    "variant": "split_output",
+    "half_dim": 256,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/contrastive_logprob_recon_d1b.json
+++ b/configs/methods/contrastive_logprob_recon_d1b.json
@@ -1,0 +1,45 @@
+{
+  "name": "contrastive_logprob_recon_d1b",
+  "routine": "contrastive_logprob_recon_shared_trunk",
+  "model_params": {
+    "variant": "split_output",
+    "half_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/contrastive_logprob_recon_d2a.json
+++ b/configs/methods/contrastive_logprob_recon_d2a.json
@@ -1,0 +1,47 @@
+{
+  "name": "contrastive_logprob_recon_d2a",
+  "routine": "contrastive_logprob_recon_shared_trunk",
+  "model_params": {
+    "variant": "projection_head",
+    "trunk_dim": 512,
+    "head_dim": 256,
+    "head_hidden_dim": 256,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/contrastive_logprob_recon_d2b.json
+++ b/configs/methods/contrastive_logprob_recon_d2b.json
@@ -1,0 +1,47 @@
+{
+  "name": "contrastive_logprob_recon_d2b",
+  "routine": "contrastive_logprob_recon_shared_trunk",
+  "model_params": {
+    "variant": "projection_head",
+    "trunk_dim": 1024,
+    "head_dim": 512,
+    "head_hidden_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -443,6 +443,194 @@ def run_contrastive_logprob_recon(
     return eval_metrics, predictions
 
 
+def run_contrastive_logprob_recon_shared_trunk(
+    ap,
+    dataset_cfg: dict,
+    method_cfg: dict,
+    experiment_cfg: dict,
+    output_dir: str,
+    device: str,
+    training_seed: int,
+    test_ap=None,
+) -> tuple[dict, list[dict]]:
+    """Train a shared-trunk twin-head model (D1 or D2) and evaluate.
+
+    Reads ``method_cfg["model_params"]["variant"]`` to select the model class:
+    - ``"split_output"`` → ``SharedTrunkSplitOutputCompressor`` (D1):
+        single trunk with ``final_dim = 2 * half_dim``.  Eval surface is
+        the full 2D embedding — KNN/Maha only (no cosine).
+    - ``"projection_head"`` → ``SharedTrunkProjectionHeadCompressor`` (D2):
+        trunk + two projection heads.  Heads discarded at eval.  Eval
+        surface is the trunk — KNN/Maha + cosine apply.
+
+    A single checkpoint ``artifacts/final_weights.pt`` is saved.  The model
+    is passed directly to ``MultiMetricHallucinationEvaluator`` (no
+    ``TwinConcatModel`` wrapper needed).
+    """
+    data_cfg = method_cfg["data"]
+    train_cfg = method_cfg["training"]
+    eval_cfg = method_cfg["evaluation"]
+
+    relevant_layers = parse_layer_range(data_cfg["relevant_layers"])
+    target_layers = data_cfg["target_layers"]
+
+    ds_kwargs = dict(
+        relevant_layers=relevant_layers,
+        num_views=data_cfg.get("num_views", 2),
+        pad_length=data_cfg.get("pad_length", 63),
+        preload=data_cfg.get("preload", True),
+        include_response_logprobs=True,
+        response_logprobs_top_k=data_cfg.get("response_logprobs_top_k", 20),
+        check_ram=False,
+    )
+
+    train_ds = ap.get_dataset("train", **ds_kwargs)
+    eval_ap = test_ap if test_ap is not None else ap
+    test_ds = eval_ap.get_dataset("test", **ds_kwargs)
+
+    has_val = ap.split_strategy == "three_way"
+    val_ds = ap.get_dataset("val", **ds_kwargs) if has_val else test_ds
+
+    from activation_research.model import (
+        SharedTrunkSplitOutputCompressor,
+        SharedTrunkProjectionHeadCompressor,
+    )
+    from activation_research.training import train_contrastive_logprob_recon_dualloss
+
+    model_params = method_cfg.get("model_params", {})
+    variant = model_params.get("variant", "split_output")
+
+    train_device = device if device != "auto" else (
+        "cuda" if torch.cuda.is_available() else "cpu"
+    )
+
+    if variant == "split_output":
+        model = SharedTrunkSplitOutputCompressor(
+            input_dim=dataset_cfg["input_dim"],
+            half_dim=model_params.get("half_dim", 256),
+            input_dropout=model_params.get("input_dropout", 0.3),
+            recon_seq_len=model_params.get("recon_seq_len", 64),
+            recon_hidden_dim=model_params.get("recon_hidden_dim", 256),
+            recon_lambda=model_params.get("recon_lambda", 1.0),
+            logprob_var_threshold=model_params.get("logprob_var_threshold", 1e-4),
+        )
+    elif variant == "projection_head":
+        model = SharedTrunkProjectionHeadCompressor(
+            input_dim=dataset_cfg["input_dim"],
+            trunk_dim=model_params.get("trunk_dim", 512),
+            head_dim=model_params.get("head_dim", 256),
+            head_hidden_dim=model_params.get("head_hidden_dim", 256),
+            input_dropout=model_params.get("input_dropout", 0.3),
+            recon_seq_len=model_params.get("recon_seq_len", 64),
+            recon_hidden_dim=model_params.get("recon_hidden_dim", 256),
+            recon_lambda=model_params.get("recon_lambda", 1.0),
+            logprob_var_threshold=model_params.get("logprob_var_threshold", 1e-4),
+        )
+    else:
+        raise ValueError(
+            f"Unknown shared-trunk variant '{variant}'. "
+            "Expected 'split_output' or 'projection_head'."
+        )
+
+    artifacts_dir = os.path.join(output_dir, "artifacts")
+    final_weights = os.path.join(artifacts_dir, "final_weights.pt")
+
+    if os.path.exists(final_weights):
+        logger.info("final_weights.pt found — skipping training, loading weights for eval")
+        ckpt = torch.load(final_weights, map_location=train_device)
+        model.load_state_dict(ckpt["model_state_dict"])
+    else:
+        os.makedirs(artifacts_dir, exist_ok=True)
+        train_contrastive_logprob_recon_dualloss(
+            model=model,
+            train_dataset=train_ds,
+            test_dataset=val_ds,
+            epochs=train_cfg["max_epochs"],
+            batch_size=train_cfg["batch_size"],
+            lr=train_cfg["lr"],
+            temperature=train_cfg["temperature"],
+            device=train_device,
+            num_workers=experiment_cfg.get("num_workers", 4),
+            sub_batch_size=train_cfg.get("sub_batch_size", 64),
+            checkpoint_dir=artifacts_dir,
+            save_every=1,
+            snapshot_every=10,
+            snapshot_keep_last=3,
+            persistent_workers=experiment_cfg.get("persistent_workers", True),
+            recon_lambda=model_params.get("recon_lambda", 1.0),
+            use_infinite_index_stream=train_cfg.get("use_infinite_index_stream", True),
+            infinite_stream_shuffle=True,
+            infinite_stream_seed=training_seed,
+            steps_per_epoch_override=train_cfg.get("steps_per_epoch_override"),
+            balanced_sampling=train_cfg.get("balanced_sampling", False),
+            grad_clip_norm=train_cfg.get("grad_clip_norm"),
+            augment_fn=None,
+            ignore_labels=(1, 0),
+        )
+        torch.save(
+            {"model_state_dict": model.state_dict()},
+            final_weights,
+        )
+
+    model.eval()
+
+    from torch.utils.data import DataLoader
+    from activation_research.metric_evaluator import MultiMetricHallucinationEvaluator
+
+    train_ds_target = train_ds.slice_layers(target_layers)
+    test_ds_target = test_ds.slice_layers(target_layers)
+
+    train_loader = DataLoader(train_ds_target, batch_size=64, shuffle=False)
+    eval_loader = DataLoader(test_ds_target, batch_size=64, shuffle=False)
+
+    metrics_list: list = []
+    for m in eval_cfg["metrics"]:
+        if m == "knn":
+            knn_params = dict(eval_cfg.get("knn_params", {}))
+            knn_params["sample_seed"] = training_seed
+            metrics_list.append(
+                {
+                    "metric": "knn",
+                    "kwargs": knn_params,
+                    "train_selection": "all",
+                }
+            )
+        else:
+            metrics_list.append(m)
+
+    flip_auroc: bool = bool(eval_cfg.get("flip_auroc", False))
+    effective_outlier_class = 0 if flip_auroc else dataset_cfg.get("outlier_class", 1)
+
+    evaluator = MultiMetricHallucinationEvaluator(
+        activation_parser_df=eval_ap.df,
+        train_data_loader=train_loader,
+        metrics=metrics_list,
+        batch_size=eval_cfg.get("eval_batch_size", 256),
+        sub_batch_size=eval_cfg.get("sub_batch_size", 64),
+        device=train_device,
+        num_workers=experiment_cfg.get("num_workers", 4),
+        persistent_workers=False,
+        outlier_class=effective_outlier_class,
+    )
+
+    ood_stats = evaluator.compute(eval_loader, model)
+
+    eval_metrics: dict = {
+        "method": method_cfg["name"],
+        "dataset": dataset_cfg["name"],
+        "seed": training_seed,
+        "flip_auroc": flip_auroc,
+        "split_seed": experiment_cfg.get("split_seed", 42),
+        "n_train": len(train_ds),
+        "n_test": len(test_ds),
+        "variant": variant,
+    }
+    eval_metrics.update(ood_stats)
+
+    predictions: list[dict] = []
+    return eval_metrics, predictions
+
+
 def run_linear_probe(
     ap,
     dataset_cfg: dict,
@@ -3161,6 +3349,11 @@ def main() -> None:
                         )
                     elif routine == "contrastive_logprob_recon_twin":
                         eval_metrics, predictions = run_contrastive_logprob_recon_twin(
+                            ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
+                            test_ap=test_ap,
+                        )
+                    elif routine == "contrastive_logprob_recon_shared_trunk":
+                        eval_metrics, predictions = run_contrastive_logprob_recon_shared_trunk(
                             ap, dataset_cfg, method_cfg, experiment_cfg, run_dir, device, effective_seed,
                             test_ap=test_ap,
                         )

--- a/specs/issue_102_shared_trunk_twin_heads.md
+++ b/specs/issue_102_shared_trunk_twin_heads.md
@@ -1,0 +1,220 @@
+# Implementation Spec: Issue #102 — Shared-Trunk Twin-Head Variants
+
+## Context
+
+Issue #99 trains **fully independent** twin compressors and concatenates their embeddings (see `TwinConcatModel` and `run_contrastive_logprob_recon_twin` in `scripts/run_experiment.py:437`). This spec adds two **shared-trunk** variants that test whether dual-loss training over a single trunk preserves the twin-head gain at half the compute.
+
+The branch `feat/102-shared-trunk-twin-heads` is **stacked on `feat/99-twin-heads-simclr-ablation`** — all the #99 infrastructure (`use_labels`, `ignore_label`, `TwinConcatModel`, `run_contrastive_logprob_recon_twin`) is already present. **Reuse it. Do not reimplement it.**
+
+Read [the full issue](https://github.com/hyang0129/HalluLens/issues/102) for the scientific motivation. This spec covers the implementation only.
+
+---
+
+## Architectures to implement
+
+### D1 — Split-output, shared trunk
+
+A single `LogprobReconProgressiveCompressor` with `final_dim=2D`. The output is sliced and each half is fed to its own SupCon loss with the opposite `ignore_label`. Eval uses the full (unsliced) output.
+
+```
+z = compressor(x)                       # (B, 2D)
+z_A, z_B = z[:, :D], z[:, D:]           # each (B, D)
+L_supcon_A = SupCon(z_A, labels, ignore_label=1)
+L_supcon_B = SupCon(z_B, labels, ignore_label=0)
+L_recon    = recon_loss(decoder(z), logprob_target)
+loss       = L_supcon_A + L_supcon_B + λ · L_recon
+```
+
+**Eval surface:** full `z` (2D-dim). KNN/Maha only — no cosine.
+
+### D2 — Shared trunk + projection heads, KNN on trunk
+
+A trunk (the existing `LogprobReconProgressiveCompressor` encoder) plus two small projection MLPs. SupCon is computed on the head outputs; eval uses the **trunk** output (heads discarded at eval).
+
+```
+z = compressor(x)                       # (B, trunk_dim) -- the eval surface
+zA, zB = head_A(z), head_B(z)           # each (B, D), training-only
+L_supcon_A = SupCon(zA, labels, ignore_label=1)
+L_supcon_B = SupCon(zB, labels, ignore_label=0)
+L_recon    = recon_loss(decoder(z), logprob_target)   # recon on TRUNK z
+loss       = L_supcon_A + L_supcon_B + λ · L_recon
+```
+
+**Eval surface:** trunk `z` (trunk_dim). KNN/Maha + cosine all apply (trunk is a single coordinate system).
+
+---
+
+## Files to modify / create
+
+### 1. `activation_research/model.py` — add two model classes
+
+#### `SharedTrunkSplitOutputCompressor` (D1)
+
+Wraps a single `LogprobReconProgressiveCompressor` whose `final_dim = 2 * D`. Stores `D` (`half_dim`) so the trainer can slice. `forward(x)` returns the full `z` (B, 2D). Helper method `forward_slices(x)` returns `(z, z_A, z_B)` for the trainer; `forward_with_recon(x)` returns `(z, logprob_pred)` for the recon path. The decoder operates on full `z`.
+
+Constructor signature:
+```python
+SharedTrunkSplitOutputCompressor(
+    input_dim: int = 4096,
+    half_dim: int = 256,                  # D; total output is 2 * half_dim
+    dropout: float = 0.1,
+    input_dropout: float = 0.2,
+    normalize_input: bool = False,
+    recon_seq_len: int = 64,
+    recon_hidden_dim: int = 256,
+    recon_lambda: float = 1.0,
+    logprob_var_threshold: float = 1e-4,
+)
+```
+
+The class is a thin wrapper around `LogprobReconProgressiveCompressor(final_dim=2*half_dim, ...)`. Expose `recon_loss` by delegating to the inner module so the training loop can reuse it unchanged.
+
+#### `SharedTrunkProjectionHeadCompressor` (D2)
+
+Wraps a `LogprobReconProgressiveCompressor` with `final_dim = trunk_dim`. Adds two `nn.Sequential` heads (each `nn.Linear(trunk_dim, head_hidden_dim) → GELU → nn.Linear(head_hidden_dim, head_dim)`). `forward(x)` returns the trunk `z` (B, trunk_dim) — this is the eval surface. Helper `forward_with_heads(x)` returns `(z, zA, zB)` for the trainer. `forward_with_recon(x)` returns `(z, logprob_pred)` from the inner module.
+
+Constructor signature:
+```python
+SharedTrunkProjectionHeadCompressor(
+    input_dim: int = 4096,
+    trunk_dim: int = 512,
+    head_dim: int = 256,
+    head_hidden_dim: int = 256,
+    dropout: float = 0.1,
+    input_dropout: float = 0.2,
+    normalize_input: bool = False,
+    recon_seq_len: int = 64,
+    recon_hidden_dim: int = 256,
+    recon_lambda: float = 1.0,
+    logprob_var_threshold: float = 1e-4,
+)
+```
+
+Heads are **trained but discarded at eval**. `eval()`-time `forward(x)` must return the trunk `z`, not anything from the heads, so existing eval code (`MultiMetricHallucinationEvaluator`, `TwinConcatModel`'s pattern of calling `model(x)` to get an embedding) works without modification.
+
+### 2. `activation_research/training.py` — add a dual-loss training function
+
+Add `train_contrastive_logprob_recon_dualloss(...)` that mirrors the signature of `train_contrastive_logprob_recon` but accepts:
+- `model`: an instance of `SharedTrunkSplitOutputCompressor` **or** `SharedTrunkProjectionHeadCompressor`
+- `ignore_labels: tuple[int, int]` — defaults to `(1, 0)` (head A gets `ignore_label=1`, head B gets `ignore_label=0`)
+
+Internally:
+1. Call the model's helper (`forward_slices` for D1, `forward_with_heads` for D2) to get `(z, zA, zB)`.
+2. Compute `SupCon(zA, labels, ignore_label=ignore_labels[0]) + SupCon(zB, labels, ignore_label=ignore_labels[1])`.
+3. Compute `recon_loss(decoder(z), target)` on the **full z** (D1) or the **trunk z** (D2) — in both cases this is what `forward_with_recon` returns from the inner module.
+4. Sum: `loss = L_A + L_B + recon_lambda * L_recon`.
+5. Everything else (optimizer, scheduler, checkpointing, AMP, grad clip, infinite stream, etc.) must be identical to `train_contrastive_logprob_recon`. **Extract shared logic into a helper if duplication is heavy**; otherwise copy-and-modify is acceptable for this PR.
+
+The trainer must NOT accept a per-loss `ignore_label` outside the `(1, 0)` default for this PR — out of scope.
+
+Add a per-head diagnostic to the existing per-step log: `view_cos_A`, `view_cos_B` (cosine between view-1 and view-2 of `zA` / `zB` averaged over batch) for the first 100 steps. Reuse whatever per-step diagnostic infrastructure already exists in `train_contrastive_logprob_recon` — do not invent a new one.
+
+### 3. `scripts/run_experiment.py` — add a dispatch routine
+
+Add `run_contrastive_logprob_recon_shared_trunk(...)` (signature matches `run_contrastive_logprob_recon_twin` at `scripts/run_experiment.py:437`). It:
+
+1. Reads `method_cfg["model_params"]["variant"]` (`"split_output"` or `"projection_head"`) to pick the model class.
+2. Constructs the model with config-driven dims.
+3. Calls `train_contrastive_logprob_recon_dualloss(...)`.
+4. Saves checkpoint to `artifacts/final_weights.pt` (single weights file — no `head_a/head_b` split; the trunk is one module).
+5. Evaluates: wraps `model.eval()` and passes directly into `MultiMetricHallucinationEvaluator` (no `TwinConcatModel` needed because both variants expose a single embedding via `forward(x)`).
+6. For D1, omit cosine from eval metrics (concat space). For D2, include cosine (single coordinate system).
+
+Wire the dispatch in the `if routine == ...` chain near `scripts/run_experiment.py:3340`:
+```python
+elif routine == "contrastive_logprob_recon_shared_trunk":
+    eval_metrics, predictions = run_contrastive_logprob_recon_shared_trunk(...)
+```
+
+### 4. Method configs — 4 new files in `configs/methods/`
+
+Model each after `configs/methods/contrastive_logprob_recon_c2.json`. Change `routine` to `"contrastive_logprob_recon_shared_trunk"`. Add `model_params.variant` and the appropriate dim fields.
+
+- **`contrastive_logprob_recon_d1a.json`**: `variant: "split_output"`, `half_dim: 256` → 512-dim eval. Metrics: `["mds", "knn"]`.
+- **`contrastive_logprob_recon_d1b.json`**: `variant: "split_output"`, `half_dim: 512` → 1024-dim eval. Metrics: `["mds", "knn"]`.
+- **`contrastive_logprob_recon_d2a.json`**: `variant: "projection_head"`, `trunk_dim: 512`, `head_dim: 256`, `head_hidden_dim: 256` → 512-dim eval. Metrics: `["cosine", "mds", "knn"]`.
+- **`contrastive_logprob_recon_d2b.json`**: `variant: "projection_head"`, `trunk_dim: 1024`, `head_dim: 512`, `head_hidden_dim: 512` → 1024-dim eval. Metrics: `["cosine", "mds", "knn"]`.
+
+All other fields (training hyperparams, data block, knn_params) match `contrastive_logprob_recon_c2.json` exactly.
+
+### 5. Experiment configs — 4 new files in `configs/experiments/`
+
+Pattern after `configs/experiments/twin_grid_sciq_llama_memmap.json` (or the closest existing config from #99). Files:
+- `sharedtrunk_grid_sciq_llama_memmap.json`
+- `sharedtrunk_grid_sciq_qwen3_memmap.json`
+- `sharedtrunk_grid_nq_llama_memmap.json`
+- `sharedtrunk_grid_nq_qwen3_memmap.json`
+
+Each lists the 4 D-configs and 1 seed (seed 0).
+
+### 6. Tests — `tests/test_shared_trunk_twin.py` (new)
+
+Minimum coverage (use `tests/test_twin_concat_model.py` as a style reference):
+
+- `test_split_output_forward_shape`: `SharedTrunkSplitOutputCompressor(half_dim=8)` forward on `(B=4, L=10, 4096)` returns `(4, 16)`.
+- `test_split_output_slice_helper`: `forward_slices` returns `z, z_A, z_B` with `z_A == z[:, :8]` and `z_B == z[:, 8:]`.
+- `test_projection_head_forward_returns_trunk`: `SharedTrunkProjectionHeadCompressor(trunk_dim=16, head_dim=8)` forward returns `(B, 16)`, NOT `(B, 8)`. Heads must not be called in `forward`.
+- `test_projection_head_with_heads_helper`: `forward_with_heads` returns `(z, zA, zB)` with shapes `(B, 16), (B, 8), (B, 8)`.
+- `test_dualloss_step_runs`: instantiate either model on CPU, run one training step via `train_contrastive_logprob_recon_dualloss` on a tiny synthetic dataset, assert loss is finite and gradients flow to all parameters (trunk + both heads for D2; trunk + decoder for D1).
+- `test_eval_surface_d2_is_trunk`: after one training step on D2 model, assert `model.eval(); model(x)` returns trunk-dim embedding and does NOT depend on head weights (e.g., zero out head weights and confirm output is unchanged).
+
+Skip GPU tests; CPU only.
+
+---
+
+## Acceptance criteria
+
+- [ ] Both new model classes (`SharedTrunkSplitOutputCompressor`, `SharedTrunkProjectionHeadCompressor`) exist in `activation_research/model.py` and pass forward/shape tests.
+- [ ] `train_contrastive_logprob_recon_dualloss` exists in `activation_research/training.py` and runs one step on CPU without error.
+- [ ] `run_contrastive_logprob_recon_shared_trunk` exists in `scripts/run_experiment.py` and is wired into the routine dispatch.
+- [ ] The 4 method configs and 4 experiment configs exist and are valid JSON.
+- [ ] `python -c "import json; [json.load(open(f'configs/methods/contrastive_logprob_recon_{c}.json')) for c in ['d1a','d1b','d2a','d2b']]"` succeeds.
+- [ ] `pytest tests/test_shared_trunk_twin.py -x` passes on CPU.
+- [ ] `python -c "from activation_research.model import SharedTrunkSplitOutputCompressor, SharedTrunkProjectionHeadCompressor; from activation_research.training import train_contrastive_logprob_recon_dualloss"` succeeds (import smoke test).
+- [ ] Existing test suite still passes (specifically `pytest tests/test_twin_concat_model.py -x` to confirm #99 was not broken).
+- [ ] No files outside the scope list below are modified.
+
+---
+
+## Scope — files you may edit or create
+
+- `activation_research/model.py` (add classes; do not modify existing classes)
+- `activation_research/training.py` (add `train_contrastive_logprob_recon_dualloss`; do not modify existing functions unless extracting a shared helper, in which case the existing function must remain behaviourally identical)
+- `scripts/run_experiment.py` (add new dispatch routine + wire one `elif` branch; do not modify other routines)
+- `configs/methods/contrastive_logprob_recon_d{1a,1b,2a,2b}.json` (4 new files)
+- `configs/experiments/sharedtrunk_grid_{sciq,nq}_{llama,qwen3}_memmap.json` (4 new files)
+- `tests/test_shared_trunk_twin.py` (1 new file)
+
+---
+
+## Out of scope (do not touch)
+
+- Existing C0–C3 method configs, `run_contrastive_logprob_recon_twin`, `TwinConcatModel`, `LogprobReconProgressiveCompressor`, `train_contrastive_logprob_recon`. **Read-only.**
+- Loss reweighting (non-1:1 SupCon weights between heads).
+- Trunk:head ratio sweeps beyond the fixed `(512, 256)` and `(1024, 512)` defined above.
+- 3+ heads.
+- Asymmetric `ignore_label` values beyond `(1, 0)`.
+- GPU smoketest (login-node-only environment).
+- Running the actual experiments (dispatch is a follow-up; this PR is implementation only).
+- Any post-hoc eval logic from #101 — those apply to artifacts after the fact.
+
+---
+
+## Implementation order (suggested)
+
+1. Add `SharedTrunkSplitOutputCompressor` + tests for it.
+2. Add `SharedTrunkProjectionHeadCompressor` + tests for it.
+3. Add `train_contrastive_logprob_recon_dualloss` + one-step test.
+4. Add `run_contrastive_logprob_recon_shared_trunk` dispatch.
+5. Add the 4 method configs + 4 experiment configs.
+6. Run full test suite. Verify acceptance criteria. Commit.
+
+Commit at logical boundaries (one commit per step is fine). Conventional commit prefix: `feat(#102): ...`.
+
+---
+
+## Working directory
+
+You are working in the git worktree at `/workspaces/hub_4/hallulens-issue-102` on branch `feat/102-shared-trunk-twin-heads`. **Do not touch `/workspaces/hub_4/hallulens` (the main checkout — that holds an independent feature branch).** All edits, tests, and commits happen inside the worktree.
+
+Push the branch when done. Do not open a new PR — one already exists (draft PR will be referenced in your starting context).

--- a/tests/test_shared_trunk_twin.py
+++ b/tests/test_shared_trunk_twin.py
@@ -1,0 +1,372 @@
+"""Tests for SharedTrunkSplitOutputCompressor (D1) and SharedTrunkProjectionHeadCompressor (D2).
+
+CPU-only; no real data or GPU.
+
+Run with:
+    pytest tests/test_shared_trunk_twin.py -v
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import tempfile
+
+import pytest
+import torch
+import torch.nn as nn
+
+from activation_research.model import (
+    SharedTrunkSplitOutputCompressor,
+    SharedTrunkProjectionHeadCompressor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Small input_dim that keeps the ProgressiveCompressor TransformerBlock happy:
+# nhead = min(8, final_dim // 64) must be >= 1, so final_dim >= 64.
+# For D1 that means half_dim >= 32 (final_dim = 2 * half_dim).
+# Use input_dim=128 so the inner encoder dimensions stay manageable.
+
+_INPUT_DIM = 128
+_B = 4
+_SEQ = 10
+
+
+def _make_d1(half_dim: int = 8) -> SharedTrunkSplitOutputCompressor:
+    torch.manual_seed(0)
+    # Use input_dim=128, half_dim=32 so final_dim=64 and nhead=1 is valid.
+    # For shape tests we use the caller's half_dim but cap at 32 for correctness.
+    return SharedTrunkSplitOutputCompressor(
+        input_dim=_INPUT_DIM,
+        half_dim=half_dim,
+    )
+
+
+def _make_d2(trunk_dim: int = 16, head_dim: int = 8) -> SharedTrunkProjectionHeadCompressor:
+    torch.manual_seed(0)
+    return SharedTrunkProjectionHeadCompressor(
+        input_dim=_INPUT_DIM,
+        trunk_dim=trunk_dim,
+        head_dim=head_dim,
+        head_hidden_dim=head_dim,
+    )
+
+
+def _random_x(b: int = _B, seq: int = _SEQ, d: int = _INPUT_DIM) -> torch.Tensor:
+    torch.manual_seed(42)
+    return torch.randn(b, seq, d)
+
+
+# ---------------------------------------------------------------------------
+# D1 — SharedTrunkSplitOutputCompressor
+# ---------------------------------------------------------------------------
+
+
+def test_split_output_forward_shape():
+    """forward() on (B, L, 128) returns (B, 2*half_dim)."""
+    # Use half_dim=32 so final_dim=64 satisfies nhead >= 1 constraint.
+    half_dim = 32
+    model = _make_d1(half_dim=half_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (_B, 2 * half_dim), (
+        f"Expected ({_B}, {2 * half_dim}), got {out.shape}"
+    )
+
+
+def test_split_output_slice_helper():
+    """forward_slices() returns (z, z_A, z_B, logprob_pred) with correct slicing."""
+    half_dim = 32
+    model = _make_d1(half_dim=half_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        z, z_A, z_B, logprob_pred = model.forward_slices(x)
+
+    assert z.shape == (_B, 2 * half_dim), f"z shape mismatch: {z.shape}"
+    assert z_A.shape == (_B, half_dim), f"z_A shape mismatch: {z_A.shape}"
+    assert z_B.shape == (_B, half_dim), f"z_B shape mismatch: {z_B.shape}"
+
+    # z_A must equal the first half of z
+    assert torch.allclose(z_A, z[:, :half_dim]), "z_A != z[:, :half_dim]"
+    # z_B must equal the second half of z
+    assert torch.allclose(z_B, z[:, half_dim:]), "z_B != z[:, half_dim:]"
+
+
+def test_split_output_forward_matches_slices_z():
+    """forward(x) and the z returned by forward_slices(x) must be identical."""
+    half_dim = 32
+    model = _make_d1(half_dim=half_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        z_forward = model(x)
+        z_slices, _, _, _ = model.forward_slices(x)
+    assert torch.allclose(z_forward, z_slices), "forward(x) != forward_slices(x)[0]"
+
+
+# ---------------------------------------------------------------------------
+# D2 — SharedTrunkProjectionHeadCompressor
+# ---------------------------------------------------------------------------
+
+
+def test_projection_head_forward_returns_trunk():
+    """forward() returns (B, trunk_dim), NOT (B, head_dim). Heads must not be called."""
+    trunk_dim = 64  # must be >= 64 for nhead constraint
+    head_dim = 8
+    model = _make_d2(trunk_dim=trunk_dim, head_dim=head_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (_B, trunk_dim), (
+        f"Expected ({_B}, {trunk_dim}), got {out.shape}"
+    )
+
+
+def test_projection_head_with_heads_helper():
+    """forward_with_heads() returns (z, zA, zB) with correct shapes."""
+    trunk_dim = 64
+    head_dim = 8
+    model = _make_d2(trunk_dim=trunk_dim, head_dim=head_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        z, zA, zB, logprob_pred = model.forward_with_heads(x)
+
+    assert z.shape == (_B, trunk_dim), f"z shape mismatch: {z.shape}"
+    assert zA.shape == (_B, head_dim), f"zA shape mismatch: {zA.shape}"
+    assert zB.shape == (_B, head_dim), f"zB shape mismatch: {zB.shape}"
+
+
+def test_projection_head_forward_matches_trunk_in_with_heads():
+    """forward(x) must equal the trunk z returned by forward_with_heads(x)."""
+    trunk_dim = 64
+    head_dim = 8
+    model = _make_d2(trunk_dim=trunk_dim, head_dim=head_dim)
+    model.eval()
+    x = _random_x()
+    with torch.no_grad():
+        z_forward = model(x)
+        z_trunk, _, _, _ = model.forward_with_heads(x)
+    assert torch.allclose(z_forward, z_trunk), "forward(x) != forward_with_heads(x)[0]"
+
+
+# ---------------------------------------------------------------------------
+# Dual-loss trainer smoke test
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_dataset(n: int = 32, seq: int = _SEQ, d: int = _INPUT_DIM):
+    """Return a lightweight in-memory dataset compatible with the contrastive collate fn."""
+    torch.manual_seed(99)
+
+    class _SyntheticDataset(torch.utils.data.Dataset):
+        def __init__(self, n, seq, d):
+            self.n = n
+            self.data = torch.randn(n, 2, seq, d)  # 2 views
+            self.labels = torch.randint(0, 2, (n,))
+            self.logprobs = torch.randn(n, seq)
+
+        def __len__(self):
+            return self.n
+
+        def __getitem__(self, idx):
+            return {
+                "views_activations": self.data[idx],       # (2, seq, d)
+                "halu": self.labels[idx],                   # scalar int tensor
+                "logprob": self.logprobs[idx],              # (seq,)
+                "hashkey": f"sample_{idx}",
+            }
+
+    return _SyntheticDataset(n, seq, d)
+
+
+def test_dualloss_step_runs_d1():
+    """One training step via train_contrastive_logprob_recon_dualloss on D1 (CPU).
+
+    Asserts:
+    - loss is finite
+    - gradients flow to trunk parameters AND decoder parameters
+    """
+    from activation_research.training import train_contrastive_logprob_recon_dualloss
+
+    model = SharedTrunkSplitOutputCompressor(
+        input_dim=_INPUT_DIM,
+        half_dim=32,  # final_dim=64, nhead=1 valid
+    )
+    ds = _make_synthetic_dataset(n=8)
+
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        train_contrastive_logprob_recon_dualloss(
+            model=model,
+            train_dataset=ds,
+            test_dataset=None,
+            epochs=1,
+            batch_size=8,
+            lr=1e-3,
+            temperature=0.1,
+            device="cpu",
+            num_workers=0,
+            sub_batch_size=8,
+            checkpoint_dir=ckpt_dir,
+            save_every=1,
+            persistent_workers=False,
+            use_infinite_index_stream=False,
+            recon_lambda=1.0,
+        )
+
+    # Check gradients flowed — re-run one manual step to inspect grads
+    model2 = SharedTrunkSplitOutputCompressor(input_dim=_INPUT_DIM, half_dim=32)
+    optimizer = torch.optim.Adam(model2.parameters(), lr=1e-3)
+
+    x = torch.randn(_B, _SEQ, _INPUT_DIM)
+    x_2views = x.unsqueeze(1).expand(-1, 2, -1, -1)  # (B, 2, seq, d)
+    bsz, num_views, seq, hidden = x_2views.shape
+    x_flat = x_2views.reshape(bsz * num_views, seq, hidden)
+
+    z_flat, zA_flat, zB_flat, logprob_pred = model2.forward_slices(x_flat)
+    labels = torch.randint(0, 2, (bsz,))
+
+    from activation_research.training import SupConLoss
+    loss_fn_A = SupConLoss(temperature=0.1, ignore_label=1)
+    loss_fn_B = SupConLoss(temperature=0.1, ignore_label=0)
+
+    zA_views = zA_flat.reshape(bsz, num_views, -1)
+    zB_views = zB_flat.reshape(bsz, num_views, -1)
+
+    target = torch.randn(bsz * num_views, model2._inner.recon_seq_len)
+    recon, _ = model2.recon_loss(logprob_pred, target)
+
+    sample_ids = torch.arange(bsz, dtype=torch.long)
+    loss = loss_fn_A(zA_views, labels=labels, sample_ids=sample_ids) + \
+           loss_fn_B(zB_views, labels=labels, sample_ids=sample_ids) + recon
+
+    optimizer.zero_grad()
+    loss.backward()
+
+    assert math.isfinite(loss.item()), f"loss is not finite: {loss.item()}"
+
+    for name, param in model2.named_parameters():
+        assert param.grad is not None, f"No gradient for param: {name}"
+        assert not torch.isnan(param.grad).any(), f"NaN gradient for param: {name}"
+
+
+def test_dualloss_step_runs_d2():
+    """One training step via train_contrastive_logprob_recon_dualloss on D2 (CPU).
+
+    Asserts:
+    - loss is finite
+    - gradients flow to trunk parameters AND both projection head parameters
+    """
+    from activation_research.training import train_contrastive_logprob_recon_dualloss
+
+    model = SharedTrunkProjectionHeadCompressor(
+        input_dim=_INPUT_DIM,
+        trunk_dim=64,
+        head_dim=8,
+        head_hidden_dim=8,
+    )
+    ds = _make_synthetic_dataset(n=8)
+
+    with tempfile.TemporaryDirectory() as ckpt_dir:
+        train_contrastive_logprob_recon_dualloss(
+            model=model,
+            train_dataset=ds,
+            test_dataset=None,
+            epochs=1,
+            batch_size=8,
+            lr=1e-3,
+            temperature=0.1,
+            device="cpu",
+            num_workers=0,
+            sub_batch_size=8,
+            checkpoint_dir=ckpt_dir,
+            save_every=1,
+            persistent_workers=False,
+            use_infinite_index_stream=False,
+            recon_lambda=1.0,
+        )
+
+    # Manual step to verify gradient flow to trunk + both heads
+    model2 = SharedTrunkProjectionHeadCompressor(
+        input_dim=_INPUT_DIM, trunk_dim=64, head_dim=8, head_hidden_dim=8
+    )
+    optimizer = torch.optim.Adam(model2.parameters(), lr=1e-3)
+
+    x = torch.randn(_B, _SEQ, _INPUT_DIM)
+    x_2views = x.unsqueeze(1).expand(-1, 2, -1, -1)
+    bsz, num_views, seq, hidden = x_2views.shape
+    x_flat = x_2views.reshape(bsz * num_views, seq, hidden)
+
+    z_flat, zA_flat, zB_flat, logprob_pred = model2.forward_with_heads(x_flat)
+    labels = torch.randint(0, 2, (bsz,))
+
+    from activation_research.training import SupConLoss
+    loss_fn_A = SupConLoss(temperature=0.1, ignore_label=1)
+    loss_fn_B = SupConLoss(temperature=0.1, ignore_label=0)
+
+    zA_views = zA_flat.reshape(bsz, num_views, -1)
+    zB_views = zB_flat.reshape(bsz, num_views, -1)
+
+    target = torch.randn(bsz * num_views, model2._inner.recon_seq_len)
+    recon, _ = model2.recon_loss(logprob_pred, target)
+
+    sample_ids = torch.arange(bsz, dtype=torch.long)
+    loss = loss_fn_A(zA_views, labels=labels, sample_ids=sample_ids) + \
+           loss_fn_B(zB_views, labels=labels, sample_ids=sample_ids) + recon
+
+    optimizer.zero_grad()
+    loss.backward()
+
+    assert math.isfinite(loss.item()), f"loss is not finite: {loss.item()}"
+
+    # Trunk parameters
+    for name, param in model2._inner.named_parameters():
+        assert param.grad is not None, f"No gradient for trunk param: {name}"
+    # Head A parameters
+    for name, param in model2.head_A.named_parameters():
+        assert param.grad is not None, f"No gradient for head_A param: {name}"
+    # Head B parameters
+    for name, param in model2.head_B.named_parameters():
+        assert param.grad is not None, f"No gradient for head_B param: {name}"
+
+
+# ---------------------------------------------------------------------------
+# Eval surface test for D2: heads must not affect forward()
+# ---------------------------------------------------------------------------
+
+
+def test_eval_surface_d2_is_trunk():
+    """After zeroing out head weights, model.eval(); model(x) is unchanged.
+
+    This confirms forward() returns purely the trunk embedding and does NOT
+    depend on head_A or head_B weights.
+    """
+    trunk_dim = 64
+    head_dim = 8
+    model = _make_d2(trunk_dim=trunk_dim, head_dim=head_dim)
+    model.eval()
+    x = _random_x()
+
+    with torch.no_grad():
+        z_before = model(x).clone()
+
+        # Zero out all head weights
+        for param in model.head_A.parameters():
+            param.data.zero_()
+        for param in model.head_B.parameters():
+            param.data.zero_()
+
+        z_after = model(x)
+
+    assert torch.allclose(z_before, z_after), (
+        "forward() changed after zeroing head weights — heads must not be called in forward()"
+    )


### PR DESCRIPTION
Closes #102.

## Summary

Adds the **D2 (projection-head)** shared-trunk variant and wires in the **C0 unsupervised baseline** for the ablation grid.

- **D2**: trunk `LogprobReconProgressiveCompressor` + two small MLP projection heads. Both heads receive the same trunk embedding `z`; each is trained with dual SupCon losses (`ignore_label=1` / `ignore_label=0` independently). **KNN/Maha/cosine eval runs on the trunk `z`** — the shared representation that feeds both heads. Heads are discarded at eval.
- **C0**: standard single-head compressor trained with `use_labels=False` (SimCLR / NT-Xent). KNN runs on the same trunk. Serves as the unsupervised lower bound for H4/H5.

D1 (split-output / concat eval) was dropped after C1–C3 results showed concat eval spaces are near-random (knn AUROC 0.53, separation delta 0.07 on SciQ seed 0). D2 avoids this by evaluating on the single-coordinate trunk.

## Experiment grid (per dataset × model)

| Config | Description | Eval surface | Metrics |
|--------|-------------|-------------|---------|
| C0 | Unsupervised (SimCLR) | trunk 512-dim | cosine, mds, knn |
| D2a | Dual SupCon, trunk 512 + heads 256 | trunk 512-dim | cosine, mds, knn |
| D2b | Dual SupCon, trunk 1024 + heads 512 | trunk 1024-dim | cosine, mds, knn |

Datasets: SciQ + NQ × Llama-3.1-8B-Instruct + Qwen3-8B, seed 0.

## Changes

- `activation_research/model.py`: `SharedTrunkSplitOutputCompressor` (D1, kept for completeness) + `SharedTrunkProjectionHeadCompressor` (D2)
- `activation_research/training.py`: `train_contrastive_logprob_recon_dualloss`
- `scripts/run_experiment.py`: `run_contrastive_logprob_recon_shared_trunk` dispatch routine
- `configs/methods/contrastive_logprob_recon_{d2a,d2b}.json`
- `configs/experiments/sharedtrunk_grid_{sciq,nq}_{llama,qwen3}_memmap.json` — each runs `[c0, d2a, d2b]`
- `tests/test_shared_trunk_twin.py`
- `specs/issue_102_shared_trunk_twin_heads.md`

## Test plan

- [ ] `pytest tests/test_shared_trunk_twin.py -x` passes on CPU
- [ ] `pytest tests/test_twin_concat_model.py -x` still passes (no #99 regression)
- [ ] Import smoke: `from activation_research.model import SharedTrunkSplitOutputCompressor, SharedTrunkProjectionHeadCompressor; from activation_research.training import train_contrastive_logprob_recon_dualloss`
- [ ] JSON validation: `d2a`, `d2b` method configs parse cleanly
- [ ] Routine dispatch wired: `contrastive_logprob_recon_shared_trunk` reachable in `run_experiment.py`

## Out of scope

Loss reweighting, trunk:head ratio sweeps, 3+ heads, asymmetric `ignore_label`, GPU smoketest, running experiments (dispatch is a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)