### PR TITLE
chore: guarded autonomous Jupyter-node launcher with job caps

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/launch_jupyter.py:*)",
+      "Bash(ssh empire-ai 'squeue --me:*)"
+    ],
+    "deny": [
+      "Bash(scancel:*)",
+      "Bash(ssh empire-ai 'scancel:*)",
+      "Bash(ssh empire-ai 'scontrol:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,31 @@ python scripts/experiment_status.py --experiment configs/experiments/baseline_co
 
 ### Running on GPU nodes
 
-**Never submit or kill SLURM jobs without explicit user approval.** Do not run `sbatch`, `srun`, `scancel`, `gpu_dispatch.py run/kill`, or kill remote processes without asking first:
+**Never submit or kill SLURM jobs without explicit user approval** — *except* launching Jupyter nodes via the guarded launcher (see below). Do not run `sbatch`, `srun`, `scancel`, `gpu_dispatch.py run/kill`, or kill remote processes without asking first:
 > "I want to [specific action, e.g. kill PID 12345 on alphagpu22]. Yes/No?"
+
+#### Autonomous exception: launching Jupyter nodes
+
+Agents **may** start a Jupyter Lab allocation **without asking**, but **only** through the guarded launcher `scripts/launch_jupyter.py`. It enforces hard caps in code (no agent can bypass them) and has **no cancel path**:
+
+- Refuses if **≥ 4 jupyter jobs are already RUNNING**.
+- Refuses if **≥ 6 jobs total** (any state, including PENDING/queued).
+- Refuses if the requested port already serves a running jupyter job.
+
+```bash
+# Launch (runs squeue + sbatch on the login node in one process — no TOCTOU race):
+ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/launch_jupyter.py <port>'
+
+# Preview the caps + the exact sbatch line without submitting:
+ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/launch_jupyter.py <port> --dry-run'
+```
+
+Ports use the 88xx convention. A non-zero exit means a cap was hit — **do not** work around a refusal (no raw `sbatch`, no editing the caps).
+
+**Still requires explicit approval / still forbidden:**
+- Raw `sbatch ... empire_jupyter_lab.sh` (or any other `sbatch`/`srun`) — it bypasses the caps. Always go through `launch_jupyter.py` for Jupyter.
+- `scancel`, `scontrol` cancel/suspend, `gpu_dispatch.py kill`, or killing remote processes — agents **must not** cancel jobs, ever, without explicit user approval.
+- `gpu_dispatch.py run` and all training/inference job submission — unchanged, still needs approval.
 
 **Avoid duplicate dispatches** — a timed-out dispatch may have actually launched. Before re-dispatching, check `gpu_dispatch.py jobs --all` and wait at least 2 minutes.
 

--- a/scripts/launch_jupyter.py
+++ b/scripts/launch_jupyter.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Guarded launcher for Jupyter Lab SLURM allocations on Empire AI.
+
+This is the ONLY sanctioned way for an agent to start a Jupyter node. It
+counts live SLURM jobs *before* submitting and refuses past two hard caps,
+so the limits hold regardless of which agent runs it:
+
+    MAX_ACTIVE_JUPYTER (4)  RUNNING jupyter_* allocations
+    MAX_TOTAL_JOBS     (6)  all of the user's jobs, any state (incl. PENDING)
+
+By design it has NO cancel/kill path. It submits exactly the approved
+sbatch line and nothing else.
+
+Run it ON the Empire AI login node (a SLURM submit host) — it shells out to
+`squeue` and `sbatch` locally, so counting and submitting happen in one
+process (no cross-SSH race). Typical invocation from an agent:
+
+    ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/launch_jupyter.py 8870'
+    ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/launch_jupyter.py 8870 --dry-run'
+
+Stdlib only. Mirrors the squeue parsing convention in scripts/gpu_dispatch.py.
+
+Exit codes:
+    0   submitted (or --dry-run would-submit)
+    10  a cap would be exceeded — not submitted
+    11  requested port already serves a running jupyter job — not submitted
+    12  environment error (squeue/sbatch missing, or squeue failed)
+    13  invalid port argument
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- Policy (hard caps) ------------------------------------------------------
+# These encode the autonomy grant: future agents may launch Jupyter nodes
+# without asking, but never past these limits. Change them here, in one place.
+MAX_ACTIVE_JUPYTER = 4   # RUNNING jupyter_* jobs
+MAX_TOTAL_JOBS = 6       # all jobs in any state, including PENDING/queued
+
+# --- Submission shape (matches the approved sbatch line) ---------------------
+JUPYTER_SCRIPT = Path.home() / "rit_rc_scripts" / "empire_jupyter_lab.sh"
+SBATCH_FLAGS = ["--cpus-per-task=16", "--mem-per-cpu=24g", "--time=0-72:00:00"]
+PORT_MIN, PORT_MAX = 8800, 8899  # 88xx convention (see gpu_dispatch._port_is_88xx)
+
+# A jupyter allocation's name is "jupyter_empire_<port>" once the job's own
+# `scontrol update` rename runs (at RUNNING). While PENDING it is still the
+# literal "jupyter_empire_PORT" placeholder. Match on the "jupyter_" prefix so
+# we never *undercount* running jupyter jobs (errs toward refusing).
+_JUPYTER_NAME = re.compile(r"^jupyter_")
+# Trailing digits = the live port, used only for the port-collision check.
+_JUPYTER_PORT = re.compile(r"_(\d+)$")
+
+SQUEUE_TIMEOUT = 20
+
+
+def query_jobs():
+    """Return one dict {job_id, name, state, nodelist} per `squeue --me` row."""
+    try:
+        result = subprocess.run(
+            ["squeue", "--me", "--noheader", "--format=%i|%j|%T|%N"],
+            capture_output=True, text=True, timeout=SQUEUE_TIMEOUT,
+        )
+    except FileNotFoundError:
+        sys.exit(_fail(12, "squeue not found in PATH — run this on the Empire AI "
+                           "login node (a SLURM submit host), not in the dev container."))
+    except subprocess.TimeoutExpired:
+        sys.exit(_fail(12, f"squeue timed out after {SQUEUE_TIMEOUT}s."))
+    if result.returncode != 0:
+        sys.exit(_fail(12, f"squeue failed (exit {result.returncode}): "
+                           f"{result.stderr.strip()}"))
+
+    jobs = []
+    for line in result.stdout.strip().splitlines():
+        if not line.strip():
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) < 4:
+            continue
+        job_id, name, state, nodelist = parts[:4]
+        jobs.append({"job_id": job_id, "name": name, "state": state,
+                     "nodelist": nodelist})
+    return jobs
+
+
+def running_jupyter_ports(jobs):
+    """Ports of currently RUNNING jupyter jobs (for collision detection)."""
+    ports = set()
+    for j in jobs:
+        if j["state"] == "RUNNING" and _JUPYTER_NAME.match(j["name"]):
+            m = _JUPYTER_PORT.search(j["name"])
+            if m:
+                ports.add(int(m.group(1)))
+    return ports
+
+
+def _fail(code, msg):
+    print(f"REFUSED: {msg}", file=sys.stderr)
+    return code
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Guarded Jupyter Lab launcher (enforces job caps; no cancel path).")
+    parser.add_argument("port", help=f"Jupyter port ({PORT_MIN}-{PORT_MAX})")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Run the cap checks and print the sbatch command, but do not submit.")
+    args = parser.parse_args()
+
+    # Validate the port.
+    try:
+        port = int(args.port)
+    except ValueError:
+        sys.exit(_fail(13, f"port must be an integer, got {args.port!r}."))
+    if not (PORT_MIN <= port <= PORT_MAX):
+        sys.exit(_fail(13, f"port {port} outside the {PORT_MIN}-{PORT_MAX} range."))
+
+    if not JUPYTER_SCRIPT.is_file():
+        sys.exit(_fail(12, f"launch script not found: {JUPYTER_SCRIPT}"))
+
+    jobs = query_jobs()
+    active_jupyter = sum(
+        1 for j in jobs if j["state"] == "RUNNING" and _JUPYTER_NAME.match(j["name"]))
+    total = len(jobs)
+
+    print(f"Current state: {active_jupyter} running jupyter job(s) "
+          f"(cap {MAX_ACTIVE_JUPYTER}), {total} total job(s) (cap {MAX_TOTAL_JOBS}).")
+
+    # --- Enforce caps ---
+    if active_jupyter >= MAX_ACTIVE_JUPYTER:
+        sys.exit(_fail(10, f"{active_jupyter} jupyter job(s) already running "
+                           f"(cap {MAX_ACTIVE_JUPYTER}). Not submitting."))
+    if total >= MAX_TOTAL_JOBS:
+        sys.exit(_fail(10, f"{total} job(s) already queued/running "
+                           f"(cap {MAX_TOTAL_JOBS}). Not submitting."))
+    if port in running_jupyter_ports(jobs):
+        sys.exit(_fail(11, f"port {port} is already served by a running jupyter "
+                           f"job. Pick another port."))
+
+    cmd = ["sbatch", *SBATCH_FLAGS, str(JUPYTER_SCRIPT), str(port)]
+    printable = " ".join(cmd)
+
+    if args.dry_run:
+        print(f"[dry-run] would submit: {printable}")
+        return 0
+
+    print(f"Submitting: {printable}")
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(Path.home()))
+    sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Grants future agents autonomy to start Jupyter Lab SLURM nodes on Empire AI, with guardrails enforced in code.

## What
- **`scripts/launch_jupyter.py`** — the only sanctioned way for an agent to launch a Jupyter node. Counts live `squeue` jobs before `sbatch` and refuses past hard caps:
  - ≥ 4 **RUNNING** jupyter jobs
  - ≥ 6 **total** jobs (any state, incl. PENDING/queued)
  - requested port already serving a running jupyter job

  No cancel/kill path by design. Supports `--dry-run`. Stdlib-only; runs on the login node so the count+submit happen in one process (no cross-SSH race).
- **`CLAUDE.md`** — autonomy carve-out: agents may launch without asking, but raw `sbatch`, `scancel`/`scontrol`, `gpu_dispatch kill`, and training/inference submission still require explicit approval.
- **`.claude/settings.json`** — allow-rules so the launcher (and read-only `squeue --me`) run hands-off; best-effort deny on direct cancel forms.

## Verification
Counting logic validated against live `squeue`: `3 running jupyter / 3 total → ALLOW` (correct).

## Caveats
- Deny-rules are best-effort: ssh-wrapped `cd … && scancel …` can't be caught by static permission rules; the real cancel prohibition lives in CLAUDE.md + the launcher having no cancel path.
- Allow-rule is a pinned prefix; an off-pattern invocation falls back to a prompt (fails safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)