### PR TITLE
fix(#115): dump_embeddings handles unlabeled records + non-fatal failure

### DIFF
--- a/activation_research/evaluation.py
+++ b/activation_research/evaluation.py
@@ -403,12 +403,26 @@ def dump_embeddings_to_memmap(
 
     os.makedirs(out_dir, exist_ok=True)
 
-    # Validate schema on the first record; subsequent records assumed consistent.
-    first = records[0]
-    if "z_views" not in first:
-        raise KeyError("Records must contain 'z_views' — legacy z1/z2 schema not supported by this dumper")
-    if "halu" not in first:
-        raise KeyError("Records must contain 'halu' — call _assign_hallucination_labels first")
+    # The parent evaluator labels its baseline embeddings with keep_unlabeled=True
+    # for callers that don't strictly need labels, so a few records can pass through
+    # without a 'halu' key (no matching hashkey in the activation parser dataframe).
+    # We skip those here — they can't be used for downstream label-conditioned
+    # analysis anyway. Test records are labeled with keep_unlabeled=False upstream
+    # so this filter should usually be a no-op for them.
+    n_input = len(records)
+    records = [r for r in records if "z_views" in r and "halu" in r]
+    n_skipped = n_input - len(records)
+    if n_skipped:
+        import logging
+        logging.getLogger(__name__).warning(
+            f"dump_embeddings_to_memmap[{split_name}]: skipped {n_skipped}/{n_input} records "
+            f"missing 'z_views' or 'halu'"
+        )
+    if not records:
+        raise ValueError(
+            f"dump_embeddings_to_memmap: no usable records for split={split_name} "
+            f"after filtering (all {n_input} missing 'z_views' or 'halu')"
+        )
 
     def _to_np(x):
         if isinstance(x, torch.Tensor):

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -459,21 +459,26 @@ def run_contrastive_logprob_recon(
     # callers must explicitly load via np.load(..., mmap_mode='r'); no path in this
     # codebase reads these files automatically.
     if eval_cfg.get("dump_embeddings", False):
-        from activation_research.evaluation import dump_embeddings_to_memmap
+        # Dump failures must not invalidate the eval — the metrics + predictions
+        # are already in hand. Log the traceback and move on.
+        try:
+            from activation_research.evaluation import dump_embeddings_to_memmap
 
-        emb_dir = os.path.join(output_dir, "embeddings")
-        train_records = getattr(evaluator, "_labeled_baseline_embeddings", None)
-        test_records = getattr(evaluator, "_labeled_test_embeddings", None)
-        if train_records:
-            train_meta = dump_embeddings_to_memmap(train_records, emb_dir, "train")
-            logger.info(f"dumped train embeddings: {train_meta['n']} × {train_meta['z_shape'][1:]} -> {emb_dir}")
-        else:
-            logger.warning("dump_embeddings=true but evaluator has no _labeled_baseline_embeddings; skipping train dump")
-        if test_records:
-            test_meta = dump_embeddings_to_memmap(test_records, emb_dir, "test")
-            logger.info(f"dumped test embeddings: {test_meta['n']} × {test_meta['z_shape'][1:]} -> {emb_dir}")
-        else:
-            logger.warning("dump_embeddings=true but evaluator has no _labeled_test_embeddings; skipping test dump")
+            emb_dir = os.path.join(output_dir, "embeddings")
+            train_records = getattr(evaluator, "_labeled_baseline_embeddings", None)
+            test_records = getattr(evaluator, "_labeled_test_embeddings", None)
+            if train_records:
+                train_meta = dump_embeddings_to_memmap(train_records, emb_dir, "train")
+                logger.info(f"dumped train embeddings: {train_meta['n']} × {train_meta['z_shape'][1:]} -> {emb_dir}")
+            else:
+                logger.warning("dump_embeddings=true but evaluator has no _labeled_baseline_embeddings; skipping train dump")
+            if test_records:
+                test_meta = dump_embeddings_to_memmap(test_records, emb_dir, "test")
+                logger.info(f"dumped test embeddings: {test_meta['n']} × {test_meta['z_shape'][1:]} -> {emb_dir}")
+            else:
+                logger.warning("dump_embeddings=true but evaluator has no _labeled_test_embeddings; skipping test dump")
+        except Exception:
+            logger.exception("dump_embeddings failed; continuing without embeddings dump")
 
     return eval_metrics, predictions
 


### PR DESCRIPTION
Follows up #115 / PR #116.

## Bug

During the issue-115 smoketest on SciQ and PopQA, both cells crashed in `dump_embeddings_to_memmap` at the end of eval:

\`\`\`
KeyError: \"Records must contain 'halu' — call _assign_hallucination_labels first\"
\`\`\`

Root cause: the parent evaluator's `_get_labeled_baseline_embeddings()` calls `_assign_hallucination_labels(baseline_embeddings, keep_unlabeled=True)`. Records whose hashkey doesn't match any row in the activation parser dataframe are kept but **without** a `halu` field. My new dumper hit the first such record and raised.

A second issue: the dump call in `run_contrastive_logprob_recon` was unguarded, so a dump failure invalidated the entire per-seed run — eval_metrics + predictions were already computed but never landed on disk, since the dump exception bubbled up to `main()` which wrote `run_error.json` and skipped the eval writes.

## Fix

1. `dump_embeddings_to_memmap`: filter out records without `z_views` or `halu` (warn the skip count), only raise if zero usable records remain. Test records are labeled with `keep_unlabeled=False` upstream so this filter is usually a no-op for them.
2. Wrap the dump call site in `run_contrastive_logprob_recon` with `try/except` — log the traceback and continue. The eval results are already in hand by that point; the dump is a post-hoc artifact.

## Verification

- 8 records (6 labeled + 2 unlabeled) → dumper writes 6, warns the 2 skipped
- All-unlabeled input → informative `ValueError`
- Files parse cleanly

## In-flight smoketests

The 4 currently-running cells (NQ, HotpotQA, redispatched HotpotQA) will hit the same crash at end-of-eval. Will kill + redispatch them after this merges.