### PR TITLE
feat(#104): channel dropout rate ablation configs (p=0.20/0.30/0.40)

### DIFF
--- a/configs/experiments/channel_dropout_ablation_nq_memmap.json
+++ b/configs/experiments/channel_dropout_ablation_nq_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "channel_dropout_ablation_nq_memmap",
+  "dataset": "nq_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b2",
+    "contrastive_logprob_recon_cd1",
+    "contrastive_logprob_recon_cd2",
+    "contrastive_logprob_recon_cd3"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/channel_dropout_ablation_nq_qwen3_memmap.json
+++ b/configs/experiments/channel_dropout_ablation_nq_qwen3_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "channel_dropout_ablation_nq_qwen3_memmap",
+  "dataset": "nq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b2",
+    "contrastive_logprob_recon_cd1",
+    "contrastive_logprob_recon_cd2",
+    "contrastive_logprob_recon_cd3"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/channel_dropout_ablation_sciq_memmap.json
+++ b/configs/experiments/channel_dropout_ablation_sciq_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "channel_dropout_ablation_sciq_memmap",
+  "dataset": "sciq_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b2",
+    "contrastive_logprob_recon_cd1",
+    "contrastive_logprob_recon_cd2",
+    "contrastive_logprob_recon_cd3"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/experiments/channel_dropout_ablation_sciq_qwen3_memmap.json
+++ b/configs/experiments/channel_dropout_ablation_sciq_qwen3_memmap.json
@@ -1,0 +1,17 @@
+{
+  "experiment_name": "channel_dropout_ablation_sciq_qwen3_memmap",
+  "dataset": "sciq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b2",
+    "contrastive_logprob_recon_cd1",
+    "contrastive_logprob_recon_cd2",
+    "contrastive_logprob_recon_cd3"
+  ],
+  "split_seed": 42,
+  "training_seeds": [0],
+  "split_seeds": [42],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs"
+}

--- a/configs/methods/contrastive_logprob_recon_cd1.json
+++ b/configs/methods/contrastive_logprob_recon_cd1.json
@@ -1,0 +1,51 @@
+{
+  "name": "contrastive_logprob_recon_cd1",
+  "routine": "contrastive_logprob_recon",
+  "model_class": "logprob_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "augmentations": {
+      "asymmetric": false,
+      "ops": [{"type": "channel_dropout", "params": {"p": 0.20}}]
+    }
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/contrastive_logprob_recon_cd2.json
+++ b/configs/methods/contrastive_logprob_recon_cd2.json
@@ -1,0 +1,51 @@
+{
+  "name": "contrastive_logprob_recon_cd2",
+  "routine": "contrastive_logprob_recon",
+  "model_class": "logprob_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "augmentations": {
+      "asymmetric": false,
+      "ops": [{"type": "channel_dropout", "params": {"p": 0.30}}]
+    }
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/configs/methods/contrastive_logprob_recon_cd3.json
+++ b/configs/methods/contrastive_logprob_recon_cd3.json
@@ -1,0 +1,51 @@
+{
+  "name": "contrastive_logprob_recon_cd3",
+  "routine": "contrastive_logprob_recon",
+  "model_class": "logprob_recon_progressive_compressor",
+  "model_params": {
+    "final_dim": 512,
+    "input_dropout": 0.3,
+    "recon_seq_len": 64,
+    "recon_hidden_dim": 256,
+    "recon_lambda": 1.0,
+    "logprob_var_threshold": 1e-4
+  },
+  "training": {
+    "max_epochs": 100,
+    "batch_size": 512,
+    "lr": 1e-5,
+    "temperature": 0.25,
+    "sub_batch_size": 64,
+    "use_labels": true,
+    "ignore_label": 1,
+    "use_infinite_index_stream": true,
+    "balanced_sampling": false,
+    "grad_clip_norm": 1.0,
+    "min_total_steps": 3000
+  },
+  "data": {
+    "relevant_layers": "14-29",
+    "target_layers": [22, 26],
+    "num_views": 2,
+    "pad_length": 63,
+    "preload": true,
+    "include_response_logprobs": true,
+    "response_logprobs_top_k": 20,
+    "augmentations": {
+      "asymmetric": false,
+      "ops": [{"type": "channel_dropout", "params": {"p": 0.40}}]
+    }
+  },
+  "evaluation": {
+    "metrics": ["cosine", "mds", "knn"],
+    "knn_params": {
+      "k": 50,
+      "metric": "euclidean",
+      "calibrate_k": true,
+      "k_candidates": [50, 100, 200, 500, 1000],
+      "max_train_size": 200000
+    },
+    "eval_batch_size": 256,
+    "sub_batch_size": 64
+  }
+}

--- a/scripts/run_channel_dropout_ablation_llama.sh
+++ b/scripts/run_channel_dropout_ablation_llama.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+for DATASET in nq sciq; do
+    echo "============================================"
+    echo "channel_dropout_ablation_${DATASET}_memmap — Llama-3.1-8B"
+    echo "Started: $(date)"
+    echo "============================================"
+
+    $PYTHON scripts/run_experiment.py \
+        --experiment configs/experiments/channel_dropout_ablation_${DATASET}_memmap.json \
+        --device cuda
+
+    echo ""
+done
+
+echo "============================================"
+echo "ALL DONE: $(date)"
+echo "============================================"

--- a/scripts/run_channel_dropout_ablation_qwen3.sh
+++ b/scripts/run_channel_dropout_ablation_qwen3.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+cd /mnt/home/hyang1/LLM_research/HalluLens
+
+PYTHON=/mnt/home/hyang1/.local/share/mamba/envs/p311/bin/python
+
+for DATASET in nq sciq; do
+    echo "============================================"
+    echo "channel_dropout_ablation_${DATASET}_qwen3_memmap — Qwen3-8B"
+    echo "Started: $(date)"
+    echo "============================================"
+
+    $PYTHON scripts/run_experiment.py \
+        --experiment configs/experiments/channel_dropout_ablation_${DATASET}_qwen3_memmap.json \
+        --device cuda
+
+    echo ""
+done
+
+echo "============================================"
+echo "ALL DONE: $(date)"
+echo "============================================"


### PR DESCRIPTION
Closes #104

## What changed

Adds JSON config files for the channel dropout rate ablation (issue #104). Three new method configs (`cd1`, `cd2`, `cd3`) extend the existing `b2` baseline (p=0.10) by testing p=0.20, p=0.30, and p=0.40. Four experiment configs wire these methods against NQ and SciQ for both Llama-3.1-8B and Qwen3-8B variants, following the established `aug_grid`/`twin_grid` naming convention.

## Implementation walkthrough

### New method configs

- **`configs/methods/contrastive_logprob_recon_cd1.json`** — identical to `b2` except `name` → `cd1` and `channel_dropout.p` → 0.20.
- **`configs/methods/contrastive_logprob_recon_cd2.json`** — `p` = 0.30.
- **`configs/methods/contrastive_logprob_recon_cd3.json`** — `p` = 0.40.

All other settings (asymmetric=false, ignore_label=1, training hyperparams, evaluation metrics) are unchanged from `b2` to ensure a clean ablation signal.

### New experiment configs

| Config | Dataset | Methods |
|---|---|---|
| `channel_dropout_ablation_nq_memmap.json` | `nq_memmap` | b2, cd1, cd2, cd3 |
| `channel_dropout_ablation_nq_qwen3_memmap.json` | `nq_qwen3_memmap` | b2, cd1, cd2, cd3 |
| `channel_dropout_ablation_sciq_memmap.json` | `sciq_memmap` | b2, cd1, cd2, cd3 |
| `channel_dropout_ablation_sciq_qwen3_memmap.json` | `sciq_qwen3_memmap` | b2, cd1, cd2, cd3 |

`b2` is included in each experiment as the in-experiment baseline so results can be directly compared without cross-experiment variance.

## Tier / approach

Tier 1 — Planner → Coder (pure JSON config additions, no code changes)

## Acceptance criteria

- [x] `contrastive_logprob_recon_cd1.json` exists with `channel_dropout p=0.20`
- [x] `contrastive_logprob_recon_cd2.json` exists with `channel_dropout p=0.30`
- [x] `contrastive_logprob_recon_cd3.json` exists with `channel_dropout p=0.40`
- [x] All method configs are otherwise identical to `b2` (asymmetric=false, ignore_label=1)
- [x] Experiment configs created for NQ and SciQ × Llama and Qwen3 variants
- [x] `b2` included as in-experiment baseline in all experiment configs
- [x] All JSON files pass `python3 -c "import json; json.load(open(...))"` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)