### PR TITLE
feat(#115): Qwen3 flipped-convention sweep — configs, polarity fix, cell generator, embeddings dump

### DIFF
--- a/activation_research/evaluation.py
+++ b/activation_research/evaluation.py
@@ -1,3 +1,7 @@
+import json
+import os
+from typing import List
+
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
@@ -357,11 +361,11 @@ def inference_embeddings(model, dataset, batch_size=512, sub_batch_size=64, devi
 def assign_hallucination_labels(embeddings, activation_parser_df):
     """
     Assign hallucination labels to embeddings records using the activation parser's dataframe.
-    
+
     Args:
         embeddings: List of dicts from inference_embeddings containing 'hashkey' and 'layer_embeddings'
         activation_parser_df: DataFrame from ActivationParser containing 'prompt_hash' and 'halu' columns
-        
+
     Returns:
         List of dicts with 'halu' key added to each record
     """
@@ -369,5 +373,75 @@ def assign_hallucination_labels(embeddings, activation_parser_df):
         ishalu = activation_parser_df[activation_parser_df['prompt_hash'] == record['hashkey']]['halu']
         assert len(ishalu) == 1, f"Expected exactly 1 match for hashkey {record['hashkey']}, found {len(ishalu)}"
         embeddings[i]['halu'] = ishalu.values[0]
-    
+
     return embeddings
+
+
+def dump_embeddings_to_memmap(
+    records: List[dict],
+    out_dir: str,
+    split_name: str,
+    *,
+    dtype: str = "float16",
+) -> dict:
+    """Write a list of (`z_views`, `halu`, `hashkey`) records to .npy files.
+
+    Files written under `out_dir`:
+      - {split_name}_z.npy        (N, K, D) `dtype`, np.save format → mmap on read
+      - {split_name}_labels.npy   (N,) int8
+      - {split_name}_hashkeys.json  list of N hashkeys (traceability)
+      - {split_name}_meta.json    shape, dtype, split_name, n
+
+    Callers load via `np.load(path, mmap_mode='r')` to get a memmap view —
+    nothing in this codebase reads these files automatically; consumers must
+    opt in explicitly.
+
+    Returns the meta dict that was written.
+    """
+    if not records:
+        raise ValueError(f"dump_embeddings_to_memmap: empty records for split={split_name}")
+
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Validate schema on the first record; subsequent records assumed consistent.
+    first = records[0]
+    if "z_views" not in first:
+        raise KeyError("Records must contain 'z_views' — legacy z1/z2 schema not supported by this dumper")
+    if "halu" not in first:
+        raise KeyError("Records must contain 'halu' — call _assign_hallucination_labels first")
+
+    def _to_np(x):
+        if isinstance(x, torch.Tensor):
+            return x.detach().cpu().numpy()
+        return np.asarray(x)
+
+    z_stack = np.stack([_to_np(r["z_views"]) for r in records]).astype(np.dtype(dtype), copy=False)
+    labels = np.array([int(r["halu"]) for r in records], dtype=np.int8)
+    hashkeys = [str(r.get("hashkey", "")) for r in records]
+
+    z_path = os.path.join(out_dir, f"{split_name}_z.npy")
+    labels_path = os.path.join(out_dir, f"{split_name}_labels.npy")
+    hash_path = os.path.join(out_dir, f"{split_name}_hashkeys.json")
+    meta_path = os.path.join(out_dir, f"{split_name}_meta.json")
+
+    np.save(z_path, z_stack)
+    np.save(labels_path, labels)
+    with open(hash_path, "w") as f:
+        json.dump(hashkeys, f)
+
+    meta = {
+        "split_name": split_name,
+        "n": int(z_stack.shape[0]),
+        "z_shape": list(z_stack.shape),
+        "z_dtype": str(z_stack.dtype),
+        "label_dtype": str(labels.dtype),
+        "files": {
+            "z": os.path.basename(z_path),
+            "labels": os.path.basename(labels_path),
+            "hashkeys": os.path.basename(hash_path),
+        },
+    }
+    with open(meta_path, "w") as f:
+        json.dump(meta, f, indent=2)
+
+    return meta

--- a/activation_research/metric_evaluator.py
+++ b/activation_research/metric_evaluator.py
@@ -130,6 +130,7 @@ class HallucinationEvaluator(MetricEvaluator):
         # Cache for computed embeddings
         self._baseline_embeddings = None
         self._labeled_baseline_embeddings = None
+        self._labeled_test_embeddings = None
 
     @staticmethod
     def _resolve_metric(metric: Union[str, Callable[..., Dict[str, Any]]]):
@@ -612,6 +613,12 @@ class MultiMetricHallucinationEvaluator(HallucinationEvaluator):
         labeled_baseline_embeddings = self._get_labeled_baseline_embeddings(baseline_embeddings)
         test_embeddings = self._compute_test_embeddings(data_loader, model)
         labeled_test_embeddings = self._assign_hallucination_labels(test_embeddings)
+
+        # Cache labeled test embeddings so a caller (e.g. run_experiment.py) can
+        # dump them after eval completes without recomputing the forward pass.
+        # Memory footprint is identical to what compute() already held locally;
+        # we just keep the reference instead of letting it be collected.
+        self._labeled_test_embeddings = labeled_test_embeddings
 
         stats = self._compute_all_metrics(labeled_baseline_embeddings, labeled_test_embeddings)
 

--- a/configs/experiments/baseline_comparison_hotpotqa_qwen3_flipped_memmap.json
+++ b/configs/experiments/baseline_comparison_hotpotqa_qwen3_flipped_memmap.json
@@ -1,0 +1,26 @@
+{
+  "experiment_name": "baseline_comparison_hotpotqa_qwen3_flipped_memmap",
+  "dataset": "hotpotqa_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "training_seeds": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "split_seeds": [
+    42,
+    1,
+    2,
+    3,
+    4
+  ]
+}

--- a/configs/experiments/baseline_comparison_nq_qwen3_flipped_memmap.json
+++ b/configs/experiments/baseline_comparison_nq_qwen3_flipped_memmap.json
@@ -1,0 +1,26 @@
+{
+  "experiment_name": "baseline_comparison_nq_qwen3_flipped_memmap",
+  "dataset": "nq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "training_seeds": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "split_seeds": [
+    42,
+    1,
+    2,
+    3,
+    4
+  ]
+}

--- a/configs/experiments/baseline_comparison_popqa_qwen3_flipped_memmap.json
+++ b/configs/experiments/baseline_comparison_popqa_qwen3_flipped_memmap.json
@@ -1,0 +1,26 @@
+{
+  "experiment_name": "baseline_comparison_popqa_qwen3_flipped_memmap",
+  "dataset": "popqa_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "training_seeds": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "split_seeds": [
+    42,
+    1,
+    2,
+    3,
+    4
+  ]
+}

--- a/configs/experiments/baseline_comparison_sciq_qwen3_flipped_memmap.json
+++ b/configs/experiments/baseline_comparison_sciq_qwen3_flipped_memmap.json
@@ -1,0 +1,26 @@
+{
+  "experiment_name": "baseline_comparison_sciq_qwen3_flipped_memmap",
+  "dataset": "sciq_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "training_seeds": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "split_seeds": [
+    42,
+    1,
+    2,
+    3,
+    4
+  ]
+}

--- a/configs/experiments/baseline_comparison_searchqa_qwen3_flipped_memmap.json
+++ b/configs/experiments/baseline_comparison_searchqa_qwen3_flipped_memmap.json
@@ -1,0 +1,26 @@
+{
+  "experiment_name": "baseline_comparison_searchqa_qwen3_flipped_memmap",
+  "dataset": "searchqa_qwen3_memmap",
+  "methods": [
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "training_seeds": [
+    0,
+    1,
+    2,
+    3,
+    4
+  ],
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "split_seeds": [
+    42,
+    1,
+    2,
+    3,
+    4
+  ]
+}

--- a/configs/methods/contrastive_logprob_recon.json
+++ b/configs/methods/contrastive_logprob_recon.json
@@ -42,6 +42,7 @@
       "max_train_size": 200000
     },
     "eval_batch_size": 256,
-    "sub_batch_size": 64
+    "sub_batch_size": 64,
+    "dump_embeddings": true
   }
 }

--- a/configs/methods/contrastive_logprob_recon_b5.json
+++ b/configs/methods/contrastive_logprob_recon_b5.json
@@ -43,6 +43,7 @@
     },
     "eval_batch_size": 256,
     "sub_batch_size": 64,
-    "flip_auroc": true
+    "flip_auroc": true,
+    "dump_embeddings": true
   }
 }

--- a/scripts/dispatch/generate_manifest_115.py
+++ b/scripts/dispatch/generate_manifest_115.py
@@ -1,0 +1,144 @@
+"""
+generate_manifest_115.py — queue cells for the Qwen3 flipped-convention sweep
+(issue #115: 5 datasets × 5 seeds of contrastive_logprob_recon_b5).
+
+Cell shape (consumed by scripts/dispatch/worker_79.sh, same protocol as #79):
+
+    {
+      "cell_id":           "seed_0__sciq_qwen3_memmap__contrastive_logprob_recon_b5",
+      "experiment_config": "configs/experiments/baseline_comparison_sciq_qwen3_flipped_memmap.json",
+      "dataset":           "sciq_qwen3_memmap",
+      "method":            "contrastive_logprob_recon_b5",
+      "seed":              0,
+      "output_check":      "runs/baseline_comparison_sciq_qwen3_flipped_memmap/sciq_qwen3_memmap/contrastive_logprob_recon_b5/seed_0/predictions.csv"
+    }
+
+cell_id is `seed_{N}__{dataset}__{method}`, so sorted-filename claim order
+drains all 5 datasets at seed 0 before any seed 1 cell is claimed. That gives
+a full results table at seed 0 in ~5 GPU-hours, well before the sweep is done.
+
+output_check points at predictions.csv (not eval_metrics.json) because the
+polarity fix in this PR specifically writes predictions.csv under the flipped
+convention — verifying the file exists is the cheap proxy for "the polarity
+fix ran". The worker re-checks this at claim time and marks pre-existing
+cells complete without re-running.
+
+Usage:
+    python scripts/dispatch/generate_manifest_115.py \\
+        --dispatch-root shared/issue_115_dispatch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.dispatch.claim import init_dispatch_dirs  # noqa: E402
+
+# (experiment_config_basename, dataset_key) — the 5 Qwen3 flipped experiments
+# created for issue #115. MMLU is excluded (cut from EMNLP paper).
+_TARGETS = [
+    ("baseline_comparison_hotpotqa_qwen3_flipped_memmap", "hotpotqa_qwen3_memmap"),
+    ("baseline_comparison_nq_qwen3_flipped_memmap",       "nq_qwen3_memmap"),
+    ("baseline_comparison_popqa_qwen3_flipped_memmap",    "popqa_qwen3_memmap"),
+    ("baseline_comparison_sciq_qwen3_flipped_memmap",     "sciq_qwen3_memmap"),
+    ("baseline_comparison_searchqa_qwen3_flipped_memmap", "searchqa_qwen3_memmap"),
+]
+
+_METHOD = "contrastive_logprob_recon_b5"
+_SEEDS = [0, 1, 2, 3, 4]
+
+
+def _dispatch_has_cell(dispatch_root: Path, cell_id: str) -> bool:
+    fname = cell_id + ".json"
+    for sub in ("pending", "done", "failed"):
+        if (dispatch_root / sub / fname).exists():
+            return True
+    claimed = dispatch_root / "claimed"
+    if claimed.exists():
+        for wd in claimed.iterdir():
+            if wd.is_dir() and (wd / fname).exists():
+                return True
+    return False
+
+
+def _output_path_for(experiment_name: str, dataset: str, method: str, seed: int) -> str:
+    return (
+        f"runs/{experiment_name}/{dataset}/{method}/seed_{seed}/predictions.csv"
+    )
+
+
+def build(dispatch_root: Path, skip_existing: bool) -> int:
+    init_dispatch_dirs(dispatch_root)
+    written = 0
+
+    # Outer loop over seeds (not datasets) so the seed-first ordering shows up
+    # in the queued log even though sorted-filename claim already enforces it.
+    for seed in _SEEDS:
+        for experiment_name, dataset_key in _TARGETS:
+            cfg_rel = f"configs/experiments/{experiment_name}.json"
+            if not (_PROJECT_ROOT / cfg_rel).exists():
+                print(f"  skip (config missing): {cfg_rel}", file=sys.stderr)
+                continue
+
+            cell_id = f"seed_{seed}__{dataset_key}__{_METHOD}"
+            if _dispatch_has_cell(dispatch_root, cell_id):
+                print(f"  skip (already queued): {cell_id}")
+                continue
+
+            output_check = _output_path_for(experiment_name, dataset_key, _METHOD, seed)
+            if skip_existing and (_PROJECT_ROOT / output_check).exists():
+                print(f"  skip (output exists): {cell_id}")
+                continue
+
+            cell = {
+                "cell_id":           cell_id,
+                "experiment_config": cfg_rel,
+                "dataset":           dataset_key,
+                "method":            _METHOD,
+                "seed":              int(seed),
+                "output_check":      output_check,
+            }
+            (dispatch_root / "pending" / f"{cell_id}.json").write_text(
+                json.dumps(cell, indent=2), encoding="utf-8"
+            )
+            written += 1
+            print(f"  queued: {cell_id}")
+
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Queue Qwen3 flipped-convention cells (issue #115)."
+    )
+    parser.add_argument(
+        "--dispatch-root",
+        default="shared/issue_115_dispatch",
+        help="Dispatch root (default: shared/issue_115_dispatch).",
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip cells whose output_check exists at manifest time. "
+             "Default OFF — emit uniformly; the worker re-checks at claim time.",
+    )
+    args = parser.parse_args()
+
+    dispatch_root = Path(args.dispatch_root)
+    if not dispatch_root.is_absolute():
+        dispatch_root = _PROJECT_ROOT / dispatch_root
+
+    total = build(dispatch_root, args.skip_existing)
+    print(f"Done — {total} cells queued in {dispatch_root}/pending")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -451,6 +451,29 @@ def run_contrastive_logprob_recon(
                 {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
                 for i, (s, l) in enumerate(zip(knn_scores_arr, knn_labels_arr))
             ]
+
+    # Optional: dump predicted train+test embeddings as memmap-friendly .npy files
+    # for downstream reuse (e.g. KNN-k sweeps, cosine-collapse analysis). Opt-in via
+    # eval_cfg["dump_embeddings"] — runs only at the final test eval, and downstream
+    # callers must explicitly load via np.load(..., mmap_mode='r'); no path in this
+    # codebase reads these files automatically.
+    if eval_cfg.get("dump_embeddings", False):
+        from activation_research.evaluation import dump_embeddings_to_memmap
+
+        emb_dir = os.path.join(output_dir, "embeddings")
+        train_records = getattr(evaluator, "_labeled_baseline_embeddings", None)
+        test_records = getattr(evaluator, "_labeled_test_embeddings", None)
+        if train_records:
+            train_meta = dump_embeddings_to_memmap(train_records, emb_dir, "train")
+            logger.info(f"dumped train embeddings: {train_meta['n']} × {train_meta['z_shape'][1:]} -> {emb_dir}")
+        else:
+            logger.warning("dump_embeddings=true but evaluator has no _labeled_baseline_embeddings; skipping train dump")
+        if test_records:
+            test_meta = dump_embeddings_to_memmap(test_records, emb_dir, "test")
+            logger.info(f"dumped test embeddings: {test_meta['n']} × {test_meta['z_shape'][1:]} -> {emb_dir}")
+        else:
+            logger.warning("dump_embeddings=true but evaluator has no _labeled_test_embeddings; skipping test dump")
+
     return eval_metrics, predictions
 
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -436,10 +436,21 @@ def run_contrastive_logprob_recon(
 
     predictions: list[dict] = []
     if knn_scores_arr is not None and knn_labels_arr is not None:
-        predictions = [
-            {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
-            for i, (s, l) in enumerate(zip(knn_scores_arr, knn_labels_arr))
-        ]
+        # Under flip_auroc=True (B5: ignore_label=0), the contrastive loss compacts hallu
+        # and the KNN base contains all train samples — so low knn_score = close to hallu cluster = halu.
+        # binary_outlier_labels is (test_label == 0), i.e. 1 = correct. Negate both so predictions.csv
+        # always has score_halu="higher = more halu" and label_halu="1 = halu" regardless of convention;
+        # AUROC computed downstream from these columns then matches eval_metrics.knn_auroc.
+        if flip_auroc:
+            predictions = [
+                {"example_id": i, "score_halu": -float(s), "label_halu": 1 - int(l)}
+                for i, (s, l) in enumerate(zip(knn_scores_arr, knn_labels_arr))
+            ]
+        else:
+            predictions = [
+                {"example_id": i, "score_halu": float(s), "label_halu": int(l)}
+                for i, (s, l) in enumerate(zip(knn_scores_arr, knn_labels_arr))
+            ]
     return eval_metrics, predictions
 
 


### PR DESCRIPTION
Closes #115.

## Summary

- 5 new experiment configs (`baseline_comparison_{hotpotqa,nq,popqa,sciq,searchqa}_qwen3_flipped_memmap.json`) — each runs `contrastive_logprob_recon_b5` × 5 seeds on the existing Qwen3 memmap datasets
- `predictions.csv` polarity fix in `run_contrastive_logprob_recon`: under `flip_auroc=true`, negate `score_halu` and flip `label_halu` so polarity is consistent across conventions (downstream AUROC from `predictions.csv` now matches `eval_metrics.knn_auroc`)
- `scripts/dispatch/generate_manifest_115.py` — seed-first cell generator (25 cells, all 5 seed-0 cells claimed before any seed-1)
- `dump_embeddings_to_memmap()` writes the trained encoder's final-test-eval embeddings (train + test) as `.npy` files for downstream reuse; opt-in via `eval_cfg["dump_embeddings"]`, enabled in both `contrastive_logprob_recon.json` and `*_b5.json`; no autoload

## Test plan

- [x] All 5 JSON configs load cleanly (parsed locally)
- [x] `run_experiment.py`, `evaluation.py`, `metric_evaluator.py` parse
- [x] Polarity math verified with synthetic data: `AUROC(score_halu, label_halu)` after the fix equals `eval_metrics.knn_auroc` for both standard and flipped
- [x] Embedding dumper round-trip: `np.load(..., mmap_mode='r')` returns a memmap, float16 precision preserved
- [x] Cell generator dry-run into `/tmp/`: emits 25 cells in correct seed-first order with `predictions.csv` as the `output_check`
- [ ] **GPU smoketest (post-merge):** dispatch seed_0 SciQ-Qwen3 cell, verify (1) `eval_metrics.knn_auroc` reproduces aug_grid B5 SciQ-Qwen3 within ±0.005, (2) `predictions.csv` polarity is natural (AUROC computed from columns matches `knn_auroc`), (3) `embeddings/train_z.npy` and `embeddings/test_z.npy` load as memmaps with the expected shape
- [ ] Full sweep (25 cells, ~19 GPU-hours) after smoketest passes