### PR TITLE
feat(#107): backfill per-sample KNN predictions.csv for contrastive_logprob_recon

### DIFF
--- a/scripts/dispatch/build_issue_107_cells.py
+++ b/scripts/dispatch/build_issue_107_cells.py
@@ -1,0 +1,139 @@
+"""
+build_issue_107_cells.py — populate pending/ with one cell per (dataset, model)
+to backfill per-sample KNN predictions.csv for the contrastive_logprob_recon
+method (issue #107).
+
+Each cell bundles all 5 training seeds into a single run_experiment.py
+invocation. Bundling keeps the activations memmap warm in the OS page cache
+across seeds and amortises Python/CUDA/HF init — modest (~10%) but free given
+the inner-loop resume rule in run_experiment.py only re-runs seeds that are
+missing predictions.csv.
+
+The existing worker_79.sh routes the default task_type to:
+
+    python scripts/run_experiment.py \
+        --experiment <EXPERIMENT> --methods <METHOD> --seeds <SEED>
+
+so we set:
+    method = "contrastive_logprob_recon"
+    seed   = "0,1,2,3,4"   (comma-separated string; argparse splits on ",")
+    output_check = .../seed_4/predictions.csv
+
+predictions.csv for seed_4 is the last per-seed artefact written by the
+bundled run. run_experiment.py now exits non-zero if any seed errors, and
+worker_79 marks the cell done only when (exit_code == 0 AND output_check
+exists), so a partial failure correctly routes the cell to failed/ for
+retry — even though seed_4 might have written its csv before an earlier
+seed failed.
+
+Usage:
+    python scripts/dispatch/build_issue_107_cells.py \
+        --dispatch-root shared/issue_107_dispatch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.dispatch.claim import init_dispatch_dirs  # noqa: E402
+
+# (experiment_config_basename, dataset_key) — derived from the canonical
+# baseline_comparison_*_memmap experiments in configs/experiments/.
+_TARGETS = [
+    ("baseline_comparison_hotpotqa_memmap",       "hotpotqa_memmap"),
+    ("baseline_comparison_hotpotqa_qwen3_memmap", "hotpotqa_qwen3_memmap"),
+    ("baseline_comparison_mmlu_memmap",           "mmlu_memmap"),
+    ("baseline_comparison_mmlu_qwen3_memmap",     "mmlu_qwen3_memmap"),
+    ("baseline_comparison_nq_memmap",             "nq_memmap"),
+    ("baseline_comparison_nq_qwen3_memmap",       "nq_qwen3_memmap"),
+    ("baseline_comparison_popqa_memmap",          "popqa_memmap"),
+    ("baseline_comparison_popqa_qwen3_memmap",    "popqa_qwen3_memmap"),
+    ("baseline_comparison_sciq_memmap",           "sciq_memmap"),
+    ("baseline_comparison_sciq_qwen3_memmap",     "sciq_qwen3_memmap"),
+    ("baseline_comparison_searchqa_memmap",       "searchqa_memmap"),
+    ("baseline_comparison_searchqa_qwen3_memmap", "searchqa_qwen3_memmap"),
+]
+
+_METHOD = "contrastive_logprob_recon"
+_SEEDS_CSV = "0,1,2,3,4"
+_LAST_SEED = 4
+
+
+def _dispatch_has_cell(dispatch_root: Path, cell_id: str) -> bool:
+    fname = cell_id + ".json"
+    for sub in ("pending", "done", "failed"):
+        if (dispatch_root / sub / fname).exists():
+            return True
+    claimed = dispatch_root / "claimed"
+    if claimed.exists():
+        for wd in claimed.iterdir():
+            if wd.is_dir() and (wd / fname).exists():
+                return True
+    return False
+
+
+def build(dispatch_root: Path) -> int:
+    init_dispatch_dirs(dispatch_root)
+    written = 0
+
+    for experiment_name, dataset_key in _TARGETS:
+        cfg_rel = f"configs/experiments/{experiment_name}.json"
+        if not (_PROJECT_ROOT / cfg_rel).exists():
+            print(f"  skip (config missing): {cfg_rel}", file=sys.stderr)
+            continue
+
+        cell_id = f"issue107__{dataset_key}__{_METHOD}"
+        if _dispatch_has_cell(dispatch_root, cell_id):
+            print(f"  skip (already queued): {cell_id}")
+            continue
+
+        output_check = (
+            f"runs/{experiment_name}/{dataset_key}/{_METHOD}/seed_{_LAST_SEED}/predictions.csv"
+        )
+
+        cell = {
+            "cell_id":           cell_id,
+            "experiment_config": cfg_rel,
+            "dataset":           dataset_key,
+            "method":            _METHOD,
+            "seed":              _SEEDS_CSV,
+            "output_check":      output_check,
+        }
+        (dispatch_root / "pending" / f"{cell_id}.json").write_text(
+            json.dumps(cell, indent=2), encoding="utf-8"
+        )
+        written += 1
+        print(f"  queued: {cell_id}")
+
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Queue contrastive_logprob_recon predictions backfill cells (issue #107)."
+    )
+    parser.add_argument(
+        "--dispatch-root",
+        default="shared/issue_107_dispatch",
+        help="Dispatch root (default: shared/issue_107_dispatch).",
+    )
+    args = parser.parse_args()
+
+    dispatch_root = Path(args.dispatch_root)
+    if not dispatch_root.is_absolute():
+        dispatch_root = _PROJECT_ROOT / dispatch_root
+
+    total = build(dispatch_root)
+    print(f"Done — {total} cells queued in {dispatch_root}/pending")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -392,6 +392,7 @@ def run_contrastive_logprob_recon(
         if m == "knn":
             knn_params = dict(eval_cfg.get("knn_params", {}))
             knn_params["sample_seed"] = training_seed
+            knn_params["include_per_sample"] = True
             metrics_list.append(
                 {
                     "metric": "knn",
@@ -419,6 +420,9 @@ def run_contrastive_logprob_recon(
 
     ood_stats = evaluator.compute(eval_loader, model)
 
+    knn_scores_arr = ood_stats.pop("knn_scores", None)
+    knn_labels_arr = ood_stats.pop("knn_labels", None)
+
     eval_metrics: dict = {
         "method": method_cfg["name"],
         "dataset": dataset_cfg["name"],
@@ -431,6 +435,11 @@ def run_contrastive_logprob_recon(
     eval_metrics.update(ood_stats)
 
     predictions: list[dict] = []
+    if knn_scores_arr is not None and knn_labels_arr is not None:
+        predictions = [
+            {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
+            for i, (s, l) in enumerate(zip(knn_scores_arr, knn_labels_arr))
+        ]
     return eval_metrics, predictions
 
 
@@ -2833,6 +2842,11 @@ def main() -> None:
         return result
 
     # ---- Main loop ----
+    # Track per-seed failures so the process can exit non-zero at the end.
+    # Worker dispatch relies on exit code AND output-file existence to decide
+    # done vs failed, and a multi-seed invocation must not silently succeed
+    # when an earlier seed errored.
+    had_failures = 0
     for dataset_name in datasets:
         # Load dataset config (use pre-loaded if available, else load from configs/)
         if dataset_name in _preloaded_dataset_cfgs:
@@ -3075,10 +3089,20 @@ def main() -> None:
 
                 # Resume check — skip only when eval_metrics.json exists AND there is
                 # no run_error.json (which would indicate the prior result was degenerate).
+                # For methods that also produce per-sample predictions.csv, require both
+                # files; otherwise a prior run that wrote only eval_metrics.json (issue #107)
+                # would be falsely treated as complete.
                 eval_metrics_path = os.path.join(run_dir, "eval_metrics.json")
+                pred_path = os.path.join(run_dir, "predictions.csv")
                 run_error_path = os.path.join(run_dir, "run_error.json")
                 prior_error = os.path.exists(run_error_path)
-                if os.path.exists(eval_metrics_path) and not args.force:
+                routine_for_skip = method_cfg.get("routine", method_cfg["name"])
+                needs_predictions = routine_for_skip in {
+                    "contrastive_logprob_recon",
+                    "contrastive_logprob_recon_twin",
+                }
+                have_predictions = (not needs_predictions) or os.path.exists(pred_path)
+                if os.path.exists(eval_metrics_path) and have_predictions and not args.force:
                     if prior_error:
                         logger.warning(
                             f"Found both eval_metrics.json and run_error.json for "
@@ -3092,6 +3116,11 @@ def main() -> None:
                         if not is_learned:
                             completed_nonlearned.add(method_name)
                         continue
+                elif os.path.exists(eval_metrics_path) and needs_predictions and not have_predictions:
+                    logger.info(
+                        f"{method_name} seed={effective_seed}: eval_metrics.json present but "
+                        f"predictions.csv missing — re-running eval to write predictions."
+                    )
 
                 os.makedirs(run_dir, exist_ok=True)
                 os.makedirs(os.path.join(run_dir, "artifacts"), exist_ok=True)
@@ -3199,9 +3228,11 @@ def main() -> None:
                         logger.warning(f"Unknown routine: {routine}, skipping")
                         continue
 
-                    # Write eval_metrics.json
-                    with open(eval_metrics_path, "w") as f:
-                        json.dump(eval_metrics, f, indent=2)
+                    # Write eval_metrics.json — preserve original mtime when re-running
+                    # only to backfill predictions.csv (values would be identical).
+                    if not os.path.exists(eval_metrics_path) or args.force:
+                        with open(eval_metrics_path, "w") as f:
+                            json.dump(eval_metrics, f, indent=2)
 
                     # Write predictions.csv
                     if predictions:
@@ -3215,6 +3246,15 @@ def main() -> None:
 
                     if not is_learned:
                         completed_nonlearned.add(method_name)
+
+                    # Free per-seed GPU/CPU state before the next iteration —
+                    # multi-seed invocations load a different checkpoint each pass
+                    # and stale CUDA allocations can pile up.
+                    import gc as _gc
+
+                    _gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
 
                 except Exception:
                     import traceback
@@ -3231,6 +3271,7 @@ def main() -> None:
                             f,
                             indent=2,
                         )
+                    had_failures += 1
 
     if args.smoketest_memmap_cache:
         n_total = len(smoketest_results)
@@ -3245,6 +3286,11 @@ def main() -> None:
         sys.exit(0 if n_miss == 0 else 1)
 
     logger.info("Experiment complete.")
+    if had_failures:
+        logger.error(
+            f"Experiment finished with {had_failures} per-seed failure(s) — exiting with code 1."
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #107

## Summary

- **`run_contrastive_logprob_recon`**: passes `include_per_sample=True` to `knn_ood_stats`, pops `knn_scores`/`knn_labels` from `ood_stats` before JSON serialisation, returns a populated `predictions` list. Existing `eval_metrics.json` values are unchanged — AUROC computed from the new CSV will match `knn_auroc` to floating-point tolerance.
- **Outer skip rule**: `contrastive_logprob_recon`/`_twin` cells now require both `eval_metrics.json` **and** `predictions.csv` to be treated as complete. Cells with only `eval_metrics.json` fall through to an eval-only rerun; training is skipped because `final_weights.pt` already exists.
- **Idempotent `eval_metrics.json` write**: gated on `not os.path.exists` to preserve original mtime during predictions-only backfill.
- **Strict exit on failure**: `had_failures` counter + `sys.exit(1)` at end of `main()`. Worker `_79` AND-gates exit code with `output_check` existence, so multi-seed cells with a partial failure correctly route to `failed/` for retry.
- **GPU cleanup between seeds**: `gc.collect()` + `torch.cuda.empty_cache()` after each seed in a multi-seed invocation.
- **`scripts/dispatch/build_issue_107_cells.py`**: emits 12 cells (6 datasets × 2 models, `seed="0,1,2,3,4"` bundled) into `shared/issue_107_dispatch/pending/`. Uses existing `task_type="train"` — no `worker_79.sh` changes, no worker restart required.

## Test plan

- [ ] Smoketest: run one seed against an existing hotpotqa checkpoint — confirm "skipping training" log, `predictions.csv` written, row count matches test set size
- [ ] AUROC sanity: `roc_auc_score(label_halu, score_halu)` from new CSV matches `eval_metrics.json["knn_auroc"]` to ~1e-6
- [ ] Full sweep: `python scripts/dispatch/build_issue_107_cells.py` → dispatch workers → `predictions_gap_report.py` shows 0 gaps for `contrastive_logprob_recon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)