### PR TITLE
feat(#145): dual-label data contract — LLM-judge label + label_source knob

### DIFF
--- a/activation_research/act_vit_dataset.py
+++ b/activation_research/act_vit_dataset.py
@@ -22,6 +22,8 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 
+from activation_research.labels import load_meta
+
 
 class ACTViTDataset(Dataset):
     """Dataset returning full activation tensors (L, N, D) per sample.
@@ -43,6 +45,7 @@ class ACTViTDataset(Dataset):
         indices: Sequence[int],
         *,
         cfg: dict | None = None,
+        label_source: str = "substring",
     ) -> None:
         self._capture_dir = Path(capture_dir)
 
@@ -72,15 +75,13 @@ class ACTViTDataset(Dataset):
             shape=(n_samples,),
         )
 
-        # Load labels from meta.jsonl.
-        labels: List[int] = []
-        with (self._capture_dir / "meta.jsonl").open() as fh:
-            for line in fh:
-                line = line.strip()
-                if line:
-                    obj = json.loads(line)
-                    labels.append(int(bool(obj["hallucinated"])))
-        self._labels = np.array(labels, dtype=np.int32)
+        # Load labels from meta.jsonl (or the LLM-judge sidecar when
+        # label_source == "llm_judge"; load_meta overrides hallucinated by
+        # sample_index — see activation_research/labels.py and issue #145).
+        meta_rows = load_meta(self._capture_dir, label_source)
+        self._labels = np.array(
+            [int(bool(r["hallucinated"])) for r in meta_rows], dtype=np.int32
+        )
 
         # meta.jsonl may have fewer committed rows than config.json's n_samples
         # (e.g. partial capture or interrupted write). Clip indices to the

--- a/activation_research/labels.py
+++ b/activation_research/labels.py
@@ -1,0 +1,108 @@
+"""labels.py — centralized correctness-label loading with a selectable source.
+
+Every icr_capture loader derives its binary correctness label from meta.jsonl's
+`hallucinated` field (substring-match). This module adds an alternate source — an
+LLM-judge sidecar (`judge_labels.jsonl`) — selectable per dataset via `label_source`.
+
+The swap happens at the meta-loading layer: ``load_meta(dir, label_source)``
+returns the meta rows with each row's ``hallucinated`` field set from the chosen
+source, so all downstream ``row["hallucinated"]`` reads, ``outlier_class``, and
+flip conventions keep working unchanged.
+
+Contract (judge sidecar — additive, non-destructive; see issue #145):
+  ``<capture_dir>/judge_labels.jsonl`` — one JSON/line, keyed by ``sample_index``::
+
+      {"sample_index": 0, "judge_verdict": "CORRECT|INCORRECT|UNKNOWN",
+       "hallucinated": false}   # hallucinated == (verdict == "INCORRECT")
+
+  ``<capture_dir>/judge_labels_meta.json`` — provenance (judge_model, prompt, ...).
+
+Alignment is by ``sample_index`` (join), NOT row order — robust to reordering
+(cf. the merge-tail-misalignment bug). Rows with no judge entry or verdict
+``UNKNOWN`` fall back to the substring label (counted; logged once).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+VALID_SOURCES = ("substring", "llm_judge")
+JUDGE_SIDECAR = "judge_labels.jsonl"
+
+
+def _read_meta_rows(capture_dir: Path) -> list[dict]:
+    rows: list[dict] = []
+    with (capture_dir / "meta.jsonl").open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _load_judge_map(capture_dir: Path) -> dict[int, bool]:
+    """Return {sample_index: judge hallucinated bool}; UNKNOWN entries omitted."""
+    path = capture_dir / JUDGE_SIDECAR
+    if not path.exists():
+        raise FileNotFoundError(
+            f"label_source='llm_judge' but {path} not found. Run "
+            f"scripts/label_audit/backfill_judge_labels.py for this capture first."
+        )
+    m: dict[int, bool] = {}
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            o = json.loads(line)
+            if str(o.get("judge_verdict", "")).upper() == "UNKNOWN":
+                continue
+            m[int(o["sample_index"])] = bool(o["hallucinated"])
+    return m
+
+
+def load_meta(capture_dir: Union[str, Path], label_source: str = "substring") -> list[dict]:
+    """Load meta.jsonl rows with ``hallucinated`` set from the chosen source.
+
+    Parameters
+    ----------
+    capture_dir : str | Path
+        An icr_capture directory.
+    label_source : {"substring", "llm_judge"}
+        "substring" (default) — use meta.jsonl's ``hallucinated`` field as-is.
+        "llm_judge" — override ``hallucinated`` from ``judge_labels.jsonl`` (joined
+        by ``sample_index``); rows missing a judge entry or marked ``UNKNOWN`` keep
+        the substring value.
+
+    Returns
+    -------
+    list[dict]
+        Meta rows in file order (unchanged), with ``hallucinated`` possibly overridden.
+    """
+    capture_dir = Path(capture_dir)
+    if label_source not in VALID_SOURCES:
+        raise ValueError(f"label_source must be one of {VALID_SOURCES}, got {label_source!r}")
+
+    rows = _read_meta_rows(capture_dir)
+    if label_source == "substring":
+        return rows
+
+    judge = _load_judge_map(capture_dir)
+    n_override = n_fallback = 0
+    for r in rows:
+        si = r.get("sample_index")
+        if si is not None and int(si) in judge:
+            r["hallucinated"] = judge[int(si)]
+            n_override += 1
+        else:
+            n_fallback += 1  # keep the substring value already in the row
+    logger.info(
+        "load_meta(%s, llm_judge): %d judge-labeled, %d substring-fallback (%.1f%% coverage)",
+        capture_dir.name, n_override, n_fallback,
+        100.0 * n_override / max(1, len(rows)),
+    )
+    return rows

--- a/activation_research/memmap_activation_parser.py
+++ b/activation_research/memmap_activation_parser.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 import numpy as np
 from sklearn.model_selection import train_test_split
 
+from activation_research.labels import load_meta
 from activation_research.memmap_contrastive_dataset import MemmapContrastiveDataset
 
 if TYPE_CHECKING:
@@ -48,6 +49,7 @@ class MemmapActivationParser:
         *,
         random_seed: int,
         split_strategy: Literal["none", "three_way"] = "three_way",
+        label_source: str = "substring",
         verbose: bool = False,
     ) -> None:
         self._capture_dir = Path(capture_dir)
@@ -57,18 +59,16 @@ class MemmapActivationParser:
             )
         self._split_strategy = split_strategy
         self._random_seed = random_seed
+        self._label_source = label_source
 
         # Load config and meta.
         with (self._capture_dir / "config.json").open() as fh:
             self._cfg: dict = json.load(fh)
         n_samples: int = self._cfg["n_samples"]
 
-        meta_rows: List[dict] = []
-        with (self._capture_dir / "meta.jsonl").open() as fh:
-            for line in fh:
-                line = line.strip()
-                if line:
-                    meta_rows.append(json.loads(line))
+        # meta rows with hallucinated set per label_source (substring | llm_judge);
+        # feeds the stratified split, self._df["halu"], and downstream labels.
+        meta_rows = load_meta(self._capture_dir, label_source)
         if not meta_rows:
             raise ValueError(f"meta.jsonl is empty in {self._capture_dir}")
         self._meta = meta_rows
@@ -180,6 +180,7 @@ class MemmapActivationParser:
                 pad_length=pad_length,
                 include_response_logprobs=include_response_logprobs,
                 response_logprobs_top_k=response_logprobs_top_k,
+                label_source=self._label_source,
                 _override_split_name="test",
             )
 
@@ -214,6 +215,7 @@ class MemmapActivationParser:
             pad_length=pad_length,
             include_response_logprobs=include_response_logprobs,
             response_logprobs_top_k=response_logprobs_top_k,
+            label_source=self._label_source,
             _override_indices=indices,
             _override_split_name=split,
         )

--- a/activation_research/memmap_contrastive_dataset.py
+++ b/activation_research/memmap_contrastive_dataset.py
@@ -36,6 +36,7 @@ import torch
 from torch.utils.data import Dataset
 
 from activation_research.icr_dataset import _make_split_indices
+from activation_research.labels import load_meta
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +157,7 @@ class MemmapContrastiveDataset(Dataset):
         split: Literal["train", "val", "test", "all"] = "train",
         val_fraction: Optional[float] = None,
         random_seed: int = 42,
+        label_source: str = "substring",
         # Contrastive view sampling
         num_views: int = 2,
         relevant_layers: Optional[List[int]] = None,
@@ -199,12 +201,9 @@ class MemmapContrastiveDataset(Dataset):
         stored_top_k: int = cfg.get("response_logprobs_top_k", response_logprobs_top_k)
 
         # --- meta.jsonl (authoritative valid-rows list) ---
-        meta_rows: List[dict] = []
-        with (capture_dir / "meta.jsonl").open() as fh:
-            for line in fh:
-                line = line.strip()
-                if line:
-                    meta_rows.append(json.loads(line))
+        # hallucinated set per label_source (substring | llm_judge); see
+        # activation_research/labels.py and issue #145.
+        meta_rows = load_meta(capture_dir, label_source)
         if not meta_rows:
             raise ValueError(f"meta.jsonl in {capture_dir} contains no rows")
         self._meta = meta_rows

--- a/scripts/label_audit/backfill_judge_labels.py
+++ b/scripts/label_audit/backfill_judge_labels.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""backfill_judge_labels.py — write LLM-judge labels into icr_capture dirs (#145).
+
+For each capture dir, reads generation.jsonl, judges every sample (Sonnet via
+`claude -p`), and writes the sidecar consumed by activation_research/labels.py:
+
+  <dir>/judge_labels.jsonl     one JSON/line keyed by sample_index:
+      {"sample_index": 0, "judge_verdict": "CORRECT|INCORRECT|UNKNOWN",
+       "hallucinated": false}   # hallucinated == (verdict == "INCORRECT")
+  <dir>/judge_labels_meta.json  provenance (judge_model, prompt_version, ...).
+
+Resumable: sample_indexes already in judge_labels.jsonl are skipped. Full train
+captures are large (up to ~90k); run incrementally / per capture as needed.
+
+Usage (local, `claude` authenticated):
+  python scripts/label_audit/backfill_judge_labels.py \
+      --capture-dirs shared/icr_capture/hotpotqa_test_Llama-3.1-8B-Instruct ... \
+      --model sonnet --batch-size 20 --workers 8
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from judge_core import PROMPT_VERSION, judge_batch  # same dir on sys.path as a script
+
+
+def _load_generation(cap: Path) -> list[dict]:
+    recs: list[dict] = []
+    with (cap / "generation.jsonl").open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                recs.append(json.loads(line))
+    return recs
+
+
+def _done_indices(sidecar: Path) -> set[int]:
+    done: set[int] = set()
+    if sidecar.exists():
+        with sidecar.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        done.add(int(json.loads(line)["sample_index"]))
+                    except (json.JSONDecodeError, KeyError, ValueError):
+                        pass
+    return done
+
+
+def _judge_record(rec: dict) -> dict:
+    """Normalize a generation.jsonl row to a judging record keyed by sample_index.
+
+    Note: some datasets (e.g. hotpotqa) carry their own `id`; we key on
+    sample_index to align with meta.jsonl, so set the judge `id` explicitly.
+    """
+    return {
+        "id": str(rec["sample_index"]),
+        "sample_index": int(rec["sample_index"]),
+        "question": rec.get("question") or rec.get("prompt", ""),
+        "answer": rec.get("answer"),
+        "possible_answers": rec.get("possible_answers"),
+        "choices": rec.get("choices"),
+        "generation": rec.get("generation", ""),
+    }
+
+
+def backfill_one(cap: Path, model: str, batch_size: int, workers: int, timeout: int) -> str:
+    if not (cap / "generation.jsonl").exists():
+        return f"SKIP  {cap.name}: no generation.jsonl"
+    recs = [_judge_record(r) for r in _load_generation(cap)]
+    sidecar = cap / "judge_labels.jsonl"
+    done = _done_indices(sidecar)
+    todo = [r for r in recs if r["sample_index"] not in done]
+    if not todo:
+        return f"OK    {cap.name}: all {len(recs)} already judged"
+
+    batches = [todo[i:i + batch_size] for i in range(0, len(todo), batch_size)]
+    lock = threading.Lock()
+    n_new = n_unknown = 0
+    with sidecar.open("a", encoding="utf-8") as w:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futs = {ex.submit(judge_batch, b, model, timeout, id_key="id"): b for b in batches}
+            for fut in as_completed(futs):
+                by_id = {r["id"]: r for r in futs[fut]}
+                with lock:
+                    for rid, v in fut.result().items():
+                        verdict = v["verdict"]
+                        n_unknown += verdict == "UNKNOWN"
+                        w.write(json.dumps({
+                            "sample_index": by_id[rid]["sample_index"],
+                            "judge_verdict": verdict,
+                            "hallucinated": verdict == "INCORRECT",
+                        }) + "\n")
+                        n_new += 1
+                    w.flush()
+
+    (cap / "judge_labels_meta.json").write_text(json.dumps({
+        "judge_model": model,
+        "prompt_version": PROMPT_VERSION,
+        "n_judged": len(done) + n_new,
+        "n_unknown_this_run": n_unknown,
+        "source": "generation.jsonl",
+    }, indent=2))
+    return f"OK    {cap.name}: +{n_new} new ({n_unknown} UNKNOWN), total {len(done)+n_new}/{len(recs)}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--capture-dirs", nargs="+", required=True,
+                    help="icr_capture dirs to backfill (each needs generation.jsonl)")
+    ap.add_argument("--model", default="sonnet")
+    ap.add_argument("--batch-size", type=int, default=20)
+    ap.add_argument("--workers", type=int, default=8)
+    ap.add_argument("--timeout", type=int, default=180)
+    args = ap.parse_args()
+    for d in args.capture_dirs:
+        print(backfill_one(Path(d), args.model, args.batch_size, args.workers, args.timeout), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/label_audit/judge.py
+++ b/scripts/label_audit/judge.py
@@ -4,12 +4,10 @@
 Reads the sample files from export_sample.py, sends batches to `claude -p`, and
 records a CORRECT/INCORRECT verdict per item to compare against the current
 substring-match label. Runs LOCALLY (where the `claude` CLI is authenticated).
+Shared judging primitives live in judge_core.py (also used by backfill_judge_labels.py).
 
-- Batched (default 20 items/call) to amortize CLI/model start-up latency.
-- Concurrent (default 8 workers).
-- Resumable: audit_ids already present in the judged output are skipped.
-- Robust parse: strips fences, extracts the JSON array; a batch that won't parse
-  or is missing ids is retried at batch size 1 before giving up (verdict=UNKNOWN).
+- Batched (default 20 items/call), concurrent (default 8 workers).
+- Resumable: audit_ids already in the judged output are skipped.
 
 Usage (local):
   python scripts/label_audit/judge.py \
@@ -21,112 +19,16 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
-import subprocess
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-INSTRUCTION = """You are grading whether a model's ANSWER to a QUESTION is correct, given the REFERENCE answer(s).
-
-Rules:
-- Judge SEMANTIC correctness, not wording. A paraphrase, synonym, or equivalent value/number is CORRECT.
-- If the answer contradicts the reference, omits the answer, or adds a wrong claim that changes the conclusion, it is INCORRECT.
-- If the answer rambles or self-corrects, judge its final/overall committed answer.
-- For MULTIPLE CHOICE, the reference is the correct option. CORRECT iff the answer selects or states that option (by letter OR by its text), even with extra text. INCORRECT if it commits to a different option.
-- Extra correct detail is fine; a different factual answer is INCORRECT.
-
-Output ONLY a JSON array, one object per item, in the SAME ORDER as given:
-[{"id": "<id>", "verdict": "CORRECT" or "INCORRECT", "reason": "<=12 words"}]
-No markdown, no code fences, no prose before or after the array.
-
-Items to grade:
-"""
-
-
-def build_item(rec: dict) -> dict:
-    g = rec.get("gold") or {}
-    ref = {}
-    if g.get("answer") is not None:
-        ref["answer"] = g["answer"]
-    if g.get("possible_answers"):
-        ref["acceptable_answers"] = g["possible_answers"]
-    item = {
-        "id": rec["audit_id"],
-        "question": rec.get("question", ""),
-        "reference": ref,
-        "model_answer": rec.get("generation", ""),
-    }
-    if rec.get("choices"):
-        item["multiple_choice_options"] = rec["choices"]
-    return item
-
-
-def _extract_json_array(text: str):
-    """Pull the first top-level JSON array out of a model response."""
-    t = text.strip()
-    t = re.sub(r"^```(?:json)?", "", t).strip()
-    t = re.sub(r"```$", "", t).strip()
-    start = t.find("[")
-    if start == -1:
-        return None
-    depth = 0
-    for i in range(start, len(t)):
-        if t[i] == "[":
-            depth += 1
-        elif t[i] == "]":
-            depth -= 1
-            if depth == 0:
-                try:
-                    return json.loads(t[start:i + 1])
-                except json.JSONDecodeError:
-                    return None
-    return None
-
-
-def call_claude(prompt: str, model: str, timeout: int) -> str:
-    r = subprocess.run(
-        ["claude", "-p", "--model", model],
-        input=prompt, capture_output=True, text=True, timeout=timeout,
-    )
-    if r.returncode != 0:
-        raise RuntimeError(f"claude rc={r.returncode}: {r.stderr[:200]}")
-    return r.stdout
-
-
-def judge_batch(batch: list[dict], model: str, timeout: int) -> dict[str, dict]:
-    """Return {audit_id: {verdict, reason}} for a batch; UNKNOWN on unrecoverable failure."""
-    items = [build_item(r) for r in batch]
-    prompt = INSTRUCTION + json.dumps(items, ensure_ascii=False)
-    ids = {r["audit_id"] for r in batch}
-    try:
-        out = call_claude(prompt, model, timeout)
-        arr = _extract_json_array(out)
-    except (subprocess.TimeoutExpired, RuntimeError):
-        arr = None
-
-    verdicts: dict[str, dict] = {}
-    if arr:
-        for o in arr:
-            oid = str(o.get("id", ""))
-            v = str(o.get("verdict", "")).upper()
-            if oid in ids and v in ("CORRECT", "INCORRECT"):
-                verdicts[oid] = {"verdict": v, "reason": str(o.get("reason", ""))[:160]}
-
-    missing = [r for r in batch if r["audit_id"] not in verdicts]
-    # Retry the missing ones one-at-a-time (only if the batch was >1, to avoid loops)
-    if missing and len(batch) > 1:
-        for r in missing:
-            verdicts.update(judge_batch([r], model, timeout))
-    elif missing:  # single item still failed
-        for r in missing:
-            verdicts[r["audit_id"]] = {"verdict": "UNKNOWN", "reason": "judge parse/timeout failure"}
-    return verdicts
+from judge_core import judge_batch  # same dir on sys.path when run as a script
 
 
 def load_done(out_path: Path) -> set[str]:
-    done = set()
+    done: set[str] = set()
     if out_path.exists():
         with out_path.open(encoding="utf-8") as fh:
             for line in fh:
@@ -153,7 +55,7 @@ def process_file(sample_path: Path, out_dir: Path, model: str,
     n_done = 0
     with out_path.open("a", encoding="utf-8") as w:
         with ThreadPoolExecutor(max_workers=workers) as ex:
-            futs = {ex.submit(judge_batch, b, model, timeout): b for b in batches}
+            futs = {ex.submit(judge_batch, b, model, timeout, id_key="audit_id"): b for b in batches}
             for fut in as_completed(futs):
                 batch = futs[fut]
                 verdicts = fut.result()

--- a/scripts/label_audit/judge_core.py
+++ b/scripts/label_audit/judge_core.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""judge_core.py — shared LLM-judge primitives (Sonnet via `claude -p`).
+
+Used by both:
+  - judge.py                 (the 1k-sample audit, issue #143)
+  - backfill_judge_labels.py (full-capture relabel into judge_labels.jsonl, #145)
+
+The judge grades whether a model's answer is correct given the reference
+answer(s), reference-grounded ("answer matching"). Verdict: CORRECT | INCORRECT.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+PROMPT_VERSION = "v1"
+
+INSTRUCTION = """You are grading whether a model's ANSWER to a QUESTION is correct, given the REFERENCE answer(s).
+
+Rules:
+- Judge SEMANTIC correctness, not wording. A paraphrase, synonym, or equivalent value/number is CORRECT.
+- If the answer contradicts the reference, omits the answer, or adds a wrong claim that changes the conclusion, it is INCORRECT.
+- If the answer rambles or self-corrects, judge its final/overall committed answer.
+- For MULTIPLE CHOICE, the reference is the correct option. CORRECT iff the answer selects or states that option (by letter OR by its text), even with extra text. INCORRECT if it commits to a different option.
+- Extra correct detail is fine; a different factual answer is INCORRECT.
+
+Output ONLY a JSON array, one object per item, in the SAME ORDER as given:
+[{"id": "<id>", "verdict": "CORRECT" or "INCORRECT", "reason": "<=12 words"}]
+No markdown, no code fences, no prose before or after the array.
+
+Items to grade:
+"""
+
+
+def build_item(rec: dict) -> dict:
+    """Map a sample record to the compact judge item. Accepts either the audit
+    sample schema (gold dict) or a raw generation.jsonl record (answer/possible_answers)."""
+    gold = rec.get("gold")
+    if gold is None:
+        gold = {}
+        if rec.get("answer") is not None:
+            gold["answer"] = rec["answer"]
+        for k in ("possible_answers", "answers", "aliases"):
+            if rec.get(k):
+                gold["possible_answers"] = rec[k]
+                break
+    ref = {}
+    if gold.get("answer") is not None:
+        ref["answer"] = gold["answer"]
+    if gold.get("possible_answers"):
+        ref["acceptable_answers"] = gold["possible_answers"]
+    item = {
+        "id": rec["id"] if "id" in rec else rec.get("audit_id"),
+        "question": rec.get("question") or rec.get("prompt", ""),
+        "reference": ref,
+        "model_answer": (rec.get("generation") or "").strip(),
+    }
+    if rec.get("choices"):
+        item["multiple_choice_options"] = rec["choices"]
+    return item
+
+
+def extract_json_array(text: str):
+    """Pull the first top-level JSON array out of a model response."""
+    t = text.strip()
+    t = re.sub(r"^```(?:json)?", "", t).strip()
+    t = re.sub(r"```$", "", t).strip()
+    start = t.find("[")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(t)):
+        if t[i] == "[":
+            depth += 1
+        elif t[i] == "]":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(t[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def call_claude(prompt: str, model: str, timeout: int) -> str:
+    r = subprocess.run(
+        ["claude", "-p", "--model", model],
+        input=prompt, capture_output=True, text=True, timeout=timeout,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"claude rc={r.returncode}: {r.stderr[:200]}")
+    return r.stdout
+
+
+def judge_batch(batch: list[dict], model: str, timeout: int, *, id_key: str) -> dict[str, dict]:
+    """Judge a batch of sample records. Returns {id: {verdict, reason}} keyed by rec[id_key].
+
+    A batch that won't parse or is missing ids is retried at batch size 1 before
+    giving up (verdict=UNKNOWN)."""
+    items = [build_item(r) for r in batch]
+    prompt = INSTRUCTION + json.dumps(items, ensure_ascii=False)
+    ids = {str(r[id_key]) for r in batch}
+    try:
+        arr = extract_json_array(call_claude(prompt, model, timeout))
+    except (subprocess.TimeoutExpired, RuntimeError):
+        arr = None
+
+    verdicts: dict[str, dict] = {}
+    if arr:
+        for o in arr:
+            oid = str(o.get("id", ""))
+            v = str(o.get("verdict", "")).upper()
+            if oid in ids and v in ("CORRECT", "INCORRECT"):
+                verdicts[oid] = {"verdict": v, "reason": str(o.get("reason", ""))[:160]}
+
+    missing = [r for r in batch if str(r[id_key]) not in verdicts]
+    if missing and len(batch) > 1:
+        for r in missing:
+            verdicts.update(judge_batch([r], model, timeout, id_key=id_key))
+    elif missing:  # single item still failed
+        for r in missing:
+            verdicts[str(r[id_key])] = {"verdict": "UNKNOWN", "reason": "judge parse/timeout failure"}
+    return verdicts

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2676,12 +2676,14 @@ def run_act_vit(
 
     icr_cfg = dataset_cfg["icr_capture"]
     split_seed = experiment_cfg.get("split_seed", 42)
+    label_source = dataset_cfg.get("label_source", "substring")  # substring | llm_judge (#145)
 
     # Build split indices from MemmapActivationParser (same pattern as other runners).
     train_parser = MemmapActivationParser(
         icr_cfg["train_dir"],
         random_seed=split_seed,
         split_strategy="three_way",
+        label_source=label_source,
     )
     _p1_expected_train_n = _apply_train_prevalence(train_parser, experiment_cfg, run_seed=training_seed)  # P1 sweep (#140); no-op otherwise
     train_df = train_parser.df[train_parser.df["split"] == "train"]
@@ -2700,19 +2702,21 @@ def run_act_vit(
             icr_cfg["test_dir"],
             random_seed=split_seed,
             split_strategy="none",
+            label_source=label_source,
         )
     else:
         test_parser = MemmapActivationParser(
             icr_cfg["test_dir"],
             random_seed=split_seed,
             split_strategy="none",
+            label_source=label_source,
         )
     test_df = test_parser.df
     test_idx = test_df["sample_index"].values
 
-    train_ds = ACTViTDataset(icr_cfg["train_dir"], train_idx)
-    val_ds = ACTViTDataset(icr_cfg["train_dir"], val_idx)
-    test_ds = ACTViTDataset(icr_cfg["test_dir"], test_idx)
+    train_ds = ACTViTDataset(icr_cfg["train_dir"], train_idx, label_source=label_source)
+    val_ds = ACTViTDataset(icr_cfg["train_dir"], val_idx, label_source=label_source)
+    test_ds = ACTViTDataset(icr_cfg["test_dir"], test_idx, label_source=label_source)
 
     num_workers = experiment_cfg.get("num_workers", 4)
     persistent_workers = experiment_cfg.get("persistent_workers", True) and num_workers > 0
@@ -3695,6 +3699,7 @@ def main() -> None:
                 capture_dir=_resolve_shared(dataset_cfg["icr_capture"]["test_dir"]),
                 random_seed=global_split_seed,
                 split_strategy="none",
+                label_source=dataset_cfg.get("label_source", "substring"),  # #145
                 verbose=True,
             )
         elif has_train_test and "test" in dataset_cfg and isinstance(dataset_cfg["test"], dict):
@@ -3814,6 +3819,7 @@ def main() -> None:
                         capture_dir=_resolve_shared(icr_cfg_block["train_dir"]),
                         random_seed=actual_split_seed,
                         split_strategy="three_way",
+                        label_source=dataset_cfg.get("label_source", "substring"),  # #145
                         verbose=True,
                     )
             elif has_train_test:

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,73 @@
+"""Tests for activation_research.labels.load_meta (dual-label contract, issue #145)."""
+import json
+
+import pytest
+
+from activation_research.labels import load_meta
+
+META = [
+    {"sample_index": 0, "hallucinated": True},
+    {"sample_index": 1, "hallucinated": False},
+    {"sample_index": 2, "hallucinated": True},
+]
+
+
+def _write_capture(tmp_path, meta, judge=None):
+    d = tmp_path / "cap"
+    d.mkdir()
+    with (d / "meta.jsonl").open("w") as f:
+        for r in meta:
+            f.write(json.dumps(r) + "\n")
+    if judge is not None:
+        with (d / "judge_labels.jsonl").open("w") as f:
+            for r in judge:
+                f.write(json.dumps(r) + "\n")
+    return d
+
+
+def test_substring_default(tmp_path):
+    d = _write_capture(tmp_path, META)
+    assert [r["hallucinated"] for r in load_meta(d, "substring")] == [True, False, True]
+
+
+def test_llm_judge_overrides(tmp_path):
+    judge = [
+        {"sample_index": 0, "judge_verdict": "CORRECT", "hallucinated": False},
+        {"sample_index": 1, "judge_verdict": "INCORRECT", "hallucinated": True},
+        {"sample_index": 2, "judge_verdict": "CORRECT", "hallucinated": False},
+    ]
+    d = _write_capture(tmp_path, META, judge)
+    assert [r["hallucinated"] for r in load_meta(d, "llm_judge")] == [False, True, False]
+
+
+def test_unknown_and_missing_fall_back_to_substring(tmp_path):
+    judge = [
+        {"sample_index": 0, "judge_verdict": "UNKNOWN", "hallucinated": False},
+        # sample_index 1 absent from the sidecar
+        {"sample_index": 2, "judge_verdict": "CORRECT", "hallucinated": False},
+    ]
+    d = _write_capture(tmp_path, META, judge)
+    # 0: UNKNOWN -> keep substring True; 1: missing -> keep substring False; 2: judge -> False
+    assert [r["hallucinated"] for r in load_meta(d, "llm_judge")] == [True, False, False]
+
+
+def test_join_is_by_sample_index_not_row_order(tmp_path):
+    judge = [  # deliberately shuffled relative to meta
+        {"sample_index": 2, "judge_verdict": "CORRECT", "hallucinated": False},
+        {"sample_index": 0, "judge_verdict": "CORRECT", "hallucinated": False},
+        {"sample_index": 1, "judge_verdict": "INCORRECT", "hallucinated": True},
+    ]
+    d = _write_capture(tmp_path, META, judge)
+    assert [r["hallucinated"] for r in load_meta(d, "llm_judge")] == [False, True, False]
+
+
+def test_missing_sidecar_raises(tmp_path):
+    d = _write_capture(tmp_path, META)
+    with pytest.raises(FileNotFoundError):
+        load_meta(d, "llm_judge")
+
+
+def test_invalid_label_source_raises(tmp_path):
+    d = _write_capture(tmp_path, META)
+    with pytest.raises(ValueError):
+        load_meta(d, "bogus")


### PR DESCRIPTION
Resolves #145. Adds a **dual-label data contract** so training/eval can choose LLM-judge vs substring-match correctness labels (motivated by #143: substring labels are noisy, MMLU 26%).

## Part 1 — data contract + loaders
- **`activation_research/labels.py::load_meta(capture_dir, label_source)`** — the single swap point. `"substring"` (default) returns meta.jsonl as-is; `"llm_judge"` overrides each row's `hallucinated` from `judge_labels.jsonl` (joined by **`sample_index`**, robust to reordering); `UNKNOWN`/missing rows fall back to substring (counted + logged).
- Loaders accept `label_source` and load via `load_meta`: `ACTViTDataset`, `MemmapActivationParser`, `MemmapContrastiveDataset`. Because the swap is at the meta layer, all downstream `hallucinated` reads / `outlier_class` / flip conventions are unchanged.
- Threaded from `dataset_cfg["label_source"]` (default `"substring"`) into `run_act_vit` and the shared `ap`/`test_ap` used by `run_contrastive_logprob_recon`.

**Config:** add `"label_source": "llm_judge"` to a dataset config JSON to train/eval on judge labels.

## Part 2 — backfill
- **`scripts/label_audit/judge_core.py`** — shared judging (build_item/call_claude/parse/judge_batch) extracted from `judge.py` (no behavior change).
- **`scripts/label_audit/backfill_judge_labels.py`** — reads a capture's `generation.jsonl`, judges via Sonnet, writes `judge_labels.jsonl` + `judge_labels_meta.json` (keyed by `sample_index`, resumable).

## Tests
`tests/test_labels.py` — `load_meta` contract: substring/judge selection, UNKNOWN + missing fallback, sample_index join (not row order), error cases. Verified.

## Scope / backward-compat
Default `label_source="substring"` reproduces existing behavior exactly. The remaining non-primary loaders (`icr_dataset`, `composite_memmap_parser`, `contrastive_actvit_dataset`) and the zarr `ActivationParser` keep substring; extending them is mechanical follow-up. **Running** the backfill + the re-score/re-train experiments are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
