### PR TITLE
fix(#140): P1 prevalence subsample silently no-op'd on the contrastive arm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,17 @@ ssh empire-ai 'squeue --me'
 ssh empire-ai 'cd ~/LLM_research/HalluLens && python scripts/results_table.py'
 ```
 
+### Deploying code changes to Empire AI
+
+**Prefer git for deploying code to the Empire AI checkout (`~/LLM_research/HalluLens`) — not `scp` or manual remote edits.** Workflow:
+
+1. Commit and push the change from this repo (branch + PR as usual).
+2. Update the remote checkout via git on the login node:
+   - merged to `main`: `ssh empire-ai 'cd ~/LLM_research/HalluLens && git pull --ff-only'`
+   - deploying a branch before merge: `ssh empire-ai 'cd ~/LLM_research/HalluLens && git fetch && git checkout <branch>'`
+
+`scp`-ing files or editing them directly on the remote leaves the checkout dirty and untracked: the next `git pull` conflicts, and a dispatched run can silently execute code that exists in no commit — producing results you cannot reproduce or trace to a diff. Reserve direct file copies for throwaway scratch (e.g. one-off smoketest scripts), never for code that generates logged results.
+
 ### Claude Code GPU execution (REMOTE_GPU only)
 
 GPU nodes (`alphagpuXX`) are not directly reachable from this dev container — they are only accessible from the Empire AI login node. Before using `jupyter_exec.py`, first SSH into the login node to open a tunnel:

--- a/activation_research/composite_memmap_parser.py
+++ b/activation_research/composite_memmap_parser.py
@@ -260,10 +260,14 @@ class CompositeMemmapActivationParser:
                     "captures (split_strategy='three_way'). Use a separate "
                     "MemmapActivationParser for the test capture."
                 )
+            # Derive from the live df (single source of truth) so in-place split
+            # edits (e.g. _apply_train_prevalence's P1 subsample, #140) are
+            # honored. The df's 0..N-1 RangeIndex aligns with self._row_map
+            # positions, so this is drop-in-equivalent for an unmodified parser.
             if split == "train":
-                idx = self._train_idx
+                idx = self._df.index[self._df["split"] == "train"].to_numpy()
             elif split == "val":
-                idx = self._val_idx
+                idx = self._df.index[self._df["split"] == "val"].to_numpy()
             else:
                 raise ValueError(f"Unknown split: {split!r}")
         else:

--- a/activation_research/memmap_activation_parser.py
+++ b/activation_research/memmap_activation_parser.py
@@ -191,10 +191,16 @@ class MemmapActivationParser:
                 "test capture directory — construct a second parser with "
                 "split_strategy='none' for test data."
             )
+        # Derive split indices from the LIVE df (single source of truth) so
+        # in-place split edits are honored — e.g. _apply_train_prevalence's P1
+        # subsample (#140) re-labels dropped train rows to '__unused__' on
+        # self._df. self._df carries a 0..N-1 RangeIndex aligned with the
+        # positional indices used downstream, so for an unmodified parser this
+        # is drop-in-equivalent to the cached self._train_idx/_val_idx.
         if split == "train":
-            indices = self._train_idx
+            indices = self._df.index[self._df["split"] == "train"].to_numpy()
         elif split == "val":
-            indices = self._val_idx
+            indices = self._df.index[self._df["split"] == "val"].to_numpy()
         else:
             raise ValueError(f"Unknown split: {split!r}")
 

--- a/configs/experiments/dataeff_hotpotqa_frac10.json
+++ b/configs/experiments/dataeff_hotpotqa_frac10.json
@@ -1,0 +1,21 @@
+{
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "methods": [
+    "act_vit",
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "experiment_name": "dataeff_hotpotqa_frac10",
+  "dataset": "hotpotqa_memmap",
+  "training_seeds": [
+    0
+  ],
+  "split_seeds": [
+    42
+  ],
+  "train_prevalence": 0.62,
+  "train_total_n": 4500
+}

--- a/configs/experiments/dataeff_hotpotqa_frac50.json
+++ b/configs/experiments/dataeff_hotpotqa_frac50.json
@@ -1,0 +1,21 @@
+{
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "methods": [
+    "act_vit",
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "experiment_name": "dataeff_hotpotqa_frac50",
+  "dataset": "hotpotqa_memmap",
+  "training_seeds": [
+    0
+  ],
+  "split_seeds": [
+    42
+  ],
+  "train_prevalence": 0.62,
+  "train_total_n": 22500
+}

--- a/configs/experiments/dataeff_hotpotqa_qwen3_frac10.json
+++ b/configs/experiments/dataeff_hotpotqa_qwen3_frac10.json
@@ -1,0 +1,21 @@
+{
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "methods": [
+    "act_vit",
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "experiment_name": "dataeff_hotpotqa_qwen3_frac10",
+  "dataset": "hotpotqa_qwen3_memmap",
+  "training_seeds": [
+    0
+  ],
+  "split_seeds": [
+    42
+  ],
+  "train_prevalence": 0.67,
+  "train_total_n": 4500
+}

--- a/configs/experiments/dataeff_hotpotqa_qwen3_frac50.json
+++ b/configs/experiments/dataeff_hotpotqa_qwen3_frac50.json
@@ -1,0 +1,21 @@
+{
+  "device": "auto",
+  "num_workers": 4,
+  "persistent_workers": true,
+  "output_dir": "runs",
+  "methods": [
+    "act_vit",
+    "contrastive_logprob_recon_b5"
+  ],
+  "split_seed": 42,
+  "experiment_name": "dataeff_hotpotqa_qwen3_frac50",
+  "dataset": "hotpotqa_qwen3_memmap",
+  "training_seeds": [
+    0
+  ],
+  "split_seeds": [
+    42
+  ],
+  "train_prevalence": 0.67,
+  "train_total_n": 22500
+}

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -279,10 +279,13 @@ def _apply_train_prevalence(parser, experiment_cfg, run_seed=None):
 
     Reads from experiment_cfg: train_prevalence (float in (0,1)), train_total_n
     (int; default = all available), resample_seed (default split_seed).
+
+    Returns the realized kept train-row count, or None when no subsample is
+    applied — so callers can assert their built train set matches it. (#140)
     """
     prev = experiment_cfg.get("train_prevalence", None)
     if prev is None:
-        return
+        return None
     import numpy as np
 
     total_n = experiment_cfg.get("train_total_n", None)
@@ -314,6 +317,9 @@ def _apply_train_prevalence(parser, experiment_cfg, run_seed=None):
         f"kept pos={n_pos} neg={n_neg} (achieved_prev={n_pos/max(n_pos+n_neg,1):.3f}; "
         f"avail pos={avail_pos} neg={avail_neg}); dropped {len(drop)} train rows"
     )
+    # Realized kept train-row count — runners assert their built train set
+    # matches this so a future subsample-propagation regression fails loudly. (#140)
+    return int((df["split"] == "train").sum())
 
 
 def run_contrastive_logprob_recon(
@@ -327,7 +333,7 @@ def run_contrastive_logprob_recon(
     test_ap=None,
 ) -> tuple[dict, list[dict]]:
     """Train and evaluate a LogprobReconProgressiveCompressor model."""
-    _apply_train_prevalence(ap, experiment_cfg, run_seed=training_seed)  # P1 sweep (#140); no-op otherwise
+    _p1_expected_train_n = _apply_train_prevalence(ap, experiment_cfg, run_seed=training_seed)  # P1 sweep (#140); no-op otherwise
     data_cfg = method_cfg["data"]
     train_cfg = method_cfg["training"]
     eval_cfg = method_cfg["evaluation"]
@@ -346,6 +352,12 @@ def run_contrastive_logprob_recon(
     )
 
     train_ds = ap.get_dataset("train", **ds_kwargs)
+    if _p1_expected_train_n is not None and len(train_ds) != _p1_expected_train_n:
+        raise RuntimeError(
+            f"[P1 guard] train_prevalence set (expected {_p1_expected_train_n} train rows) "
+            f"but get_dataset('train') returned {len(train_ds)} — subsample did not "
+            f"propagate to the contrastive train set."
+        )
     eval_ap = test_ap if test_ap is not None else ap
     test_ds = eval_ap.get_dataset("test", **ds_kwargs)
 
@@ -2671,10 +2683,15 @@ def run_act_vit(
         random_seed=split_seed,
         split_strategy="three_way",
     )
-    _apply_train_prevalence(train_parser, experiment_cfg, run_seed=training_seed)  # P1 sweep (#140); no-op otherwise
+    _p1_expected_train_n = _apply_train_prevalence(train_parser, experiment_cfg, run_seed=training_seed)  # P1 sweep (#140); no-op otherwise
     train_df = train_parser.df[train_parser.df["split"] == "train"]
     val_df = train_parser.df[train_parser.df["split"] == "val"]
     train_idx = train_df["sample_index"].values
+    if _p1_expected_train_n is not None and len(train_idx) != _p1_expected_train_n:
+        raise RuntimeError(
+            f"[P1 guard] train_prevalence set (expected {_p1_expected_train_n} train rows) "
+            f"but act_vit train split has {len(train_idx)} — subsample did not propagate."
+        )
     val_idx = val_df["sample_index"].values
 
     if test_ap is not None:


### PR DESCRIPTION
## Problem
The #140 imbalance-robustness sweep varies `train_prevalence` to test how methods degrade under class imbalance. But `MemmapActivationParser.get_dataset("train")` returned a **cached `self._train_idx`** computed at construction, ignoring the live `self._df["split"]` that `_apply_train_prevalence` edits in place.

Result: the **contrastive arm trained and built its kNN/mahalanobis/cosine reference bank on the full ~45k train split at hotpotqa's natural 62% halu rate**, regardless of the prevalence setting — `n_train=44996` instead of `15000` at prev05. The contrastive curve would have been flat (measuring nothing), and the apparent "+0.03 at prev05" was contrastive@~62% vs act_vit@5% (apples-to-oranges). `act_vit` was unaffected — it bypasses `get_dataset` and re-filters `self._df` directly. The same latent bug existed in `CompositeMemmapParser`.

## Fix
- Both parsers derive train/val indices from the **live `self._df`** (single source of truth). Drop-in-equivalent for an unmodified parser (df has a 0..N-1 RangeIndex aligned with the positional indices used downstream).
- `_apply_train_prevalence` returns the realized kept train-row count; the contrastive + act_vit runners **hard-raise** if their built train set != expected — so a future propagation regression fails loudly instead of silently training on the wrong data.

## Validation (alphagpu16, p311)
- Parser unit test: `n_train=15000` at prev 0.05/0.50/0.90, achieved prevalence exact, val fixed at 5000, and the **baseline reproduces the buggy 44996**.
- 1-epoch end-to-end contrastive run: records `n_train=15000`, guard passes.

## Also
- Doc commit: prefer git (not scp/manual edits) for deploying code to the Empire AI checkout.

## Follow-ups (not in this PR)
- Pre-fix contrastive results were quarantined; the sweep was restarted on this code in smart order (act_vit curve first, then contrastive coarse-first 50/05/90).
- triviaqa cells not yet queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)